### PR TITLE
Add default browser launch for cloud recording and prefer GitHub skill installs

### DIFF
--- a/packages/opensteer/src/cli/open-browser.ts
+++ b/packages/opensteer/src/cli/open-browser.ts
@@ -1,0 +1,52 @@
+import { spawn } from "node:child_process";
+import os from "node:os";
+import process from "node:process";
+
+export type BrowserUrlOpener = (url: string) => Promise<void>;
+
+export async function openBrowserUrl(url: string): Promise<void> {
+  const command = resolveOpenBrowserCommand(url);
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command.executable, command.args, {
+      detached: process.platform !== "win32",
+      stdio: "ignore",
+    });
+    child.once("error", reject);
+    child.once("spawn", () => {
+      child.unref();
+      resolve();
+    });
+  });
+}
+
+function resolveOpenBrowserCommand(url: string): {
+  readonly executable: string;
+  readonly args: readonly string[];
+} {
+  if (process.platform === "darwin") {
+    return {
+      executable: "open",
+      args: [url],
+    };
+  }
+
+  if (process.platform === "win32" || isWsl()) {
+    return {
+      executable: process.platform === "win32" ? "cmd" : "cmd.exe",
+      args: ["/c", "start", "", url],
+    };
+  }
+
+  return {
+    executable: "xdg-open",
+    args: [url],
+  };
+}
+
+function isWsl(): boolean {
+  return (
+    process.platform === "linux" &&
+    (process.env.WSL_DISTRO_NAME !== undefined ||
+      os.release().toLowerCase().includes("microsoft"))
+  );
+}

--- a/packages/opensteer/src/cli/record.ts
+++ b/packages/opensteer/src/cli/record.ts
@@ -21,6 +21,7 @@ import { requireCloudAppBaseUrl, type OpensteerCloudConfig } from "../cloud/conf
 import { CloudSessionProxy } from "../cloud/session-proxy.js";
 import type { OpensteerDisconnectableRuntime } from "../sdk/semantic-runtime.js";
 import { resolveFilesystemWorkspacePath } from "../root.js";
+import { openBrowserUrl, type BrowserUrlOpener } from "./open-browser.js";
 
 export interface OpensteerRecordCommandInput {
   readonly runtime: OpensteerDisconnectableRuntime;
@@ -65,6 +66,7 @@ export interface OpensteerCloudRecordCommandInput {
   readonly runtime?: OpensteerCloudRecordRuntime;
   readonly client?: OpensteerCloudRecordClient;
   readonly sleep?: (ms: number) => Promise<void>;
+  readonly openUrl?: BrowserUrlOpener;
 }
 
 export async function runOpensteerRecordCommand(
@@ -145,6 +147,7 @@ export async function runOpensteerCloudRecordCommand(
     });
   const client = input.client ?? resolveCloud();
   const sleep = input.sleep ?? delay;
+  const openUrl = input.openUrl ?? openBrowserUrl;
   let closed = false;
 
   try {
@@ -158,6 +161,11 @@ export async function runOpensteerCloudRecordCommand(
     const sessionUrl = buildCloudRecordingSessionUrl(cloudAppBaseUrl, sessionId);
 
     await client.startSessionRecording(sessionId);
+    await tryOpenCloudRecordingSessionUrl({
+      sessionUrl,
+      stderr,
+      openUrl,
+    });
     stderr.write(
       `Recording browser actions for workspace "${input.workspace}". Open ${sessionUrl} and click "Stop recording" in the browser session toolbar when you're done.\n`,
     );
@@ -234,6 +242,20 @@ function buildCloudRecordingSessionUrl(
   sessionId: string,
 ): string {
   return `${appBaseUrl}/browsers/${encodeURIComponent(sessionId)}`;
+}
+
+async function tryOpenCloudRecordingSessionUrl(input: {
+  readonly sessionUrl: string;
+  readonly stderr: NodeJS.WritableStream;
+  readonly openUrl: BrowserUrlOpener;
+}): Promise<void> {
+  try {
+    await input.openUrl(input.sessionUrl);
+  } catch {
+    input.stderr.write(
+      `Could not automatically open the cloud browser session. Open it manually: ${input.sessionUrl}\n`,
+    );
+  }
 }
 
 async function resolveCloudRecordingSessionId(

--- a/packages/opensteer/src/cli/skills-installer.ts
+++ b/packages/opensteer/src/cli/skills-installer.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 
+export const OPENSTEER_GITHUB_SOURCE = "steerlabs/opensteer";
+
 export interface OpensteerSkillsInstallOptions {
   readonly agents?: readonly string[];
   readonly skills?: readonly string[];
@@ -21,7 +23,8 @@ interface OpensteerSkillsInvocation {
 
 interface OpensteerSkillsInstallerDeps {
   readonly resolveSkillsCliPath: () => string;
-  readonly resolveSkillSourcePath: () => string;
+  readonly resolveLocalSkillSourcePath: () => string;
+  readonly checkGitHubReachable: () => Promise<boolean>;
   readonly spawnInvocation: (invocation: OpensteerSkillsInvocation) => Promise<number>;
 }
 
@@ -75,7 +78,7 @@ export function resolveOpensteerSkillsCliPath(): string {
   return cliPath;
 }
 
-export function resolveOpensteerSkillSourcePath(): string {
+export function resolveOpensteerLocalSkillSourcePath(): string {
   let ancestor = path.dirname(fileURLToPath(import.meta.url));
 
   for (let index = 0; index < 6; index += 1) {
@@ -90,21 +93,40 @@ export function resolveOpensteerSkillSourcePath(): string {
   throw new Error("Unable to find the packaged Opensteer skill source directory.");
 }
 
+export async function checkOpensteerGitHubReachable(): Promise<boolean> {
+  try {
+    const response = await fetch(`https://github.com/${OPENSTEER_GITHUB_SOURCE}`, {
+      method: "HEAD",
+      signal: AbortSignal.timeout(3000),
+      redirect: "manual",
+    });
+    return response.status < 500;
+  } catch {
+    return false;
+  }
+}
+
 export async function runOpensteerSkillsInstaller(
   options: OpensteerSkillsInstallOptions = {},
   overrideDeps: Partial<OpensteerSkillsInstallerDeps> = {},
 ): Promise<number> {
   const deps: OpensteerSkillsInstallerDeps = {
     resolveSkillsCliPath: resolveOpensteerSkillsCliPath,
-    resolveSkillSourcePath: resolveOpensteerSkillSourcePath,
+    resolveLocalSkillSourcePath: resolveOpensteerLocalSkillSourcePath,
+    checkGitHubReachable: checkOpensteerGitHubReachable,
     spawnInvocation: spawnOpensteerSkillsInvocation,
     ...overrideDeps,
   };
 
+  const useGitHub = await deps.checkGitHubReachable();
+  const skillSourcePath = useGitHub
+    ? OPENSTEER_GITHUB_SOURCE
+    : deps.resolveLocalSkillSourcePath();
+
   const invocation = createOpensteerSkillsInvocation({
     options,
     skillsCliPath: deps.resolveSkillsCliPath(),
-    skillSourcePath: deps.resolveSkillSourcePath(),
+    skillSourcePath,
   });
 
   return deps.spawnInvocation(invocation);

--- a/tests/opensteer/record-command.test.ts
+++ b/tests/opensteer/record-command.test.ts
@@ -332,6 +332,7 @@ describe("runOpensteerRecordCommand", () => {
       },
     ]);
     const sleep = vi.fn(async () => undefined);
+    const openUrl = vi.fn(async () => undefined);
     const stdout = new PassThrough();
     const stderr = new PassThrough();
     const outputPath = path.join(rootDir, "recorded-flow.ts");
@@ -353,6 +354,7 @@ describe("runOpensteerRecordCommand", () => {
       runtime,
       client,
       sleep,
+      openUrl,
       stdout,
       stderr,
     });
@@ -369,11 +371,60 @@ describe("runOpensteerRecordCommand", () => {
     expect(client.startCalls).toEqual(["cloud-session-123"]);
     expect(client.getCalls).toEqual(["cloud-session-123", "cloud-session-123"]);
     expect(sleep).toHaveBeenCalledTimes(1);
+    expect(openUrl).toHaveBeenCalledWith("http://127.0.0.1:3000/browsers/cloud-session-123");
     expect(runtime.closeCalls).toBe(1);
     await expect(readFile(outputPath, "utf8")).resolves.toBe('console.log("cloud recording");\n');
     expect(stdout.read()?.toString("utf8")).toContain(outputPath);
     expect(stderr.read()?.toString("utf8")).toContain(
       "http://127.0.0.1:3000/browsers/cloud-session-123",
+    );
+  });
+
+  test("continues cloud recording when opening the browser URL fails", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "opensteer-record-command-"));
+    temporaryRoots.push(rootDir);
+
+    const runtime = new FakeCloudRecordRuntime();
+    const client = new FakeCloudRecordClient([
+      {
+        status: "completed",
+        result: {
+          fileName: "recorded-flow.ts",
+          script: 'console.log("cloud recording");\n',
+          actionCount: 1,
+        },
+      },
+    ]);
+    const openUrl = vi.fn(async () => {
+      throw new Error("No browser available");
+    });
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const outputPath = path.join(rootDir, "recorded-flow.ts");
+
+    await runOpensteerCloudRecordCommand({
+      cloudConfig: {
+        apiKey: "test-api-key",
+        baseUrl: "http://127.0.0.1:8180",
+        appBaseUrl: "http://127.0.0.1:3000",
+      },
+      workspace: "recorded-cloud",
+      url: "https://example.com",
+      rootDir,
+      outputPath,
+      runtime,
+      client,
+      openUrl,
+      stdout,
+      stderr,
+    });
+
+    expect(openUrl).toHaveBeenCalledWith("http://127.0.0.1:3000/browsers/cloud-session-123");
+    expect(runtime.closeCalls).toBe(1);
+    await expect(readFile(outputPath, "utf8")).resolves.toBe('console.log("cloud recording");\n');
+    expect(stdout.read()?.toString("utf8")).toContain(outputPath);
+    expect(stderr.read()?.toString("utf8")).toContain(
+      "Could not automatically open the cloud browser session.",
     );
   });
 

--- a/tests/opensteer/skills-installer.test.ts
+++ b/tests/opensteer/skills-installer.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from "vitest";
 
 import {
   createOpensteerSkillsInvocation,
+  OPENSTEER_GITHUB_SOURCE,
   runOpensteerSkillsInstaller,
 } from "../../packages/opensteer/src/cli/skills-installer.js";
 
@@ -47,7 +48,7 @@ describe("Opensteer skills installer", () => {
     });
   });
 
-  test("uses the resolved packaged skill directory when running", async () => {
+  test("uses GitHub source when reachable for registry tracking", async () => {
     let receivedInvocation:
       | {
           readonly cliPath: string;
@@ -61,7 +62,38 @@ describe("Opensteer skills installer", () => {
       },
       {
         resolveSkillsCliPath: () => "/tmp/skills-cli.mjs",
-        resolveSkillSourcePath: () => path.join("/tmp", "packaged-skills"),
+        resolveLocalSkillSourcePath: () => path.join("/tmp", "packaged-skills"),
+        checkGitHubReachable: async () => true,
+        spawnInvocation: async (invocation) => {
+          receivedInvocation = invocation;
+          return 0;
+        },
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(receivedInvocation).toEqual({
+      cliPath: "/tmp/skills-cli.mjs",
+      cliArgs: ["add", OPENSTEER_GITHUB_SOURCE, "--skill", "opensteer", "--yes"],
+    });
+  });
+
+  test("falls back to local bundled skills when GitHub is unreachable", async () => {
+    let receivedInvocation:
+      | {
+          readonly cliPath: string;
+          readonly cliArgs: readonly string[];
+        }
+      | undefined;
+
+    const exitCode = await runOpensteerSkillsInstaller(
+      {
+        yes: true,
+      },
+      {
+        resolveSkillsCliPath: () => "/tmp/skills-cli.mjs",
+        resolveLocalSkillSourcePath: () => path.join("/tmp", "packaged-skills"),
+        checkGitHubReachable: async () => false,
         spawnInvocation: async (invocation) => {
           receivedInvocation = invocation;
           return 0;


### PR DESCRIPTION
## Summary
- auto-open the cloud recording session URL after recording starts, while keeping the existing manual URL fallback if browser launch fails
- add focused recorder tests for successful browser launch and graceful fallback behavior
- update skills installer resolution to prefer the GitHub source when reachable and fall back to bundled local skills otherwise
- add installer tests covering both GitHub and local fallback paths

## Testing
- `pnpm vitest run --config vitest.unit.config.ts tests/opensteer/record-command.test.ts`
- `pnpm --filter opensteer build`
- `pnpm --filter opensteer typecheck` (fails due to a pre-existing unrelated error in `packages/engine-abp/src/action-settle.ts`)