### PR TITLE
Refactor Opensteer request tooling and bump npm package versions

### DIFF
--- a/.agents/skills/opensteer/SKILL.md
+++ b/.agents/skills/opensteer/SKILL.md
@@ -133,11 +133,11 @@ The first command shows: URL, method, request headers, cookies sent, request/res
 
 Add `--probe` to also test which transport works for this API:
 
-| Transport | Meaning | SDK usage |
-|---|---|---|
-| `direct-http` | Plain HTTP works | `this.fetch(url)` (default) |
+| Transport     | Meaning                        | SDK usage                                       |
+| ------------- | ------------------------------ | ----------------------------------------------- |
+| `direct-http` | Plain HTTP works               | `this.fetch(url)` (default)                     |
 | `matched-tls` | Needs TLS fingerprint matching | `this.fetch(url, { transport: "matched-tls" })` |
-| `page-http` | Needs a live browser page | `this.fetch(url, { transport: "page" })` |
+| `page-http`   | Needs a live browser page      | `this.fetch(url, { transport: "page" })`        |
 
 ### Step 4: Check browser state (if 401/403)
 
@@ -269,26 +269,26 @@ opensteer computer screenshot --workspace demo
 
 ## CLI Quick Reference
 
-| Command | Positional args | Key flags |
-|---|---|---|
-| `open <url>` | url | `--headless`, `--provider`, `--attach-endpoint`, `--attach-header` |
-| `close` | — | — |
-| `status` | — | — |
-| `goto <url>` | url | `--capture-network` |
-| `snapshot [mode]` | action \| extraction | — |
-| `click <element>` | element number | `--persist`, `--capture-network`, `--button` |
-| `hover <element>` | element number | `--persist`, `--capture-network` |
-| `input <element> <text>` | element, text | `--persist`, `--press-enter`, `--capture-network` |
-| `scroll <dir> <amount>` | direction, amount | `--element`, `--persist`, `--capture-network` |
-| `extract <schema>` | JSON schema | `--persist` |
-| `evaluate <script>` | JS expression | — |
-| `network query` | — | `--capture`, `--url`, `--hostname`, `--json`, `--limit`, +6 filters |
-| `network detail <id>` | recordId | `--probe` |
-| `fetch <url>` | url | `--method`, `--header`, `--query`, `--body`, `--transport`, `--cookies` |
-| `state [domain]` | domain (optional) | — |
-| `exec <expression>` | JS expression | — |
-| `tab list / new / <n> / close` | varies | — |
-| `computer click/type/key/scroll/move/drag/screenshot/wait` | varies | `--capture-network` |
+| Command                                                    | Positional args      | Key flags                                                               |
+| ---------------------------------------------------------- | -------------------- | ----------------------------------------------------------------------- |
+| `open <url>`                                               | url                  | `--headless`, `--provider`, `--attach-endpoint`, `--attach-header`      |
+| `close`                                                    | —                    | —                                                                       |
+| `status`                                                   | —                    | —                                                                       |
+| `goto <url>`                                               | url                  | `--capture-network`                                                     |
+| `snapshot [mode]`                                          | action \| extraction | —                                                                       |
+| `click <element>`                                          | element number       | `--persist`, `--capture-network`, `--button`                            |
+| `hover <element>`                                          | element number       | `--persist`, `--capture-network`                                        |
+| `input <element> <text>`                                   | element, text        | `--persist`, `--press-enter`, `--capture-network`                       |
+| `scroll <dir> <amount>`                                    | direction, amount    | `--element`, `--persist`, `--capture-network`                           |
+| `extract <schema>`                                         | JSON schema          | `--persist`                                                             |
+| `evaluate <script>`                                        | JS expression        | —                                                                       |
+| `network query`                                            | —                    | `--capture`, `--url`, `--hostname`, `--json`, `--limit`, +6 filters     |
+| `network detail <id>`                                      | recordId             | `--probe`                                                               |
+| `fetch <url>`                                              | url                  | `--method`, `--header`, `--query`, `--body`, `--transport`, `--cookies` |
+| `state [domain]`                                           | domain (optional)    | —                                                                       |
+| `exec <expression>`                                        | JS expression        | —                                                                       |
+| `tab list / new / <n> / close`                             | varies               | —                                                                       |
+| `computer click/type/key/scroll/move/drag/screenshot/wait` | varies               | `--capture-network`                                                     |
 
 ## SDK Quick Reference
 
@@ -336,11 +336,11 @@ const html = await opensteer.snapshot("extraction");
 
 ## Common Issues
 
-| Symptom | Fix |
-|---|---|
-| Element numbers wrong after navigation | Re-snapshot before using element numbers |
-| `fetch()` returns 401/403 | Check `state` — request depends on session cookies or tokens |
-| Direct HTTP blocked, browser transport works | Site uses TLS fingerprinting — use `transport: "matched-tls"` |
-| Extract returns empty data | Element numbers changed — re-snapshot and rebuild the schema |
-| `fetch()` fails with no session | Call `opensteer.goto(url)` first to establish cookies, then `fetch()` |
-| Using `evaluate` for API calls | Use `exec` instead — `evaluate` runs inside the page where anti-bot scripts can intercept requests |
+| Symptom                                      | Fix                                                                                                |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Element numbers wrong after navigation       | Re-snapshot before using element numbers                                                           |
+| `fetch()` returns 401/403                    | Check `state` — request depends on session cookies or tokens                                       |
+| Direct HTTP blocked, browser transport works | Site uses TLS fingerprinting — use `transport: "matched-tls"`                                      |
+| Extract returns empty data                   | Element numbers changed — re-snapshot and rebuild the schema                                       |
+| `fetch()` fails with no session              | Call `opensteer.goto(url)` first to establish cookies, then `fetch()`                              |
+| Using `evaluate` for API calls               | Use `exec` instead — `evaluate` runs inside the page where anti-bot scripts can intercept requests |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project should be recorded in this file.
 
 ## Unreleased
 
+## 0.8.16 - 2026-04-08
+
+- Refined request tooling around exec-driven flows, transport probing, and CLI/runtime selection
+- Normalized DOM runtime persist keys and trimmed snapshot interaction output to reduce agent-facing noise
+- Updated protocol and runtime internals to match the new request flow behavior with added regression coverage
+
 ## 0.8.0 - 2026-03-27
 
 - Added stable browser-native instrumentation APIs for init scripts, routing, script interception, and script capture

--- a/packages/browser-core/package.json
+++ b/packages/browser-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opensteer/browser-core",
   "private": false,
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Engine-neutral primitives and contracts for Opensteer browser backends.",
   "license": "MIT",
   "type": "module",

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opensteer/conformance",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Reusable conformance cases for Opensteer local and cloud runtimes.",
   "license": "MIT",
   "type": "module",

--- a/packages/opensteer/package.json
+++ b/packages/opensteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensteer",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "Opensteer browser automation, replay, and reverse-engineering toolkit.",
   "license": "MIT",
   "type": "module",

--- a/packages/opensteer/src/cli/bin.ts
+++ b/packages/opensteer/src/cli/bin.ts
@@ -37,11 +37,7 @@ const emitProcessWarning = process.emitWarning.bind(process);
 
 process.emitWarning = ((warning: string | Error, ...args: unknown[]) => {
   const name =
-    warning instanceof Error
-      ? warning.name
-      : typeof args[0] === "string"
-        ? args[0]
-        : undefined;
+    warning instanceof Error ? warning.name : typeof args[0] === "string" ? args[0] : undefined;
   const message = warning instanceof Error ? warning.message : warning;
   if (
     name === "ExperimentalWarning" &&
@@ -110,9 +106,7 @@ async function main(): Promise<void> {
   }
 
   if (parsed.options.workspace === undefined) {
-    throw new Error(
-      'Stateful commands require "--workspace <id>" or OPENSTEER_WORKSPACE.',
-    );
+    throw new Error('Stateful commands require "--workspace <id>" or OPENSTEER_WORKSPACE.');
   }
 
   const { engineName, provider, runtimeProvider } = resolveCliRuntimeSelection(parsed);
@@ -157,7 +151,9 @@ async function handleExecCommand(parsed: ParsedCommandLine): Promise<void> {
   }
   const expression = parsed.rest.join(" ");
   if (!expression) {
-    throw new Error("exec requires an expression. Example: exec \"await this.evaluate('document.title')\"");
+    throw new Error(
+      "exec requires an expression. Example: exec \"await this.evaluate('document.title')\"",
+    );
   }
 
   const { engineName, runtimeProvider } = resolveCliRuntimeSelection(parsed);

--- a/packages/opensteer/src/cli/exec.ts
+++ b/packages/opensteer/src/cli/exec.ts
@@ -1,9 +1,6 @@
 // Tries expression-mode first (auto-return); falls back to statement block
 // (requires explicit return). Runs in the local Node.js process.
-export async function runExecExpression(
-  context: object,
-  expression: string,
-): Promise<unknown> {
+export async function runExecExpression(context: object, expression: string): Promise<unknown> {
   const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as new (
     ...args: string[]
   ) => (...args: unknown[]) => Promise<unknown>;

--- a/packages/opensteer/src/cli/open-browser.ts
+++ b/packages/opensteer/src/cli/open-browser.ts
@@ -46,7 +46,6 @@ function resolveOpenBrowserCommand(url: string): {
 function isWsl(): boolean {
   return (
     process.platform === "linux" &&
-    (process.env.WSL_DISTRO_NAME !== undefined ||
-      os.release().toLowerCase().includes("microsoft"))
+    (process.env.WSL_DISTRO_NAME !== undefined || os.release().toLowerCase().includes("microsoft"))
   );
 }

--- a/packages/opensteer/src/cli/operation-input.ts
+++ b/packages/opensteer/src/cli/operation-input.ts
@@ -537,13 +537,9 @@ function readCaptchaProvider(value: string | undefined): "2captcha" | "capsolver
   return value as "2captcha" | "capsolver";
 }
 
-function readCaptchaType(
-  value: string | undefined,
-): "recaptcha-v2" | "hcaptcha" | "turnstile" {
+function readCaptchaType(value: string | undefined): "recaptcha-v2" | "hcaptcha" | "turnstile" {
   if (value === undefined || !CAPTCHA_TYPES.has(value)) {
-    throw new Error(
-      'Expected "--type" to be one of: recaptcha-v2, hcaptcha, turnstile.',
-    );
+    throw new Error('Expected "--type" to be one of: recaptcha-v2, hcaptcha, turnstile.');
   }
   return value as "recaptcha-v2" | "hcaptcha" | "turnstile";
 }
@@ -612,10 +608,7 @@ function readExtractPersistKey(parsed: ParsedCommandLine): string | undefined {
   return value;
 }
 
-function parseRequiredJsonObjectArgument(
-  value: string,
-  label: string,
-): Record<string, unknown> {
+function parseRequiredJsonObjectArgument(value: string, label: string): Record<string, unknown> {
   const parsed = JSON.parse(value);
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error(`${label} must be a JSON object.`);

--- a/packages/opensteer/src/cli/output.ts
+++ b/packages/opensteer/src/cli/output.ts
@@ -57,8 +57,12 @@ export function renderOperationOutput(
 
 function formatNavigationOutput(result: unknown): Record<string, unknown> {
   return {
-    ...(readStringField(result, "url") === undefined ? {} : { url: readStringField(result, "url") }),
-    ...(readStringField(result, "title") === undefined ? {} : { title: readStringField(result, "title") }),
+    ...(readStringField(result, "url") === undefined
+      ? {}
+      : { url: readStringField(result, "url") }),
+    ...(readStringField(result, "title") === undefined
+      ? {}
+      : { title: readStringField(result, "title") }),
   };
 }
 
@@ -79,8 +83,12 @@ function formatActionOutput(
 ): Record<string, unknown> {
   const target = readObjectField(result, "target");
   const output: Record<string, unknown> = {
-    ...(readStringField(target, "tagName") === undefined ? {} : { tagName: readStringField(target, "tagName") }),
-    ...(readStringField(target, "pathHint") === undefined ? {} : { pathHint: readStringField(target, "pathHint") }),
+    ...(readStringField(target, "tagName") === undefined
+      ? {}
+      : { tagName: readStringField(target, "tagName") }),
+    ...(readStringField(target, "pathHint") === undefined
+      ? {}
+      : { pathHint: readStringField(target, "pathHint") }),
   };
 
   const point = readObjectField(result, "point");
@@ -228,7 +236,10 @@ function formatNetworkDetailOutput(result: unknown): string {
 
   const redirectChain = readArrayField(result, "redirectChain");
   if (redirectChain.length > 0) {
-    lines.push("", `Redirect chain (${redirectChain.length} hop${redirectChain.length === 1 ? "" : "s"}):`);
+    lines.push(
+      "",
+      `Redirect chain (${redirectChain.length} hop${redirectChain.length === 1 ? "" : "s"}):`,
+    );
     redirectChain.forEach((hop, index) => {
       const location = readStringField(hop, "location");
       lines.push(
@@ -260,10 +271,7 @@ function formatNetworkDetailOutput(result: unknown): string {
       const summary = readObjectField(result, "summary");
       const method = readStringField(summary, "method") ?? "GET";
       const url = readStringField(summary, "url") ?? "";
-      lines.push(
-        "",
-        `-> SDK: await this.fetch("${url}", { method: "${method}" })`,
-      );
+      lines.push("", `-> SDK: await this.fetch("${url}", { method: "${method}" })`);
     }
   }
 
@@ -293,19 +301,24 @@ function formatTransportOutput(
     ...(readNumberField(attempt, "status") === undefined
       ? {}
       : { status: readNumberField(attempt, "status") }),
-    ...(readStringField(attempt, "note") === undefined ? {} : { note: readStringField(attempt, "note") }),
-    ...(readStringField(attempt, "error") === undefined ? {} : { error: readStringField(attempt, "error") }),
+    ...(readStringField(attempt, "note") === undefined
+      ? {}
+      : { note: readStringField(attempt, "note") }),
+    ...(readStringField(attempt, "error") === undefined
+      ? {}
+      : { error: readStringField(attempt, "error") }),
   }));
   const contentType =
     response === undefined
       ? undefined
-      : findHeaderValue(readArrayField(response, "headers"), "content-type") ??
-        readStringField(readObjectField(response, "body"), "mimeType");
+      : (findHeaderValue(readArrayField(response, "headers"), "content-type") ??
+        readStringField(readObjectField(response, "body"), "mimeType"));
   const body = readObjectField(response, "body");
   const bodySize =
     body === undefined
       ? undefined
-      : readNumberField(body, "originalByteLength") ?? readNumberField(body, "capturedByteLength");
+      : (readNumberField(body, "originalByteLength") ??
+        readNumberField(body, "capturedByteLength"));
   const output: Record<string, unknown> = {
     ...(readStringField(result, "transport") === undefined
       ? {}
@@ -342,7 +355,9 @@ function formatCookiesOutput(result: unknown): string {
   }
   const cookies = readArrayField(result, "cookies");
   const domain = readStringField(result, "domain");
-  const lines = [`[cookies] ${cookies.length} cookie${cookies.length === 1 ? "" : "s"}${domain === undefined ? "" : ` for ${domain}`}`];
+  const lines = [
+    `[cookies] ${cookies.length} cookie${cookies.length === 1 ? "" : "s"}${domain === undefined ? "" : ` for ${domain}`}`,
+  ];
   for (const cookie of cookies) {
     const flags = [
       readBooleanField(cookie, "session") === true ? "session" : undefined,
@@ -367,9 +382,16 @@ function formatStorageOutput(result: unknown): string {
     const domainName = readStringField(domain, "domain") ?? "unknown";
     const localStorage = readArrayField(domain, "localStorage");
     const sessionStorage = readArrayField(domain, "sessionStorage");
-    lines.push(`[storage] localStorage for ${domainName} (${localStorage.length} key${localStorage.length === 1 ? "" : "s"})`, "");
+    lines.push(
+      `[storage] localStorage for ${domainName} (${localStorage.length} key${localStorage.length === 1 ? "" : "s"})`,
+      "",
+    );
     lines.push(...localStorage.map((entry) => formatStorageEntry(entry)));
-    lines.push("", `[storage] sessionStorage for ${domainName} (${sessionStorage.length} key${sessionStorage.length === 1 ? "" : "s"})`, "");
+    lines.push(
+      "",
+      `[storage] sessionStorage for ${domainName} (${sessionStorage.length} key${sessionStorage.length === 1 ? "" : "s"})`,
+      "",
+    );
     lines.push(...sessionStorage.map((entry) => formatStorageEntry(entry)), "");
   }
   return `${lines.join("\n").trimEnd()}\n`;
@@ -401,10 +423,16 @@ function formatStateOutput(result: unknown): string {
       ),
     );
     const localStorage = readArrayField(domain, "localStorage");
-    lines.push("", `localStorage (${localStorage.length} key${localStorage.length === 1 ? "" : "s"}):`);
+    lines.push(
+      "",
+      `localStorage (${localStorage.length} key${localStorage.length === 1 ? "" : "s"}):`,
+    );
     lines.push(...localStorage.map((entry) => formatStorageEntry(entry)));
     const sessionStorage = readArrayField(domain, "sessionStorage");
-    lines.push("", `sessionStorage (${sessionStorage.length} key${sessionStorage.length === 1 ? "" : "s"}):`);
+    lines.push(
+      "",
+      `sessionStorage (${sessionStorage.length} key${sessionStorage.length === 1 ? "" : "s"}):`,
+    );
     lines.push(...sessionStorage.map((entry) => formatStorageEntry(entry)));
     const globals = readObjectField(domain, "globals");
     if (globals !== undefined) {
@@ -429,9 +457,15 @@ function formatComputerOutput(result: unknown): Record<string, unknown> {
       ? {}
       : {
           screenshot: {
-            ...(readStringField(payload, "uri") === undefined ? {} : { uri: readStringField(payload, "uri") }),
-            ...(readStringField(screenshot, "format") === undefined ? {} : { format: readStringField(screenshot, "format") }),
-            ...(readObjectField(screenshot, "size") === undefined ? {} : { size: readObjectField(screenshot, "size") }),
+            ...(readStringField(payload, "uri") === undefined
+              ? {}
+              : { uri: readStringField(payload, "uri") }),
+            ...(readStringField(screenshot, "format") === undefined
+              ? {}
+              : { format: readStringField(screenshot, "format") }),
+            ...(readObjectField(screenshot, "size") === undefined
+              ? {}
+              : { size: readObjectField(screenshot, "size") }),
           },
         }),
     ...(timing === undefined ? {} : { timingMs: timing }),
@@ -495,8 +529,12 @@ function formatInteractionTraceOutput(result: unknown): Record<string, unknown> 
     ...(readStringField(trace, "version") === undefined
       ? {}
       : { version: readStringField(trace, "version") }),
-    ...(readStringField(payload, "mode") === undefined ? {} : { mode: readStringField(payload, "mode") }),
-    ...(readStringField(payload, "url") === undefined ? {} : { url: readStringField(payload, "url") }),
+    ...(readStringField(payload, "mode") === undefined
+      ? {}
+      : { mode: readStringField(payload, "mode") }),
+    ...(readStringField(payload, "url") === undefined
+      ? {}
+      : { url: readStringField(payload, "url") }),
     ...(readArrayField(payload, "events").length === 0
       ? {}
       : { eventCount: readArrayField(payload, "events").length }),
@@ -557,7 +595,9 @@ function formatCaptchaSolveOutput(result: unknown): Record<string, unknown> {
               : { pageUrl: readStringField(captcha, "pageUrl") }),
           },
         }),
-    ...(readStringField(result, "token") === undefined ? {} : { token: readStringField(result, "token") }),
+    ...(readStringField(result, "token") === undefined
+      ? {}
+      : { token: readStringField(result, "token") }),
     ...(readBooleanField(result, "injected") === undefined
       ? {}
       : { injected: readBooleanField(result, "injected") }),
@@ -586,14 +626,18 @@ function formatInteractionDiffOutput(result: unknown): Record<string, unknown> {
 
 function formatInteractionReplayOutput(result: unknown): Record<string, unknown> {
   return {
-    ...(readStringField(result, "traceId") === undefined ? {} : { traceId: readStringField(result, "traceId") }),
+    ...(readStringField(result, "traceId") === undefined
+      ? {}
+      : { traceId: readStringField(result, "traceId") }),
     ...(readNumberField(result, "replayedEventCount") === undefined
       ? {}
       : { replayedEventCount: readNumberField(result, "replayedEventCount") }),
     ...(readBooleanField(result, "success") === undefined
       ? {}
       : { success: readBooleanField(result, "success") }),
-    ...(readStringField(result, "error") === undefined ? {} : { error: readStringField(result, "error") }),
+    ...(readStringField(result, "error") === undefined
+      ? {}
+      : { error: readStringField(result, "error") }),
   };
 }
 
@@ -746,7 +790,9 @@ function padRight(value: string, width: number): string {
 }
 
 function truncateInline(value: string, limit: number): string {
-  return value.length <= limit ? value : `${value.slice(0, Math.max(0, limit - 18))}...${value.length} chars`;
+  return value.length <= limit
+    ? value
+    : `${value.slice(0, Math.max(0, limit - 18))}...${value.length} chars`;
 }
 
 function stringifyValue(value: unknown): string {

--- a/packages/opensteer/src/cli/parse.ts
+++ b/packages/opensteer/src/cli/parse.ts
@@ -2,10 +2,7 @@ import process from "node:process";
 
 import type { OpensteerBrowserOptions } from "@opensteer/protocol";
 
-import {
-  normalizeOpensteerProviderMode,
-  type OpensteerProviderMode,
-} from "../provider/config.js";
+import { normalizeOpensteerProviderMode, type OpensteerProviderMode } from "../provider/config.js";
 import { resolveCommandLength } from "./commands.js";
 
 export interface ParsedCliOptions {
@@ -246,7 +243,10 @@ export function parseCommandLine(argv: readonly string[]): ParsedCommandLine {
   const cloudApiKey = readSingle(rawOptions, "cloud-api-key");
   const cloudAppBaseUrl = readSingle(rawOptions, "cloud-app-base-url");
   const cloudProfileId = readSingle(rawOptions, "cloud-profile-id");
-  const cloudProfileReuseIfActive = readOptionalBoolean(rawOptions, "cloud-profile-reuse-if-active");
+  const cloudProfileReuseIfActive = readOptionalBoolean(
+    rawOptions,
+    "cloud-profile-reuse-if-active",
+  );
   const json = readOptionalBoolean(rawOptions, "json");
   const agents = rawOptions.get("agent");
   const skills = rawOptions.get("skill");

--- a/packages/opensteer/src/cli/record.ts
+++ b/packages/opensteer/src/cli/record.ts
@@ -69,9 +69,7 @@ export interface OpensteerCloudRecordCommandInput {
   readonly openUrl?: BrowserUrlOpener;
 }
 
-export async function runOpensteerRecordCommand(
-  input: OpensteerRecordCommandInput,
-): Promise<void> {
+export async function runOpensteerRecordCommand(input: OpensteerRecordCommandInput): Promise<void> {
   const stdout = input.stdout ?? process.stdout;
   const stderr = input.stderr ?? process.stderr;
   const outputPath = resolveRecordOutputPath({
@@ -237,10 +235,7 @@ export function createRecorderRuntimeAdapter(
   };
 }
 
-function buildCloudRecordingSessionUrl(
-  appBaseUrl: string,
-  sessionId: string,
-): string {
+function buildCloudRecordingSessionUrl(appBaseUrl: string, sessionId: string): string {
   return `${appBaseUrl}/browsers/${encodeURIComponent(sessionId)}`;
 }
 

--- a/packages/opensteer/src/cli/skills-installer.ts
+++ b/packages/opensteer/src/cli/skills-installer.ts
@@ -119,9 +119,7 @@ export async function runOpensteerSkillsInstaller(
   };
 
   const useGitHub = await deps.checkGitHubReachable();
-  const skillSourcePath = useGitHub
-    ? OPENSTEER_GITHUB_SOURCE
-    : deps.resolveLocalSkillSourcePath();
+  const skillSourcePath = useGitHub ? OPENSTEER_GITHUB_SOURCE : deps.resolveLocalSkillSourcePath();
 
   const invocation = createOpensteerSkillsInvocation({
     options,

--- a/packages/opensteer/src/cloud/config.ts
+++ b/packages/opensteer/src/cloud/config.ts
@@ -41,8 +41,7 @@ export function resolveCloudConfig(
   if (!baseUrl || baseUrl.trim().length === 0) {
     throw new Error("provider=cloud requires OPENSTEER_BASE_URL or provider.baseUrl.");
   }
-  const appBaseUrl =
-    cloudProvider?.appBaseUrl ?? input.environment?.OPENSTEER_CLOUD_APP_BASE_URL;
+  const appBaseUrl = cloudProvider?.appBaseUrl ?? input.environment?.OPENSTEER_CLOUD_APP_BASE_URL;
 
   return {
     apiKey: apiKey.trim(),

--- a/packages/opensteer/src/local-browser/cookie-reader.ts
+++ b/packages/opensteer/src/local-browser/cookie-reader.ts
@@ -5,10 +5,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { promisify } from "node:util";
-import type {
-  DatabaseSync as NodeSqliteDatabaseSync,
-  SQLOutputValue,
-} from "node:sqlite";
+import type { DatabaseSync as NodeSqliteDatabaseSync, SQLOutputValue } from "node:sqlite";
 
 import {
   type BrowserBrandId,
@@ -220,12 +217,7 @@ const BRAND_KEYCHAIN_SERVICE: Record<BrowserBrandId, string> = {
 async function resolveKeychainPassword(brandId: BrowserBrandId): Promise<string> {
   const service = BRAND_KEYCHAIN_SERVICE[brandId];
   try {
-    const { stdout } = await execFile("security", [
-      "find-generic-password",
-      "-s",
-      service,
-      "-w",
-    ]);
+    const { stdout } = await execFile("security", ["find-generic-password", "-s", service, "-w"]);
     return stdout.trim();
   } catch {
     throw new Error(

--- a/packages/opensteer/src/sdk/opensteer.ts
+++ b/packages/opensteer/src/sdk/opensteer.ts
@@ -244,8 +244,7 @@ export class Opensteer {
 
     this.network = {
       query: (input = {}) => this.queryNetwork(input),
-      detail: (recordId, options) =>
-        this.runtime.getNetworkDetail({ recordId, ...options }),
+      detail: (recordId, options) => this.runtime.getNetworkDetail({ recordId, ...options }),
     };
   }
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opensteer/protocol",
   "private": false,
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Public wire schemas and versioned envelopes for Opensteer APIs.",
   "license": "MIT",
   "type": "module",

--- a/packages/protocol/src/cloud.ts
+++ b/packages/protocol/src/cloud.ts
@@ -79,12 +79,7 @@ export const cloudSessionStatuses = [
 
 export type CloudSessionStatus = (typeof cloudSessionStatuses)[number];
 
-export const cloudSessionRecordingStatuses = [
-  "idle",
-  "recording",
-  "completed",
-  "failed",
-] as const;
+export const cloudSessionRecordingStatuses = ["idle", "recording", "completed", "failed"] as const;
 
 export type CloudSessionRecordingStatus = (typeof cloudSessionRecordingStatuses)[number];
 

--- a/packages/protocol/src/mcp.ts
+++ b/packages/protocol/src/mcp.ts
@@ -50,9 +50,7 @@ const readOnlyOperations = new Set<OpensteerSemanticOperationName>([
   "session.state",
 ]);
 
-const destructiveOperations = new Set<OpensteerSemanticOperationName>([
-  "session.close",
-]);
+const destructiveOperations = new Set<OpensteerSemanticOperationName>(["session.close"]);
 
 function toolNameFromOperation(operation: OpensteerSemanticOperationName): string {
   return `opensteer_${operation.replaceAll(".", "_").replaceAll("-", "_")}`;

--- a/packages/protocol/src/semantic.ts
+++ b/packages/protocol/src/semantic.ts
@@ -1104,9 +1104,12 @@ const opensteerNetworkDetailInputSchema: JsonSchema = objectSchema(
   },
 );
 
-const opensteerComputerMouseButtonSchema: JsonSchema = enumSchema(["left", "middle", "right"] as const, {
-  title: "OpensteerComputerMouseButton",
-});
+const opensteerComputerMouseButtonSchema: JsonSchema = enumSchema(
+  ["left", "middle", "right"] as const,
+  {
+    title: "OpensteerComputerMouseButton",
+  },
+);
 
 const opensteerComputerKeyModifierSchema: JsonSchema = enumSchema(
   ["Shift", "Control", "Alt", "Meta"] as const,
@@ -1190,10 +1193,7 @@ const opensteerDomExtractInputSchema: JsonSchema = defineSchema({
       title: "OpensteerDomExtractInput",
     },
   ),
-  anyOf: [
-    defineSchema({ required: ["persist"] }),
-    defineSchema({ required: ["schema"] }),
-  ],
+  anyOf: [defineSchema({ required: ["persist"] }), defineSchema({ required: ["schema"] })],
 });
 
 const jsonValueSchema: JsonSchema = recordSchema({}, { title: "JsonValueRecord" });
@@ -1704,7 +1704,8 @@ const opensteerSemanticOperationSpecificationsBase = [
   }),
   defineSemanticOperationSpec<OpensteerCookieQueryInput, OpensteerCookieQueryOutput>({
     name: "session.cookies",
-    description: "Read browser cookies for the active page domain or an explicitly selected domain.",
+    description:
+      "Read browser cookies for the active page domain or an explicitly selected domain.",
     inputSchema: opensteerCookieQueryInputSchema,
     outputSchema: opensteerCookieQueryOutputSchema,
     requiredCapabilities: ["inspect.cookies"],

--- a/packages/runtime-core/package.json
+++ b/packages/runtime-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensteer/runtime-core",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Shared semantic runtime for Opensteer local and cloud execution.",
   "license": "MIT",
   "type": "module",

--- a/packages/runtime-core/src/sdk/extraction.ts
+++ b/packages/runtime-core/src/sdk/extraction.ts
@@ -24,7 +24,6 @@ import {
   joinDataPath,
 } from "./extraction-data-path.js";
 
-
 interface OpensteerSchemaFieldByElement {
   readonly element: number;
   readonly attribute?: string;

--- a/packages/runtime-core/src/sdk/runtime.ts
+++ b/packages/runtime-core/src/sdk/runtime.ts
@@ -1472,7 +1472,6 @@ export class OpensteerSessionRuntime {
     );
   }
 
-
   async captureInteraction(
     input: OpensteerInteractionCaptureInput,
     options: RuntimeOperationOptions = {},
@@ -3111,11 +3110,7 @@ export class OpensteerSessionRuntime {
     for (const transport of REPLAY_TRANSPORT_LADDER) {
       const attemptStartedAt = Date.now();
       try {
-        const output = await this.executeReplayTransportAttempt(
-          transport,
-          request,
-          timeout,
-        );
+        const output = await this.executeReplayTransportAttempt(transport, request, timeout);
         const ok = matchesSuccessFingerprintFromProtocolResponse(output.response, fingerprint);
         attempts.push({
           transport,
@@ -3293,7 +3288,6 @@ export class OpensteerSessionRuntime {
       }),
     };
   }
-
 
   private async executeSessionFetch(
     request: {

--- a/skills/opensteer/SKILL.md
+++ b/skills/opensteer/SKILL.md
@@ -133,11 +133,11 @@ The first command shows: URL, method, request headers, cookies sent, request/res
 
 Add `--probe` to also test which transport works for this API:
 
-| Transport | Meaning | SDK usage |
-|---|---|---|
-| `direct-http` | Plain HTTP works | `this.fetch(url)` (default) |
+| Transport     | Meaning                        | SDK usage                                       |
+| ------------- | ------------------------------ | ----------------------------------------------- |
+| `direct-http` | Plain HTTP works               | `this.fetch(url)` (default)                     |
 | `matched-tls` | Needs TLS fingerprint matching | `this.fetch(url, { transport: "matched-tls" })` |
-| `page-http` | Needs a live browser page | `this.fetch(url, { transport: "page" })` |
+| `page-http`   | Needs a live browser page      | `this.fetch(url, { transport: "page" })`        |
 
 ### Step 4: Check browser state (if 401/403)
 
@@ -269,26 +269,26 @@ opensteer computer screenshot --workspace demo
 
 ## CLI Quick Reference
 
-| Command | Positional args | Key flags |
-|---|---|---|
-| `open <url>` | url | `--headless`, `--provider`, `--attach-endpoint`, `--attach-header` |
-| `close` | — | — |
-| `status` | — | — |
-| `goto <url>` | url | `--capture-network` |
-| `snapshot [mode]` | action \| extraction | — |
-| `click <element>` | element number | `--persist`, `--capture-network`, `--button` |
-| `hover <element>` | element number | `--persist`, `--capture-network` |
-| `input <element> <text>` | element, text | `--persist`, `--press-enter`, `--capture-network` |
-| `scroll <dir> <amount>` | direction, amount | `--element`, `--persist`, `--capture-network` |
-| `extract <schema>` | JSON schema | `--persist` |
-| `evaluate <script>` | JS expression | — |
-| `network query` | — | `--capture`, `--url`, `--hostname`, `--json`, `--limit`, +6 filters |
-| `network detail <id>` | recordId | `--probe` |
-| `fetch <url>` | url | `--method`, `--header`, `--query`, `--body`, `--transport`, `--cookies` |
-| `state [domain]` | domain (optional) | — |
-| `exec <expression>` | JS expression | — |
-| `tab list / new / <n> / close` | varies | — |
-| `computer click/type/key/scroll/move/drag/screenshot/wait` | varies | `--capture-network` |
+| Command                                                    | Positional args      | Key flags                                                               |
+| ---------------------------------------------------------- | -------------------- | ----------------------------------------------------------------------- |
+| `open <url>`                                               | url                  | `--headless`, `--provider`, `--attach-endpoint`, `--attach-header`      |
+| `close`                                                    | —                    | —                                                                       |
+| `status`                                                   | —                    | —                                                                       |
+| `goto <url>`                                               | url                  | `--capture-network`                                                     |
+| `snapshot [mode]`                                          | action \| extraction | —                                                                       |
+| `click <element>`                                          | element number       | `--persist`, `--capture-network`, `--button`                            |
+| `hover <element>`                                          | element number       | `--persist`, `--capture-network`                                        |
+| `input <element> <text>`                                   | element, text        | `--persist`, `--press-enter`, `--capture-network`                       |
+| `scroll <dir> <amount>`                                    | direction, amount    | `--element`, `--persist`, `--capture-network`                           |
+| `extract <schema>`                                         | JSON schema          | `--persist`                                                             |
+| `evaluate <script>`                                        | JS expression        | —                                                                       |
+| `network query`                                            | —                    | `--capture`, `--url`, `--hostname`, `--json`, `--limit`, +6 filters     |
+| `network detail <id>`                                      | recordId             | `--probe`                                                               |
+| `fetch <url>`                                              | url                  | `--method`, `--header`, `--query`, `--body`, `--transport`, `--cookies` |
+| `state [domain]`                                           | domain (optional)    | —                                                                       |
+| `exec <expression>`                                        | JS expression        | —                                                                       |
+| `tab list / new / <n> / close`                             | varies               | —                                                                       |
+| `computer click/type/key/scroll/move/drag/screenshot/wait` | varies               | `--capture-network`                                                     |
 
 ## SDK Quick Reference
 
@@ -336,11 +336,11 @@ const html = await opensteer.snapshot("extraction");
 
 ## Common Issues
 
-| Symptom | Fix |
-|---|---|
-| Element numbers wrong after navigation | Re-snapshot before using element numbers |
-| `fetch()` returns 401/403 | Check `state` — request depends on session cookies or tokens |
-| Direct HTTP blocked, browser transport works | Site uses TLS fingerprinting — use `transport: "matched-tls"` |
-| Extract returns empty data | Element numbers changed — re-snapshot and rebuild the schema |
-| `fetch()` fails with no session | Call `opensteer.goto(url)` first to establish cookies, then `fetch()` |
-| Using `evaluate` for API calls | Use `exec` instead — `evaluate` runs inside the page where anti-bot scripts can intercept requests |
+| Symptom                                      | Fix                                                                                                |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Element numbers wrong after navigation       | Re-snapshot before using element numbers                                                           |
+| `fetch()` returns 401/403                    | Check `state` — request depends on session cookies or tokens                                       |
+| Direct HTTP blocked, browser transport works | Site uses TLS fingerprinting — use `transport: "matched-tls"`                                      |
+| Extract returns empty data                   | Element numbers changed — re-snapshot and rebuild the schema                                       |
+| `fetch()` fails with no session              | Call `opensteer.goto(url)` first to establish cookies, then `fetch()`                              |
+| Using `evaluate` for API calls               | Use `exec` instead — `evaluate` runs inside the page where anti-bot scripts can intercept requests |

--- a/tests/browser-core/post-load-tracker.test.ts
+++ b/tests/browser-core/post-load-tracker.test.ts
@@ -148,7 +148,9 @@ describe("post-load tracker", () => {
         }
         set.add(listener);
       },
-      setTimeout: (_callback: (...args: unknown[]) => unknown, _delay?: number) => ({ callback: _callback }),
+      setTimeout: (_callback: (...args: unknown[]) => unknown, _delay?: number) => ({
+        callback: _callback,
+      }),
       clearTimeout: () => undefined,
       globalThis: undefined as unknown,
     });

--- a/tests/opensteer/cli-artifacts.ts
+++ b/tests/opensteer/cli-artifacts.ts
@@ -6,7 +6,12 @@ import { promisify } from "node:util";
 const execFile = promisify(execFileCallback);
 const CLI_SCRIPT = path.resolve(process.cwd(), "packages/opensteer/dist/cli/bin.js");
 const CLI_BUILD_LOCK = path.resolve(process.cwd(), ".opensteer", "test-locks", "cli-build");
-const CLI_BUILD_STAMP = path.resolve(process.cwd(), ".opensteer", "test-locks", "cli-build-ready.json");
+const CLI_BUILD_STAMP = path.resolve(
+  process.cwd(),
+  ".opensteer",
+  "test-locks",
+  "cli-build-ready.json",
+);
 const CLI_BUILD_TIMEOUT_MS = 120_000;
 const CLI_BUILD_POLL_INTERVAL_MS = 100;
 const CLI_BUILD_INPUTS = [
@@ -112,7 +117,10 @@ async function isCliBuildReady(sourceMtimeMs: number): Promise<boolean> {
 async function getLatestCliInputMtimeMs(): Promise<number> {
   let latestMtimeMs = 0;
   for (const relativePath of CLI_BUILD_INPUTS) {
-    latestMtimeMs = Math.max(latestMtimeMs, await getLatestPathMtimeMs(path.resolve(process.cwd(), relativePath)));
+    latestMtimeMs = Math.max(
+      latestMtimeMs,
+      await getLatestPathMtimeMs(path.resolve(process.cwd(), relativePath)),
+    );
   }
   return latestMtimeMs;
 }

--- a/tests/opensteer/cli-surface.test.ts
+++ b/tests/opensteer/cli-surface.test.ts
@@ -75,7 +75,7 @@ describe("CLI surface parsing", () => {
   test("builds extract input from positional schema and optional persist", async () => {
     const parsed = parseCommandLine([
       "extract",
-      "{\"title\":{\"element\":3}}",
+      '{"title":{"element":3}}',
       "--persist",
       "page summary",
     ]);
@@ -97,7 +97,7 @@ describe("CLI surface parsing", () => {
       "--method",
       "POST",
       "--body",
-      "{\"keyword\":\"laptop\"}",
+      '{"keyword":"laptop"}',
       "--header",
       "accept=application/json",
       "--cookies",
@@ -126,7 +126,7 @@ describe("CLI surface parsing", () => {
       "open",
       "https://example.com",
       "--context",
-      "{\"locale\":\"en-US\"}",
+      '{"locale":"en-US"}',
     ]);
 
     expect(parsed.options.context).toEqual({

--- a/tests/opensteer/cli-v2.test.ts
+++ b/tests/opensteer/cli-v2.test.ts
@@ -48,8 +48,10 @@ describe("Opensteer v2 CLI", () => {
     });
 
     expect(result.stdout).toContain("Opensteer CLI");
-    expect(result.stdout).toContain("open <url> [--workspace <id>] [--headless] [--provider local|cloud]");
-    expect(result.stdout).toContain('extract <schema> [--persist <key>]');
+    expect(result.stdout).toContain(
+      "open <url> [--workspace <id>] [--headless] [--provider local|cloud]",
+    );
+    expect(result.stdout).toContain("extract <schema> [--persist <key>]");
     expect(result.stdout).toContain("--body <json>");
     expect(result.stdout).toContain("--workspace <id>");
     expect(result.stdout).toContain("--json filters to JSON and GraphQL responses only");

--- a/tests/opensteer/exec.test.ts
+++ b/tests/opensteer/exec.test.ts
@@ -30,10 +30,7 @@ describe("exec command", () => {
         return { status: 200, items: [1, 2, 3] };
       },
     };
-    const result = await runExecExpression(
-      context,
-      "await this.fetchData()",
-    );
+    const result = await runExecExpression(context, "await this.fetchData()");
     expect(result).toEqual({ status: 200, items: [1, 2, 3] });
   });
 

--- a/tests/opensteer/navigation-network-capture.test.ts
+++ b/tests/opensteer/navigation-network-capture.test.ts
@@ -555,7 +555,9 @@ describe.sequential("cross-document action boundary", () => {
         opensteer.fetch("http://127.0.0.1:1/unreachable", {
           transport: "direct",
         }),
-      ).rejects.toThrow(/no transport completed successfully|session\.fetch did not produce a response/i);
+      ).rejects.toThrow(
+        /no transport completed successfully|session\.fetch did not produce a response/i,
+      );
 
       const traces = await readTraceEntries(rootPath);
       const fetchTrace = [...traces]

--- a/tests/opensteer/record-command.test.ts
+++ b/tests/opensteer/record-command.test.ts
@@ -186,9 +186,9 @@ const temporaryRoots: string[] = [];
 describe("runOpensteerRecordCommand", () => {
   afterEach(async () => {
     await Promise.all(
-      temporaryRoots.splice(0).map((rootPath) =>
-        rm(rootPath, { recursive: true, force: true }).catch(() => undefined),
-      ),
+      temporaryRoots
+        .splice(0)
+        .map((rootPath) => rm(rootPath, { recursive: true, force: true }).catch(() => undefined)),
     );
   });
 

--- a/tests/opensteer/recorder-browser-script.test.ts
+++ b/tests/opensteer/recorder-browser-script.test.ts
@@ -139,7 +139,9 @@ describe.sequential("recorder browser script", () => {
       const url = new URL(request.url ?? "/", "http://127.0.0.1");
       response.setHeader("content-type", "text/html; charset=utf-8");
       if (url.pathname === "/" || url.pathname === "/next" || url.pathname === "/popup") {
-        response.end(`<!doctype html><html lang="en"><body><main>${url.pathname}</main></body></html>`);
+        response.end(
+          `<!doctype html><html lang="en"><body><main>${url.pathname}</main></body></html>`,
+        );
         return;
       }
       response.statusCode = 404;
@@ -206,7 +208,9 @@ describe.sequential("recorder browser script", () => {
       const url = new URL(request.url ?? "/", "http://127.0.0.1");
       response.setHeader("content-type", "text/html; charset=utf-8");
       if (url.pathname === "/" || url.pathname === "/step1" || url.pathname === "/step2") {
-        response.end(`<!doctype html><html lang="en"><body><main>${url.pathname}</main></body></html>`);
+        response.end(
+          `<!doctype html><html lang="en"><body><main>${url.pathname}</main></body></html>`,
+        );
         return;
       }
       response.statusCode = 404;
@@ -277,8 +281,9 @@ describe.sequential("recorder browser script", () => {
       } | null;
 
       expect(drained?.url).toBe(`${baseUrl}/`);
-      expect(drained?.events.some((event) => event.kind === "go-back" && event.url === `${baseUrl}/`))
-        .toBe(true);
+      expect(
+        drained?.events.some((event) => event.kind === "go-back" && event.url === `${baseUrl}/`),
+      ).toBe(true);
     } finally {
       await opensteer.close().catch(() => undefined);
       server.close();

--- a/tests/opensteer/recorder-event-collector.test.ts
+++ b/tests/opensteer/recorder-event-collector.test.ts
@@ -51,12 +51,14 @@ class FakeRecorderRuntimeAdapter implements RecorderRuntimeAdapter {
     if (input.pageRef === undefined) {
       throw new Error("Drain snapshots require an explicit pageRef.");
     }
-    return this.currentSnapshots[input.pageRef] ?? {
-      url: "about:blank",
-      focused: false,
-      visibilityState: "hidden",
-      events: [],
-    };
+    return (
+      this.currentSnapshots[input.pageRef] ?? {
+        url: "about:blank",
+        focused: false,
+        visibilityState: "hidden",
+        events: [],
+      }
+    );
   }
 
   async listPages(): Promise<{

--- a/tests/opensteer/runtime-stale-page-recovery.test.ts
+++ b/tests/opensteer/runtime-stale-page-recovery.test.ts
@@ -45,10 +45,12 @@ describe("runtime stale page recovery", () => {
         activePageRef: secondPage.pageRef,
         pages: [expect.objectContaining({ pageRef: secondPage.pageRef })],
       });
-      await expect(runtime.evaluate({
-        pageRef: secondPage.pageRef,
-        script: "() => null",
-      })).resolves.toMatchObject({
+      await expect(
+        runtime.evaluate({
+          pageRef: secondPage.pageRef,
+          script: "() => null",
+        }),
+      ).resolves.toMatchObject({
         pageRef: secondPage.pageRef,
         value: null,
       });


### PR DESCRIPTION
## Summary
- refine Opensteer CLI request flows around exec-based runtime selection, parsing, output, and browser helpers
- update protocol and runtime internals for cloud, semantic request handling, extraction, and cookie/config behavior
- bump published package versions and refresh changelog and skill docs
- add and update regression coverage for CLI, network capture, recorder flows, and runtime recovery

## Testing
- `pnpm check`