### PR TITLE
Add hybrid post-action waits for mutating actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Breaking: `OPENSTEER_AI_MODEL` is no longer supported; use `OPENSTEER_MODEL`.
 - Opensteer now enables built-in LLM resolve/extract by default with model `gpt-5.1`.
 - Cloud mode now falls back to `OPENSTEER_API_KEY` when `cloud.key` is omitted.
+- Mutating actions now include smart best-effort post-action wait with per-action
+  profiles and optional per-call overrides via `wait`.
 
 ## 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ For actions like `click`/`input`/`hover`/`select`/`scroll`:
 
 When steps 2-4 resolve and `description` is provided, the path is persisted.
 
+## Smart Post-Action Wait
+
+Mutating actions (`click`, `input`, `select`, `scroll`, etc.) include a
+best-effort post-action wait so delayed visual updates are usually settled
+before the method resolves.
+
+You can disable or tune this per call:
+
+```ts
+await ov.click({ description: "Save button", wait: false });
+
+await ov.click({
+  description: "Save button",
+  wait: { timeout: 9000, settleMs: 900, includeNetwork: true, networkQuietMs: 400 },
+});
+```
+
 ## Snapshot Modes
 
 ```ts

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -32,6 +32,31 @@ new Opensteer(config?: OpensteerConfig)
 - `select(options: SelectOptions): Promise<ActionResult>`
 - `scroll(options?: ScrollOptions): Promise<ActionResult>`
 
+Mutating actions apply a best-effort post-action wait by default so delayed UI
+updates are visible before the method resolves.
+
+Use `wait: false` on action options to disable this behavior per call.
+
+```ts
+interface ActionWaitOptions {
+    enabled?: boolean
+    timeout?: number
+    settleMs?: number
+    networkQuietMs?: number
+    includeNetwork?: boolean
+}
+
+interface BaseActionOptions {
+    description?: string
+    element?: number
+    selector?: string
+    wait?: false | ActionWaitOptions
+}
+```
+
+`pressKey()` and `type()` also use post-action wait internally with default
+profiles, but they do not take per-call wait options.
+
 ### Extraction
 
 - `extract<T>(options: ExtractOptions): Promise<T>`

--- a/src/action-wait.ts
+++ b/src/action-wait.ts
@@ -1,0 +1,245 @@
+import type { Page, Request } from 'playwright'
+import { waitForVisualStabilityAcrossFrames } from './navigation.js'
+import type { ActionWaitOptions } from './types.js'
+
+export type PostActionKind =
+    | 'click'
+    | 'dblclick'
+    | 'rightclick'
+    | 'hover'
+    | 'input'
+    | 'select'
+    | 'scroll'
+    | 'uploadFile'
+    | 'pressKey'
+    | 'type'
+
+interface ResolvedActionWaitProfile {
+    enabled: boolean
+    timeout: number
+    settleMs: number
+    networkQuietMs: number
+    includeNetwork: boolean
+}
+
+interface PostActionWaitSession {
+    wait(): Promise<void>
+    dispose(): void
+}
+
+const ROBUST_PROFILE: ResolvedActionWaitProfile = {
+    enabled: true,
+    timeout: 7000,
+    settleMs: 750,
+    networkQuietMs: 300,
+    includeNetwork: true,
+}
+
+const SCROLL_PROFILE: ResolvedActionWaitProfile = {
+    enabled: true,
+    timeout: 7000,
+    settleMs: 600,
+    networkQuietMs: 400,
+    includeNetwork: true,
+}
+
+const HOVER_PROFILE: ResolvedActionWaitProfile = {
+    enabled: true,
+    timeout: 2500,
+    settleMs: 200,
+    networkQuietMs: 0,
+    includeNetwork: false,
+}
+
+const ACTION_WAIT_PROFILES: Record<PostActionKind, ResolvedActionWaitProfile> = {
+    click: ROBUST_PROFILE,
+    dblclick: ROBUST_PROFILE,
+    rightclick: ROBUST_PROFILE,
+    hover: HOVER_PROFILE,
+    input: ROBUST_PROFILE,
+    select: ROBUST_PROFILE,
+    scroll: SCROLL_PROFILE,
+    uploadFile: ROBUST_PROFILE,
+    pressKey: ROBUST_PROFILE,
+    type: ROBUST_PROFILE,
+}
+
+const NETWORK_POLL_MS = 50
+const IGNORED_RESOURCE_TYPES = new Set(['websocket', 'eventsource'])
+
+const NOOP_SESSION: PostActionWaitSession = {
+    async wait() {},
+    dispose() {},
+}
+
+export function createPostActionWaitSession(
+    page: Page,
+    action: PostActionKind,
+    override?: false | ActionWaitOptions
+): PostActionWaitSession {
+    const profile = resolveActionWaitProfile(action, override)
+    if (!profile.enabled) return NOOP_SESSION
+
+    const tracker = profile.includeNetwork ? new ScopedNetworkTracker(page) : null
+    tracker?.start()
+
+    let settled = false
+
+    return {
+        async wait() {
+            if (settled) return
+            settled = true
+
+            const deadline = Date.now() + profile.timeout
+            const networkWait = tracker
+                ? tracker.waitForQuiet({
+                      deadline,
+                      quietMs: profile.networkQuietMs,
+                  })
+                : Promise.resolve()
+
+            try {
+                await Promise.all([
+                    waitForVisualStabilityAcrossFrames(page, {
+                        timeout: profile.timeout,
+                        settleMs: profile.settleMs,
+                    }),
+                    networkWait,
+                ])
+            } catch {
+            } finally {
+                tracker?.stop()
+            }
+        },
+        dispose() {
+            settled = true
+            tracker?.stop()
+        },
+    }
+}
+
+function resolveActionWaitProfile(
+    action: PostActionKind,
+    override?: false | ActionWaitOptions
+): ResolvedActionWaitProfile {
+    const base = ACTION_WAIT_PROFILES[action]
+
+    if (override === false) {
+        return {
+            ...base,
+            enabled: false,
+        }
+    }
+
+    if (!override) {
+        return { ...base }
+    }
+
+    const merged: ResolvedActionWaitProfile = {
+        enabled:
+            typeof override.enabled === 'boolean'
+                ? override.enabled
+                : base.enabled,
+        timeout: normalizeMs(override.timeout, base.timeout),
+        settleMs: normalizeMs(override.settleMs, base.settleMs),
+        networkQuietMs: normalizeMs(override.networkQuietMs, base.networkQuietMs),
+        includeNetwork:
+            typeof override.includeNetwork === 'boolean'
+                ? override.includeNetwork
+                : base.includeNetwork,
+    }
+
+    if (!merged.includeNetwork) {
+        merged.networkQuietMs = 0
+    }
+
+    return merged
+}
+
+function normalizeMs(value: number | undefined, fallback: number): number {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return fallback
+    }
+
+    return Math.max(0, Math.floor(value))
+}
+
+class ScopedNetworkTracker {
+    private readonly pending = new Set<Request>()
+    private started = false
+    private idleSince = Date.now()
+
+    constructor(private readonly page: Page) {}
+
+    start(): void {
+        if (this.started) return
+        this.started = true
+
+        this.page.on('request', this.handleRequestStarted)
+        this.page.on('requestfinished', this.handleRequestFinished)
+        this.page.on('requestfailed', this.handleRequestFinished)
+    }
+
+    stop(): void {
+        if (!this.started) return
+        this.started = false
+
+        this.page.off('request', this.handleRequestStarted)
+        this.page.off('requestfinished', this.handleRequestFinished)
+        this.page.off('requestfailed', this.handleRequestFinished)
+
+        this.pending.clear()
+        this.idleSince = Date.now()
+    }
+
+    async waitForQuiet(options: {
+        deadline: number
+        quietMs: number
+    }): Promise<void> {
+        const quietMs = Math.max(0, options.quietMs)
+        if (quietMs === 0) return
+
+        while (Date.now() < options.deadline) {
+            if (this.pending.size === 0) {
+                if (this.idleSince === 0) {
+                    this.idleSince = Date.now()
+                }
+
+                const idleFor = Date.now() - this.idleSince
+                if (idleFor >= quietMs) {
+                    return
+                }
+            } else {
+                this.idleSince = 0
+            }
+
+            const remaining = Math.max(1, options.deadline - Date.now())
+            await sleep(Math.min(NETWORK_POLL_MS, remaining))
+        }
+    }
+
+    private readonly handleRequestStarted = (request: Request): void => {
+        if (!this.started) return
+
+        const resourceType = request.resourceType()
+        if (IGNORED_RESOURCE_TYPES.has(resourceType)) return
+
+        this.pending.add(request)
+        this.idleSince = 0
+    }
+
+    private readonly handleRequestFinished = (request: Request): void => {
+        if (!this.started) return
+        if (!this.pending.delete(request)) return
+
+        if (this.pending.size === 0) {
+            this.idleSince = Date.now()
+        }
+    }
+}
+
+async function sleep(ms: number): Promise<void> {
+    await new Promise<void>((resolve) => {
+        setTimeout(resolve, ms)
+    })
+}

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1,27 +1,78 @@
-import type { Page } from 'playwright'
+import type { Frame, Page } from 'playwright'
 
 const DEFAULT_TIMEOUT = 30000
 const DEFAULT_SETTLE_MS = 750
 
-// String expression to avoid esbuild's __name() transform inside page.evaluate.
+interface VisualStabilityOptions {
+    timeout?: number
+    settleMs?: number
+}
+
+// String expression to avoid esbuild's __name() transform inside frame/page.evaluate.
 function buildStabilityScript(timeout: number, settleMs: number): string {
     return `new Promise(function(resolve) {
     var deadline = Date.now() + ${timeout};
     var timer = null;
-    var fontsReady = document.fonts.status === 'loaded';
     var resolved = false;
+    var observers = [];
+    var observedShadowRoots = [];
+    var fonts = document.fonts;
+    var fontsReady = !fonts || fonts.status === 'loaded';
+
+    function clearObservers() {
+        for (var i = 0; i < observers.length; i++) {
+            observers[i].disconnect();
+        }
+        observers = [];
+    }
 
     function done() {
         if (resolved) return;
         resolved = true;
-        observer.disconnect();
         if (timer) clearTimeout(timer);
         if (safetyTimer) clearTimeout(safetyTimer);
+        clearObservers();
         resolve();
     }
 
-    function checkViewportImages() {
-        var images = document.querySelectorAll('img');
+    function observeMutations(target) {
+        if (!target) return;
+        var observer = new MutationObserver(function() { settle(); });
+        observer.observe(target, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            characterData: true
+        });
+        observers.push(observer);
+    }
+
+    function hasObservedShadowRoot(root) {
+        for (var i = 0; i < observedShadowRoots.length; i++) {
+            if (observedShadowRoots[i] === root) return true;
+        }
+        return false;
+    }
+
+    function observeOpenShadowRoots() {
+        if (!document.documentElement || !document.createTreeWalker) return;
+        var walker = document.createTreeWalker(
+            document.documentElement,
+            NodeFilter.SHOW_ELEMENT
+        );
+        while (walker.nextNode()) {
+            var current = walker.currentNode;
+            if (!(current instanceof Element)) continue;
+            var shadowRoot = current.shadowRoot;
+            if (!shadowRoot || shadowRoot.mode !== 'open') continue;
+            if (hasObservedShadowRoot(shadowRoot)) continue;
+            observedShadowRoots.push(shadowRoot);
+            observeMutations(shadowRoot);
+        }
+    }
+
+    function checkViewportImages(root) {
+        var images = root.querySelectorAll('img');
         for (var i = 0; i < images.length; i++) {
             var img = images[i];
             var rect = img.getBoundingClientRect();
@@ -35,11 +86,40 @@ function buildStabilityScript(timeout: number, settleMs: number): string {
         return true;
     }
 
+    function hasRunningFiniteAnimations() {
+        if (typeof document.getAnimations !== 'function') return false;
+        var animations = document.getAnimations();
+
+        for (var i = 0; i < animations.length; i++) {
+            var animation = animations[i];
+            if (!animation || animation.playState !== 'running') continue;
+            var effect = animation.effect;
+            if (!effect || typeof effect.getComputedTiming !== 'function') continue;
+            var timing = effect.getComputedTiming();
+            var endTime = timing && typeof timing.endTime === 'number'
+                ? timing.endTime
+                : Number.POSITIVE_INFINITY;
+            if (Number.isFinite(endTime) && endTime > 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    function isVisuallyReady() {
+        if (!fontsReady) return false;
+        if (!checkViewportImages(document)) return false;
+        if (hasRunningFiniteAnimations()) return false;
+        return true;
+    }
+
     function settle() {
         if (Date.now() > deadline) { done(); return; }
         if (timer) clearTimeout(timer);
+        observeOpenShadowRoots();
         timer = setTimeout(function() {
-            if (checkViewportImages() && fontsReady) {
+            if (isVisuallyReady()) {
                 done();
             } else {
                 settle();
@@ -47,18 +127,15 @@ function buildStabilityScript(timeout: number, settleMs: number): string {
         }, ${settleMs});
     }
 
-    var observer = new MutationObserver(function() { settle(); });
-    observer.observe(document.documentElement, {
-        childList: true,
-        subtree: true,
-        attributes: true,
-        characterData: true
-    });
+    observeMutations(document.documentElement);
+    observeOpenShadowRoots();
 
-    document.fonts.ready.then(function() {
-        fontsReady = true;
-        settle();
-    });
+    if (fonts && fonts.ready && typeof fonts.ready.then === 'function') {
+        fonts.ready.then(function() {
+            fontsReady = true;
+            settle();
+        });
+    }
 
     var safetyTimer = setTimeout(done, ${timeout});
 
@@ -68,10 +145,77 @@ function buildStabilityScript(timeout: number, settleMs: number): string {
 
 export async function waitForVisualStability(
     page: Page,
-    options: { timeout?: number; settleMs?: number } = {}
+    options: VisualStabilityOptions = {}
 ): Promise<void> {
     const timeout = options.timeout ?? DEFAULT_TIMEOUT
     const settleMs = options.settleMs ?? DEFAULT_SETTLE_MS
 
-    await page.evaluate(buildStabilityScript(timeout, settleMs))
+    await waitForFrameVisualStability(page.mainFrame(), {
+        timeout,
+        settleMs,
+    })
+}
+
+export async function waitForVisualStabilityAcrossFrames(
+    page: Page,
+    options: VisualStabilityOptions = {}
+): Promise<void> {
+    const timeout = options.timeout ?? DEFAULT_TIMEOUT
+    const settleMs = options.settleMs ?? DEFAULT_SETTLE_MS
+    const deadline = Date.now() + timeout
+
+    while (true) {
+        const remaining = Math.max(0, deadline - Date.now())
+        if (remaining === 0) return
+
+        const frames = page.frames()
+        await Promise.all(
+            frames.map(async (frame) => {
+                try {
+                    await waitForFrameVisualStability(frame, {
+                        timeout: remaining,
+                        settleMs,
+                    })
+                } catch (error) {
+                    if (isIgnorableFrameError(error)) return
+                    throw error
+                }
+            })
+        )
+
+        const currentFrames = page.frames()
+        if (sameFrames(frames, currentFrames)) {
+            return
+        }
+    }
+}
+
+async function waitForFrameVisualStability(
+    frame: Frame,
+    options: VisualStabilityOptions
+): Promise<void> {
+    const timeout = options.timeout ?? DEFAULT_TIMEOUT
+    const settleMs = options.settleMs ?? DEFAULT_SETTLE_MS
+    if (timeout <= 0) return
+
+    await frame.evaluate(buildStabilityScript(timeout, settleMs))
+}
+
+function sameFrames(before: Frame[], after: Frame[]): boolean {
+    if (before.length !== after.length) return false
+
+    for (const frame of before) {
+        if (!after.includes(frame)) return false
+    }
+    return true
+}
+
+function isIgnorableFrameError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false
+    const message = error.message
+    return (
+        message.includes('Frame was detached') ||
+        message.includes('Execution context was destroyed') ||
+        message.includes('Target page, context or browser has been closed')
+    )
 }

--- a/src/opensteer.ts
+++ b/src/opensteer.ts
@@ -75,6 +75,10 @@ import {
     type CounterRequest,
 } from './html/counter-runtime.js'
 import {
+    createPostActionWaitSession,
+    type PostActionKind,
+} from './action-wait.js'
+import {
     buildPersistedExtractPayload,
     collectArrayItemFieldDescriptors,
     isPersistablePathField,
@@ -734,9 +738,11 @@ export class Opensteer {
                     )
                 }
 
-                await handle.hover({
-                    force: options.force,
-                    position: options.position,
+                await this.runWithPostActionWait('hover', options.wait, async () => {
+                    await handle.hover({
+                        force: options.force,
+                        position: options.position,
+                    })
                 })
             } catch (err) {
                 const message =
@@ -770,18 +776,27 @@ export class Opensteer {
         if (!resolution.path) {
             throw new Error('Unable to resolve element path for hover action.')
         }
+        const path = resolution.path
 
-        const result = await performHover(this.page, resolution.path, options)
+        const result = await this.runWithPostActionWait(
+            'hover',
+            options.wait,
+            async () => {
+                const actionResult = await performHover(this.page, path, options)
 
-        if (!result.ok) {
-            throw new Error(
-                formatActionFailureMessage(
-                    'hover',
-                    options.description,
-                    result.error || 'Hover failed.'
-                )
-            )
-        }
+                if (!actionResult.ok) {
+                    throw new Error(
+                        formatActionFailureMessage(
+                            'hover',
+                            options.description,
+                            actionResult.error || 'Hover failed.'
+                        )
+                    )
+                }
+
+                return actionResult
+            }
+        )
         this.snapshotCache = null
 
         const persisted =
@@ -819,14 +834,16 @@ export class Opensteer {
                     )
                 }
 
-                if (options.clear !== false) {
-                    await handle.fill(options.text)
-                } else {
-                    await handle.type(options.text)
-                }
-                if (options.pressEnter) {
-                    await handle.press('Enter')
-                }
+                await this.runWithPostActionWait('input', options.wait, async () => {
+                    if (options.clear !== false) {
+                        await handle.fill(options.text)
+                    } else {
+                        await handle.type(options.text)
+                    }
+                    if (options.pressEnter) {
+                        await handle.press('Enter')
+                    }
+                })
             } catch (err) {
                 const message =
                     err instanceof Error ? err.message : 'Input failed.'
@@ -859,18 +876,27 @@ export class Opensteer {
         if (!resolution.path) {
             throw new Error('Unable to resolve element path for input action.')
         }
+        const path = resolution.path
 
-        const result = await performInput(this.page, resolution.path, options)
+        const result = await this.runWithPostActionWait(
+            'input',
+            options.wait,
+            async () => {
+                const actionResult = await performInput(this.page, path, options)
 
-        if (!result.ok) {
-            throw new Error(
-                formatActionFailureMessage(
-                    'input',
-                    options.description,
-                    result.error || 'Input failed.'
-                )
-            )
-        }
+                if (!actionResult.ok) {
+                    throw new Error(
+                        formatActionFailureMessage(
+                            'input',
+                            options.description,
+                            actionResult.error || 'Input failed.'
+                        )
+                    )
+                }
+
+                return actionResult
+            }
+        )
         this.snapshotCache = null
 
         const persisted =
@@ -908,15 +934,23 @@ export class Opensteer {
                     )
                 }
 
-                if (options.value != null) {
-                    await handle.selectOption(options.value)
-                } else if (options.label != null) {
-                    await handle.selectOption({ label: options.label })
-                } else if (options.index != null) {
-                    await handle.selectOption({ index: options.index })
-                } else {
-                    throw new Error('Select requires value, label, or index.')
-                }
+                await this.runWithPostActionWait(
+                    'select',
+                    options.wait,
+                    async () => {
+                        if (options.value != null) {
+                            await handle.selectOption(options.value)
+                        } else if (options.label != null) {
+                            await handle.selectOption({ label: options.label })
+                        } else if (options.index != null) {
+                            await handle.selectOption({ index: options.index })
+                        } else {
+                            throw new Error(
+                                'Select requires value, label, or index.'
+                            )
+                        }
+                    }
+                )
             } catch (err) {
                 const message =
                     err instanceof Error ? err.message : 'Select failed.'
@@ -949,18 +983,27 @@ export class Opensteer {
         if (!resolution.path) {
             throw new Error('Unable to resolve element path for select action.')
         }
+        const path = resolution.path
 
-        const result = await performSelect(this.page, resolution.path, options)
+        const result = await this.runWithPostActionWait(
+            'select',
+            options.wait,
+            async () => {
+                const actionResult = await performSelect(this.page, path, options)
 
-        if (!result.ok) {
-            throw new Error(
-                formatActionFailureMessage(
-                    'select',
-                    options.description,
-                    result.error || 'Select failed.'
-                )
-            )
-        }
+                if (!actionResult.ok) {
+                    throw new Error(
+                        formatActionFailureMessage(
+                            'select',
+                            options.description,
+                            actionResult.error || 'Select failed.'
+                        )
+                    )
+                }
+
+                return actionResult
+            }
+        )
         this.snapshotCache = null
 
         const persisted =
@@ -999,11 +1042,13 @@ export class Opensteer {
                 }
 
                 const delta = getScrollDelta(options)
-                await handle.evaluate((el, value) => {
-                    if (el instanceof HTMLElement) {
-                        el.scrollBy(value.x, value.y)
-                    }
-                }, delta)
+                await this.runWithPostActionWait('scroll', options.wait, async () => {
+                    await handle.evaluate((el, value) => {
+                        if (el instanceof HTMLElement) {
+                            el.scrollBy(value.x, value.y)
+                        }
+                    }, delta)
+                })
             } catch (err) {
                 const message =
                     err instanceof Error ? err.message : 'Scroll failed.'
@@ -1033,17 +1078,29 @@ export class Opensteer {
             )
         }
 
-        const result = await performScroll(this.page, resolution.path, options)
-
-        if (!result.ok) {
-            throw new Error(
-                formatActionFailureMessage(
-                    'scroll',
-                    options.description,
-                    result.error || 'Scroll failed.'
+        const result = await this.runWithPostActionWait(
+            'scroll',
+            options.wait,
+            async () => {
+                const actionResult = await performScroll(
+                    this.page,
+                    resolution.path,
+                    options
                 )
-            )
-        }
+
+                if (!actionResult.ok) {
+                    throw new Error(
+                        formatActionFailureMessage(
+                            'scroll',
+                            options.description,
+                            actionResult.error || 'Scroll failed.'
+                        )
+                    )
+                }
+
+                return actionResult
+            }
+        )
         this.snapshotCache = null
 
         const persisted =
@@ -1117,12 +1174,16 @@ export class Opensteer {
     // --- Keyboard Input ---
 
     async pressKey(key: string): Promise<void> {
-        await pressKey(this.page, key)
+        await this.runWithPostActionWait('pressKey', undefined, async () => {
+            await pressKey(this.page, key)
+        })
         this.snapshotCache = null
     }
 
     async type(text: string): Promise<void> {
-        await typeText(this.page, text)
+        await this.runWithPostActionWait('type', undefined, async () => {
+            await typeText(this.page, text)
+        })
         this.snapshotCache = null
     }
 
@@ -1250,7 +1311,13 @@ export class Opensteer {
                         resolution.counter
                     )
                 }
-                await handle.setInputFiles(options.paths)
+                await this.runWithPostActionWait(
+                    'uploadFile',
+                    options.wait,
+                    async () => {
+                        await handle.setInputFiles(options.paths)
+                    }
+                )
             } catch (err) {
                 const message =
                     err instanceof Error ? err.message : 'File upload failed.'
@@ -1283,22 +1350,31 @@ export class Opensteer {
         if (!resolution.path) {
             throw new Error('Unable to resolve element path for file upload.')
         }
+        const path = resolution.path
 
-        const result = await performFileUpload(
-            this.page,
-            resolution.path,
-            options.paths
-        )
-
-        if (!result.ok) {
-            throw new Error(
-                formatActionFailureMessage(
-                    'uploadFile',
-                    options.description,
-                    result.error || 'File upload failed.'
+        const result = await this.runWithPostActionWait(
+            'uploadFile',
+            options.wait,
+            async () => {
+                const actionResult = await performFileUpload(
+                    this.page,
+                    path,
+                    options.paths
                 )
-            )
-        }
+
+                if (!actionResult.ok) {
+                    throw new Error(
+                        formatActionFailureMessage(
+                            'uploadFile',
+                            options.description,
+                            actionResult.error || 'File upload failed.'
+                        )
+                    )
+                }
+
+                return actionResult
+            }
+        )
         this.snapshotCache = null
 
         const persisted =
@@ -1472,6 +1548,26 @@ export class Opensteer {
         this.snapshotCache = null
     }
 
+    private async runWithPostActionWait<T>(
+        action: PostActionKind,
+        waitOverride: BaseActionOptions['wait'],
+        execute: () => Promise<T>
+    ): Promise<T> {
+        const waitSession = createPostActionWaitSession(
+            this.page,
+            action,
+            waitOverride
+        )
+
+        try {
+            const result = await execute()
+            await waitSession.wait()
+            return result
+        } finally {
+            waitSession.dispose()
+        }
+    }
+
     private async executeClickVariant(
         method: 'click' | 'dblclick' | 'rightclick',
         options: ClickOptions
@@ -1491,10 +1587,12 @@ export class Opensteer {
                     )
                 }
 
-                await handle.click({
-                    button: options.button,
-                    clickCount: options.clickCount,
-                    modifiers: options.modifiers,
+                await this.runWithPostActionWait(method, options.wait, async () => {
+                    await handle.click({
+                        button: options.button,
+                        clickCount: options.clickCount,
+                        modifiers: options.modifiers,
+                    })
                 })
             } catch (err) {
                 const message =
@@ -1528,18 +1626,25 @@ export class Opensteer {
         if (!resolution.path) {
             throw new Error('Unable to resolve element path for click action.')
         }
+        const path = resolution.path
 
-        const result = await performClick(this.page, resolution.path, options)
-
-        if (!result.ok) {
-            throw new Error(
-                formatActionFailureMessage(
-                    method,
-                    options.description,
-                    result.error || 'Click failed.'
-                )
-            )
-        }
+        const result = await this.runWithPostActionWait(
+            method,
+            options.wait,
+            async () => {
+                const actionResult = await performClick(this.page, path, options)
+                if (!actionResult.ok) {
+                    throw new Error(
+                        formatActionFailureMessage(
+                            method,
+                            options.description,
+                            actionResult.error || 'Click failed.'
+                        )
+                    )
+                }
+                return actionResult
+            }
+        )
         this.snapshotCache = null
 
         const persisted =

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,10 +109,19 @@ export interface OpensteerConfig {
     debug?: boolean
 }
 
+export interface ActionWaitOptions {
+    enabled?: boolean
+    timeout?: number
+    settleMs?: number
+    networkQuietMs?: number
+    includeNetwork?: boolean
+}
+
 export interface BaseActionOptions {
     description?: string
     element?: number
     selector?: string
+    wait?: false | ActionWaitOptions
 }
 
 export interface ClickOptions extends BaseActionOptions {

--- a/tests/actions/post-action-wait.test.ts
+++ b/tests/actions/post-action-wait.test.ts
@@ -1,0 +1,116 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { BrowserContext, Page } from 'playwright'
+import { Opensteer } from '../../src/opensteer.js'
+import { closeTestBrowser, createTestPage } from '../helpers/browser.js'
+import { setFixture } from '../helpers/fixture.js'
+
+describe('post-action wait', () => {
+    let context: BrowserContext
+    let page: Page
+
+    beforeEach(async () => {
+        ;({ context, page } = await createTestPage())
+    })
+
+    afterEach(async () => {
+        await context.close()
+    })
+
+    afterAll(async () => {
+        await closeTestBrowser()
+    })
+
+    it('waits for delayed DOM updates by default', async () => {
+        await setFixture(
+            page,
+            `
+        <button id="trigger">Trigger update</button>
+        <p id="status">idle</p>
+        <script>
+          const trigger = document.querySelector('#trigger');
+          const status = document.querySelector('#status');
+          trigger?.addEventListener('click', () => {
+            window.setTimeout(() => {
+              if (status) {
+                status.textContent = 'done';
+              }
+            }, 320);
+          });
+        </script>
+      `
+        )
+
+        const ov = Opensteer.from(page, { name: 'post-action-dom' })
+        await ov.click({ selector: '#trigger' })
+
+        expect((await page.textContent('#status'))?.trim()).toBe('done')
+    })
+
+    it('waits for delayed network-backed updates by default', async () => {
+        await page.route('https://opensteer.local/post-action', async (route) => {
+            await new Promise<void>((resolve) => {
+                setTimeout(resolve, 250)
+            })
+
+            await route.fulfill({
+                status: 200,
+                contentType: 'text/plain',
+                body: 'ok',
+            })
+        })
+
+        await setFixture(
+            page,
+            `
+        <button id="trigger">Trigger fetch</button>
+        <p id="status">idle</p>
+        <script>
+          const trigger = document.querySelector('#trigger');
+          const status = document.querySelector('#status');
+          trigger?.addEventListener('click', async () => {
+            const response = await fetch('https://opensteer.local/post-action');
+            const body = await response.text();
+            if (status) {
+              status.textContent = 'network:' + body;
+            }
+          });
+        </script>
+      `
+        )
+
+        const ov = Opensteer.from(page, { name: 'post-action-network' })
+        await ov.click({ selector: '#trigger' })
+
+        expect((await page.textContent('#status'))?.trim()).toBe('network:ok')
+        await page.unroute('https://opensteer.local/post-action')
+    })
+
+    it('skips post-action wait when wait is false', async () => {
+        await setFixture(
+            page,
+            `
+        <button id="trigger">No wait</button>
+        <p id="status">idle</p>
+        <script>
+          const trigger = document.querySelector('#trigger');
+          const status = document.querySelector('#status');
+          trigger?.addEventListener('click', () => {
+            window.setTimeout(() => {
+              if (status) {
+                status.textContent = 'done';
+              }
+            }, 450);
+          });
+        </script>
+      `
+        )
+
+        const ov = Opensteer.from(page, { name: 'post-action-skip' })
+        await ov.click({ selector: '#trigger', wait: false })
+
+        expect((await page.textContent('#status'))?.trim()).toBe('idle')
+        await page.waitForFunction(() => {
+            return document.querySelector('#status')?.textContent === 'done'
+        })
+    })
+})

--- a/tests/integration/visual-stability.test.ts
+++ b/tests/integration/visual-stability.test.ts
@@ -1,0 +1,142 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { BrowserContext, Page } from 'playwright'
+import { waitForVisualStabilityAcrossFrames } from '../../src/navigation.js'
+import { closeTestBrowser, createTestPage } from '../helpers/browser.js'
+import { setFixture } from '../helpers/fixture.js'
+
+describe('integration/visual-stability', () => {
+    let context: BrowserContext
+    let page: Page
+
+    beforeEach(async () => {
+        ;({ context, page } = await createTestPage())
+    })
+
+    afterEach(async () => {
+        await context.close()
+    })
+
+    afterAll(async () => {
+        await closeTestBrowser()
+    })
+
+    it('waits for delayed iframe mutations', async () => {
+        await setFixture(
+            page,
+            `
+        <iframe
+          id="frame"
+          srcdoc="<html><body><p id='frame-status'>idle</p></body></html>"
+        ></iframe>
+      `
+        )
+
+        await page.waitForFunction(() => {
+            const frame = document.querySelector('#frame') as
+                | HTMLIFrameElement
+                | null
+            return !!frame?.contentDocument
+        })
+
+        await page.evaluate(() => {
+            const frame = document.querySelector('#frame') as HTMLIFrameElement
+            const frameDocument = frame.contentDocument
+            const status = frameDocument?.querySelector('#frame-status')
+
+            window.setTimeout(() => {
+                if (status) {
+                    status.textContent = 'updated'
+                }
+            }, 80)
+        })
+
+        const startedAt = Date.now()
+        await waitForVisualStabilityAcrossFrames(page, {
+            timeout: 3000,
+            settleMs: 120,
+        })
+        const elapsed = Date.now() - startedAt
+
+        const text = await page.evaluate(() => {
+            const frame = document.querySelector('#frame') as HTMLIFrameElement
+            return (
+                frame.contentDocument?.querySelector('#frame-status')
+                    ?.textContent || ''
+            )
+        })
+
+        expect(text).toBe('updated')
+        expect(elapsed).toBeGreaterThanOrEqual(70)
+    })
+
+    it('waits for delayed mutations inside open shadow roots', async () => {
+        await setFixture(
+            page,
+            `
+        <div id="host"></div>
+        <script>
+          const host = document.querySelector('#host');
+          const root = host?.attachShadow({ mode: 'open' });
+          if (root) {
+            root.innerHTML = '<span id="shadow-status">idle</span>';
+            const status = root.querySelector('#shadow-status');
+            window.setTimeout(() => {
+              if (status) status.textContent = 'done';
+            }, 80);
+          }
+        </script>
+      `
+        )
+
+        const startedAt = Date.now()
+        await waitForVisualStabilityAcrossFrames(page, {
+            timeout: 3000,
+            settleMs: 120,
+        })
+        const elapsed = Date.now() - startedAt
+
+        const text = await page.evaluate(() => {
+            const host = document.querySelector('#host')
+            const shadowRoot = host?.shadowRoot
+            return shadowRoot?.querySelector('#shadow-status')?.textContent || ''
+        })
+
+        expect(text).toBe('done')
+        expect(elapsed).toBeGreaterThanOrEqual(70)
+    })
+
+    it('returns on timeout without throwing when DOM never settles', async () => {
+        await setFixture(
+            page,
+            `
+        <p id="status">0</p>
+        <script>
+          let counter = 0;
+          window.__testIntervalId = window.setInterval(() => {
+            counter += 1;
+            const status = document.querySelector('#status');
+            if (status) status.textContent = String(counter);
+          }, 25);
+        </script>
+      `
+        )
+
+        const startedAt = Date.now()
+        await waitForVisualStabilityAcrossFrames(page, {
+            timeout: 300,
+            settleMs: 60,
+        })
+        const elapsed = Date.now() - startedAt
+
+        await page.evaluate(() => {
+            const intervalId = (window as Window & { __testIntervalId?: number })
+                .__testIntervalId
+            if (typeof intervalId === 'number') {
+                window.clearInterval(intervalId)
+            }
+        })
+
+        expect(elapsed).toBeGreaterThanOrEqual(250)
+        expect(elapsed).toBeLessThan(1500)
+    })
+})


### PR DESCRIPTION
Summary
- Introduces the post-action wait orchestration in `Opensteer` to centralize visual/network settle logic for all mutating APIs.
- Adds action-specific wait profiles plus the `wait` override option so callers can fine-tune or disable the best-effort stabilization.
- Documents the new semantics in the API reference and README to highlight the default behavior and the new option.

Testing
- Not run (not requested)