### PR TITLE
Improve visibility detection for display-contents wrappers

### DIFF
--- a/skills/opensteer/references/sdk-reference.md
+++ b/skills/opensteer/references/sdk-reference.md
@@ -12,6 +12,24 @@ const opensteer = new Opensteer({
 await opensteer.launch({ headless: false });
 await opensteer.close();
 
+// Use the user's local Chrome profile state:
+const opensteer = new Opensteer({
+  name: "my-scraper",
+  browser: {
+    mode: "real",
+    profileDirectory: "Default",
+    headless: false,
+  },
+});
+await opensteer.launch();
+
+// Or pass real-browser mode at launch time:
+await opensteer.launch({
+  mode: "real",
+  profileDirectory: "Default",
+  headless: false,
+});
+
 // Wrap an existing page instance:
 const opensteer = Opensteer.from(existingPage, { name: "my-scraper" });
 ```

--- a/src/html/interactivity.ts
+++ b/src/html/interactivity.ts
@@ -59,6 +59,70 @@ export async function markInteractiveElements(
                     'searchbox',
                 ])
 
+                function isExplicitlyHidden(
+                    el: HTMLElement,
+                    style: CSSStyleDeclaration
+                ): boolean {
+                    if (el.hasAttribute('hidden')) {
+                        return true
+                    }
+
+                    if (el.getAttribute('aria-hidden') === 'true') {
+                        return true
+                    }
+
+                    if (style.display === 'none') {
+                        return true
+                    }
+
+                    if (
+                        style.visibility === 'hidden' ||
+                        style.visibility === 'collapse'
+                    ) {
+                        return true
+                    }
+
+                    const opacity = Number.parseFloat(style.opacity)
+                    return Number.isFinite(opacity) && opacity <= 0
+                }
+
+                function hasVisibleOutOfFlowChild(el: HTMLElement): boolean {
+                    const children = el.children
+                    for (let i = 0; i < children.length; i++) {
+                        const child = children[i] as HTMLElement
+                        const childStyle = window.getComputedStyle(child)
+                        if (
+                            childStyle.position !== 'fixed' &&
+                            childStyle.position !== 'absolute'
+                        ) {
+                            continue
+                        }
+
+                        const childRect = child.getBoundingClientRect()
+                        if (childRect.width > 0 && childRect.height > 0) {
+                            return true
+                        }
+                    }
+
+                    return false
+                }
+
+                function isHiddenByOwnRect(
+                    el: HTMLElement,
+                    style: CSSStyleDeclaration
+                ): boolean {
+                    if (style.display === 'contents') {
+                        return false
+                    }
+
+                    const rect = el.getBoundingClientRect()
+                    if (rect.width > 0 && rect.height > 0) {
+                        return false
+                    }
+
+                    return !hasVisibleOutOfFlowChild(el)
+                }
+
                 const roots: Array<Document | ShadowRoot> = [document]
                 while (roots.length) {
                     const root = roots.pop()
@@ -80,56 +144,9 @@ export async function markInteractiveElements(
                         }
 
                         const style = window.getComputedStyle(el)
-                        let hidden = false
-
-                        if (el.hasAttribute('hidden')) {
-                            hidden = true
-                        } else if (el.getAttribute('aria-hidden') === 'true') {
-                            hidden = true
-                        } else if (style.display === 'none') {
-                            hidden = true
-                        } else if (
-                            style.visibility === 'hidden' ||
-                            style.visibility === 'collapse'
-                        ) {
-                            hidden = true
-                        }
-
-                        if (!hidden) {
-                            const opacity = Number.parseFloat(style.opacity)
-                            if (Number.isFinite(opacity) && opacity <= 0) {
-                                hidden = true
-                            }
-                        }
-
-                        if (!hidden) {
-                            const rect = el.getBoundingClientRect()
-                            if (rect.width <= 0 || rect.height <= 0) {
-                                hidden = true
-                                const children = el.children
-                                for (let i = 0; i < children.length; i++) {
-                                    const childStyle = window.getComputedStyle(
-                                        children[i]
-                                    )
-                                    if (
-                                        childStyle.position !== 'fixed' &&
-                                        childStyle.position !== 'absolute'
-                                    ) {
-                                        continue
-                                    }
-                                    const childRect = (
-                                        children[i] as HTMLElement
-                                    ).getBoundingClientRect()
-                                    if (
-                                        childRect.width > 0 &&
-                                        childRect.height > 0
-                                    ) {
-                                        hidden = false
-                                        break
-                                    }
-                                }
-                            }
-                        }
+                        const hidden =
+                            isExplicitlyHidden(el, style) ||
+                            isHiddenByOwnRect(el, style)
 
                         if (hidden) {
                             el.setAttribute(hiddenAttr, '1')

--- a/tests/integration/shadow-slot-snapshot.test.ts
+++ b/tests/integration/shadow-slot-snapshot.test.ts
@@ -1,0 +1,165 @@
+import * as cheerio from 'cheerio'
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { BrowserContext, Page } from 'playwright'
+import { markInteractiveElements } from '../../src/html/interactivity.js'
+import { prepareSnapshot } from '../../src/html/pipeline.js'
+import { closeTestBrowser, createTestPage } from '../helpers/browser.js'
+import { setFixture } from '../helpers/fixture.js'
+
+describe('integration/shadow-slot-snapshot', () => {
+    let context: BrowserContext
+    let page: Page
+
+    beforeEach(async () => {
+        ;({ context, page } = await createTestPage())
+    })
+
+    afterEach(async () => {
+        await context.close()
+    })
+
+    afterAll(async () => {
+        await closeTestBrowser()
+    })
+
+    describe('display: contents visibility handling', () => {
+        it('does not mark slot wrappers hidden when their fallback input is visibly rendered', async () => {
+            await mountShadowSlotFallbackFixture(page)
+            await markInteractiveElements(page)
+
+            const state = await page.evaluate(() => {
+                const host = document.querySelector('#search-host')
+                if (!(host instanceof HTMLElement) || !host.shadowRoot) {
+                    throw new Error('Expected the search host shadow root.')
+                }
+
+                const slot = host.shadowRoot.querySelector('slot')
+                const input = host.shadowRoot.querySelector(
+                    '#slotted-search-input'
+                )
+
+                if (
+                    !(slot instanceof HTMLSlotElement) ||
+                    !(input instanceof HTMLInputElement)
+                ) {
+                    throw new Error(
+                        'Expected the slot and fallback input inside the shadow root.'
+                    )
+                }
+
+                const slotRect = slot.getBoundingClientRect()
+                const inputRect = input.getBoundingClientRect()
+
+                return {
+                    slotDisplay: getComputedStyle(slot).display,
+                    slotWidth: slotRect.width,
+                    slotHeight: slotRect.height,
+                    slotHidden: slot.getAttribute('data-opensteer-hidden'),
+                    inputWidth: inputRect.width,
+                    inputHeight: inputRect.height,
+                    inputHidden: input.getAttribute('data-opensteer-hidden'),
+                    inputInteractive: input.getAttribute(
+                        'data-opensteer-interactive'
+                    ),
+                }
+            })
+
+            expect(state.slotDisplay).toBe('contents')
+            expect(state.slotWidth).toBe(0)
+            expect(state.slotHeight).toBe(0)
+            expect(state.slotHidden).toBeNull()
+            expect(state.inputWidth).toBeGreaterThan(0)
+            expect(state.inputHeight).toBeGreaterThan(0)
+            expect(state.inputHidden).toBeNull()
+            expect(state.inputInteractive).toBe('1')
+        })
+
+        it('keeps the visible fallback input in action snapshots', async () => {
+            await mountShadowSlotFallbackFixture(page)
+
+            const snapshot = await prepareSnapshot(page, {
+                mode: 'action',
+                withCounters: true,
+                markInteractive: true,
+            })
+
+            const raw = cheerio.load(snapshot.rawHtml)
+            const reduced = cheerio.load(snapshot.reducedHtml)
+            const cleaned = cheerio.load(snapshot.cleanedHtml)
+            const hasInputCounter = [
+                ...(snapshot.counterIndex?.values() || []),
+            ].some((path) => path.nodes[path.nodes.length - 1]?.tag === 'input')
+
+            expect(raw('slot[data-opensteer-hidden="1"]').length).toBe(0)
+            expect(raw('slot #slotted-search-input').length).toBe(1)
+
+            expect(reduced('input[placeholder="Search"]').length).toBe(1)
+            expect(cleaned('input[placeholder="Search"]').length).toBe(1)
+            expect(hasInputCounter).toBe(true)
+
+            expect(cleaned('os-shadow-root').text()).toContain('Search catalog')
+            expect(snapshot.cleanedHtml).toContain('placeholder="Search"')
+        })
+    })
+})
+
+async function mountShadowSlotFallbackFixture(page: Page): Promise<void> {
+    await setFixture(
+        page,
+        `
+        <style>
+            custom-search {
+                display: block;
+                width: 320px;
+            }
+        </style>
+        <custom-search id="search-host"></custom-search>
+        <script>
+            customElements.define('custom-search', class extends HTMLElement {
+                connectedCallback() {
+                    if (this.shadowRoot) return
+
+                    const root = this.attachShadow({ mode: 'open' })
+                    root.innerHTML = \`
+                        <style>
+                            .field {
+                                display: block;
+                                border: 1px solid #cbd5e1;
+                                padding: 12px;
+                            }
+
+                            label {
+                                display: block;
+                                margin-bottom: 6px;
+                                font: 600 14px/1.3 sans-serif;
+                            }
+
+                            input {
+                                width: 240px;
+                                height: 36px;
+                            }
+                        </style>
+                        <div class="field">
+                            <label for="slotted-search-input">Search catalog</label>
+                            <slot name="input">
+                                <input
+                                    id="slotted-search-input"
+                                    placeholder="Search"
+                                />
+                            </slot>
+                        </div>
+                    \`
+                }
+            })
+        </script>
+        `
+    )
+
+    await page.waitForFunction(() => {
+        const host = document.querySelector('#search-host')
+        return Boolean(
+            host instanceof HTMLElement &&
+                host.shadowRoot?.querySelector('#slotted-search-input')
+        )
+    })
+}

--- a/tests/integration/visibility.test.ts
+++ b/tests/integration/visibility.test.ts
@@ -1,6 +1,8 @@
+import * as cheerio from 'cheerio'
 import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { BrowserContext, Page } from 'playwright'
 import { markInteractiveElements } from '../../src/html/interactivity.js'
+import { prepareSnapshot } from '../../src/html/pipeline.js'
 import { closeTestBrowser, createTestPage } from '../helpers/browser.js'
 import {
     getHiddenIds,
@@ -41,6 +43,17 @@ describe('integration/visibility', () => {
         expect(interactive).toContain('visible-btn')
         expect(interactive).toContain('display-contents-btn')
         expect(interactive).toContain('behind-overlay-btn')
+    })
+
+    it('keeps action-mode controls nested under display-contents wrappers', async () => {
+        const snapshot = await prepareSnapshot(page, { mode: 'action' })
+        const $ = cheerio.load(snapshot.cleanedHtml)
+        const displayContentsButton = $('button').filter((_, el) => {
+            return $(el).text().trim() === 'Display contents child'
+        })
+
+        expect(displayContentsButton.length).toBe(1)
+        expect(displayContentsButton.attr('c')).toBeTruthy()
     })
 
     describe('current behavior (pinned)', () => {


### PR DESCRIPTION
Summary
- consolidate element visibility checks into reusable helpers covering hidden attributes, opacity, and zero-sized rects without visible out-of-flow children
- add integration and snapshot tests for display-contents wrappers and shadow-slot fallbacks to ensure action snapshots keep visible content marked
- document how to launch Opensteer with a local Chrome profile in the SDK reference

Testing
- Not run (not requested)