### PR TITLE
Update docs to remove Stagehand references

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ try {
 }
 ```
 
-## CUA Agent (Stagehand-Style)
+## CUA Agent
 
 ```ts
 import { Opensteer } from "opensteer";

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -54,7 +54,7 @@ Returns the cloud session URL for deep-linking after `launch()` in cloud mode.
 
 #### `agent(config: OpensteerAgentConfig): OpensteerAgentInstance`
 
-Create a Computer Use Agent (CUA) instance with Stagehand-style ergonomics.
+Create a Computer Use Agent (CUA) instance with ergonomic defaults.
 
 ```ts
 const agent = opensteer.agent({


### PR DESCRIPTION
## Summary
- drop the "Stagehand" qualifier from the README CUA Agent heading
- update the API reference description to avoid mentioning Stagehand and emphasize ergonomic defaults
- confirm no other Stagehand references remain in the touched docs
## Testing
- Not run (not requested)