### PR TITLE
Fix packaged manifests and align network request types

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "opensteer:local": "node scripts/opensteer-local.mjs",
-    "package:check": "publint packages/browser-core && publint packages/engine-abp && publint packages/engine-playwright && publint packages/opensteer && publint packages/protocol && publint packages/runtime-core",
+    "package:check": "publint packages/browser-core && publint packages/engine-abp && publint packages/engine-playwright && publint packages/opensteer && publint packages/protocol && publint packages/runtime-core && node scripts/check-packed-manifests.mjs",
     "release:publish": "node scripts/publish-npm.mjs",
     "skills:check": "skills add . --list",
     "test": "vitest run --config vitest.config.ts --passWithNoTests",

--- a/packages/opensteer/package.json
+++ b/packages/opensteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensteer",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "description": "Opensteer browser automation, replay, and reverse-engineering toolkit.",
   "license": "MIT",
   "type": "module",

--- a/packages/opensteer/src/cloud/session-proxy.ts
+++ b/packages/opensteer/src/cloud/session-proxy.ts
@@ -21,6 +21,7 @@ import type {
   OpensteerDomHoverInput,
   OpensteerDomInputInput,
   OpensteerDomScrollInput,
+  OpensteerNetworkDetailInput,
   OpensteerNetworkQueryInput,
   OpensteerNetworkQueryOutput,
   OpensteerNetworkDetailOutput,
@@ -287,10 +288,9 @@ export class CloudSessionProxy implements OpensteerDisconnectableRuntime {
     return this.requireClient().invoke("network.query", input);
   }
 
-  async getNetworkDetail(input: {
-    readonly recordId: string;
-    readonly probe?: boolean;
-  }): Promise<OpensteerNetworkDetailOutput> {
+  async getNetworkDetail(
+    input: OpensteerNetworkDetailInput,
+  ): Promise<OpensteerNetworkDetailOutput> {
     await this.ensureSession();
     return this.requireClient().invoke("network.detail", input);
   }

--- a/packages/opensteer/src/sdk/opensteer.ts
+++ b/packages/opensteer/src/sdk/opensteer.ts
@@ -25,6 +25,7 @@ import type {
   OpensteerPageListOutput,
   OpensteerPageNewInput,
   OpensteerPageNewOutput,
+  OpensteerRequestBodyInput,
   OpensteerRequestResponseResult,
   OpensteerSessionCloseOutput,
   OpensteerSessionFetchInput,
@@ -106,15 +107,9 @@ export type OpensteerGotoOptions = Omit<OpensteerPageGotoInput, "url">;
 export type OpensteerNetworkQueryOptions = OpensteerNetworkQueryInput;
 export type OpensteerNetworkQueryResult = OpensteerNetworkQueryOutput;
 export type OpensteerNetworkDetailResult = OpensteerNetworkDetailOutput;
-export interface OpensteerFetchOptions {
-  readonly method?: string;
-  readonly headers?: Record<string, string>;
-  readonly body?: string;
-  readonly query?: Record<string, string | number | boolean>;
-  readonly transport?: "auto" | "direct" | "matched-tls" | "page";
-  readonly cookies?: boolean;
-  readonly followRedirects?: boolean;
-}
+export type OpensteerFetchOptions = Omit<OpensteerSessionFetchInput, "url" | "body"> & {
+  readonly body?: string | OpensteerRequestBodyInput;
+};
 export type OpensteerComputerExecuteOptions = OpensteerComputerExecuteInput;
 export type OpensteerStorageMap = Readonly<Record<string, string>>;
 export type OpensteerBrowserState = OpensteerStateQueryOutput;
@@ -136,7 +131,10 @@ export interface OpensteerDomController {
 
 export interface OpensteerNetworkController {
   query(input?: OpensteerNetworkQueryOptions): Promise<OpensteerNetworkQueryResult>;
-  detail(recordId: string, options?: { probe?: boolean }): Promise<OpensteerNetworkDetailResult>;
+  detail(
+    recordId: string,
+    options?: { readonly probe?: boolean },
+  ): Promise<OpensteerNetworkDetailResult>;
 }
 
 export interface OpensteerOptions extends OpensteerRuntimeOptions {
@@ -566,27 +564,38 @@ function pickStorageDomainSnapshot(
 }
 
 function buildFetchInput(url: string, options: OpensteerFetchOptions): OpensteerSessionFetchInput {
+  const { body, ...rest } = options;
   return {
     url,
-    ...(options.method !== undefined && { method: options.method }),
-    ...(options.headers !== undefined && { headers: options.headers }),
-    ...(options.query !== undefined && { query: options.query }),
-    ...(options.transport !== undefined && { transport: options.transport }),
-    ...(options.cookies !== undefined && { cookies: options.cookies }),
-    ...(options.followRedirects !== undefined && { followRedirects: options.followRedirects }),
-    ...(options.body !== undefined && { body: toRuntimeBody(options.body) }),
-  } as OpensteerSessionFetchInput;
+    ...rest,
+    ...(body === undefined ? {} : { body: normalizeFetchBody(body, rest.headers) }),
+  };
 }
 
-// The runtime transport layer needs structured body input ({json} or {text})
-// to set content-type and encoding correctly. We sniff JSON here so callers
-// can pass standard fetch-style string bodies without knowing about the internal format.
-function toRuntimeBody(body: string): { json: unknown } | { text: string } {
-  try {
-    return { json: JSON.parse(body) };
-  } catch {
-    return { text: body };
+function normalizeFetchBody(
+  body: string | OpensteerRequestBodyInput,
+  headers: OpensteerSessionFetchInput["headers"],
+): OpensteerRequestBodyInput {
+  if (typeof body !== "string") {
+    return body;
   }
+
+  const contentType = findHeaderValue(headers, "content-type");
+  return contentType === undefined ? { text: body } : { text: body, contentType };
+}
+
+function findHeaderValue(
+  headers: OpensteerSessionFetchInput["headers"],
+  headerName: string,
+): string | undefined {
+  if (headers === undefined) {
+    return undefined;
+  }
+
+  const match = Object.entries(headers).find(
+    ([name]) => name.toLowerCase() === headerName.toLowerCase(),
+  );
+  return match === undefined ? undefined : String(match[1]);
 }
 
 function toResponse(response: OpensteerRequestResponseResult): Response {

--- a/packages/protocol/src/requests.ts
+++ b/packages/protocol/src/requests.ts
@@ -462,6 +462,11 @@ export interface OpensteerNetworkDetailOutput {
   };
 }
 
+export interface OpensteerNetworkDetailInput {
+  readonly recordId: string;
+  readonly probe?: boolean;
+}
+
 export interface OpensteerReplayAttempt {
   readonly transport: TransportKind;
   readonly status?: number;
@@ -1520,6 +1525,17 @@ export const opensteerNetworkQueryOutputSchema: JsonSchema = objectSchema(
   {
     title: "OpensteerNetworkQueryOutput",
     required: ["records"],
+  },
+);
+
+export const opensteerNetworkDetailInputSchema: JsonSchema = objectSchema(
+  {
+    recordId: stringSchema({ minLength: 1 }),
+    probe: { type: "boolean" },
+  },
+  {
+    title: "OpensteerNetworkDetailInput",
+    required: ["recordId"],
   },
 );
 

--- a/packages/protocol/src/semantic.ts
+++ b/packages/protocol/src/semantic.ts
@@ -53,6 +53,7 @@ import {
 import {
   opensteerCookieQueryInputSchema,
   opensteerCookieQueryOutputSchema,
+  opensteerNetworkDetailInputSchema,
   opensteerNetworkDetailOutputSchema,
   opensteerNetworkQueryInputSchema,
   opensteerNetworkQueryOutputSchema,
@@ -66,6 +67,7 @@ import {
   opensteerStorageQueryOutputSchema,
   type OpensteerCookieQueryInput,
   type OpensteerCookieQueryOutput,
+  type OpensteerNetworkDetailInput,
   type OpensteerNetworkDetailOutput,
   type OpensteerNetworkQueryInput,
   type OpensteerNetworkQueryOutput,
@@ -1094,16 +1096,6 @@ const opensteerPageSnapshotOutputSchema: JsonSchema = objectSchema(
   },
 );
 
-const opensteerNetworkDetailInputSchema: JsonSchema = objectSchema(
-  {
-    recordId: stringSchema({ minLength: 1 }),
-  },
-  {
-    title: "OpensteerNetworkDetailInput",
-    required: ["recordId"],
-  },
-);
-
 const opensteerComputerMouseButtonSchema: JsonSchema = enumSchema(
   ["left", "middle", "right"] as const,
   {
@@ -1610,12 +1602,7 @@ const opensteerSemanticOperationSpecificationsBase = [
     outputSchema: opensteerNetworkQueryOutputSchema,
     requiredCapabilities: ["inspect.network"],
   }),
-  defineSemanticOperationSpec<
-    {
-      readonly recordId: string;
-    },
-    OpensteerNetworkDetailOutput
-  >({
+  defineSemanticOperationSpec<OpensteerNetworkDetailInput, OpensteerNetworkDetailOutput>({
     name: "network.detail",
     description:
       "Inspect one captured network record with parsed headers, cookies, redirects, and truncated bodies.",

--- a/packages/runtime-core/src/sdk/runtime.ts
+++ b/packages/runtime-core/src/sdk/runtime.ts
@@ -49,6 +49,7 @@ import {
   type OpensteerDomInputInput,
   type OpensteerDomScrollInput,
   type OpensteerError,
+  type OpensteerNetworkDetailInput,
   type OpensteerNetworkQueryInput,
   type OpensteerNetworkQueryOutput,
   type OpensteerNetworkDetailOutput,
@@ -1339,10 +1340,7 @@ export class OpensteerSessionRuntime {
   }
 
   async getNetworkDetail(
-    input: {
-      readonly recordId: string;
-      readonly probe?: boolean;
-    },
+    input: OpensteerNetworkDetailInput,
     options: RuntimeOperationOptions = {},
   ): Promise<OpensteerNetworkDetailOutput> {
     const startedAt = Date.now();

--- a/packages/runtime-core/src/sdk/semantic-runtime.ts
+++ b/packages/runtime-core/src/sdk/semantic-runtime.ts
@@ -12,6 +12,7 @@ import type {
   OpensteerDomHoverInput,
   OpensteerDomInputInput,
   OpensteerDomScrollInput,
+  OpensteerNetworkDetailInput,
   OpensteerNetworkQueryInput,
   OpensteerNetworkQueryOutput,
   OpensteerNetworkDetailOutput,
@@ -128,10 +129,7 @@ export interface OpensteerSemanticRuntime {
     options?: OpensteerRuntimeOperationOptions,
   ): Promise<OpensteerNetworkQueryOutput>;
   getNetworkDetail(
-    input: {
-      readonly recordId: string;
-      readonly probe?: boolean;
-    },
+    input: OpensteerNetworkDetailInput,
     options?: OpensteerRuntimeOperationOptions,
   ): Promise<OpensteerNetworkDetailOutput>;
   captureInteraction(

--- a/scripts/build-runtime-artifact.mjs
+++ b/scripts/build-runtime-artifact.mjs
@@ -3,6 +3,11 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
 
+import {
+  readWorkspacePackageVersions,
+  rewriteWorkspaceProtocolSpecifiers,
+} from "./package-manifest-utils.mjs";
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
 const packageDir = path.join(repoRoot, "packages", "opensteer");
@@ -49,7 +54,10 @@ if (!tarballName) {
 process.stdout.write(`${path.join(outDir, tarballName)}\n`);
 
 async function createRuntimePackageManifest() {
-  const packageJson = JSON.parse(await readFile(path.join(packageDir, "package.json"), "utf8"));
+  const packageJson = rewriteWorkspaceProtocolSpecifiers(
+    JSON.parse(await readFile(path.join(packageDir, "package.json"), "utf8")),
+    await readWorkspacePackageVersions(repoRoot),
+  );
 
   return {
     name: packageJson.name,

--- a/scripts/check-packed-manifests.mjs
+++ b/scripts/check-packed-manifests.mjs
@@ -47,9 +47,13 @@ async function packPackage(packageDir, outDir) {
 }
 
 async function buildRuntimeArtifact(outDir) {
-  const { stdout } = await runCommand("node", ["scripts/build-runtime-artifact.mjs", "--out", outDir], {
-    cwd: repoRoot,
-  });
+  const { stdout } = await runCommand(
+    "node",
+    ["scripts/build-runtime-artifact.mjs", "--out", outDir],
+    {
+      cwd: repoRoot,
+    },
+  );
   const tarballPath = stdout
     .trim()
     .split("\n")
@@ -72,7 +76,9 @@ async function assertTarballHasNoWorkspaceSpecifiers(label, tarballPath) {
   const formattedSpecifiers = workspaceSpecifiers
     .map(({ section, packageName, specifier }) => `${section}.${packageName}=${specifier}`)
     .join(", ");
-  throw new Error(`${label} tarball still contains workspace protocol specifiers: ${formattedSpecifiers}`);
+  throw new Error(
+    `${label} tarball still contains workspace protocol specifiers: ${formattedSpecifiers}`,
+  );
 }
 
 async function readTarballManifest(tarballPath) {

--- a/scripts/check-packed-manifests.mjs
+++ b/scripts/check-packed-manifests.mjs
@@ -1,0 +1,124 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+import { collectWorkspaceProtocolSpecifiers } from "./package-manifest-utils.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const publishPackageDirs = [
+  "packages/browser-core",
+  "packages/protocol",
+  "packages/runtime-core",
+  "packages/engine-playwright",
+  "packages/engine-abp",
+  "packages/opensteer",
+];
+
+const tempRoot = await mkdtemp(path.join(os.tmpdir(), "opensteer-pack-check-"));
+
+try {
+  for (const relativePackageDir of publishPackageDirs) {
+    const packageDir = path.join(repoRoot, relativePackageDir);
+    const tarballPath = await packPackage(packageDir, tempRoot);
+    await assertTarballHasNoWorkspaceSpecifiers(relativePackageDir, tarballPath);
+  }
+
+  const runtimeOutDir = path.join(tempRoot, "runtime-artifact");
+  const runtimeTarballPath = await buildRuntimeArtifact(runtimeOutDir);
+  await assertTarballHasNoWorkspaceSpecifiers("runtime-artifact", runtimeTarballPath);
+
+  console.log("packed manifests verified");
+} finally {
+  await rm(tempRoot, { recursive: true, force: true });
+}
+
+async function packPackage(packageDir, outDir) {
+  const { stdout } = await runCommand("pnpm", ["pack", "--pack-destination", outDir], {
+    cwd: packageDir,
+  });
+  const tarballName = findLastTarballLine(stdout);
+  if (!tarballName) {
+    throw new Error(`Failed to determine tarball filename for ${packageDir}.`);
+  }
+  return path.isAbsolute(tarballName) ? tarballName : path.join(outDir, tarballName);
+}
+
+async function buildRuntimeArtifact(outDir) {
+  const { stdout } = await runCommand("node", ["scripts/build-runtime-artifact.mjs", "--out", outDir], {
+    cwd: repoRoot,
+  });
+  const tarballPath = stdout
+    .trim()
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.endsWith(".tgz"))
+    .at(-1);
+  if (!tarballPath) {
+    throw new Error("Failed to determine runtime artifact tarball path.");
+  }
+  return tarballPath;
+}
+
+async function assertTarballHasNoWorkspaceSpecifiers(label, tarballPath) {
+  const manifest = await readTarballManifest(tarballPath);
+  const workspaceSpecifiers = collectWorkspaceProtocolSpecifiers(manifest);
+  if (workspaceSpecifiers.length === 0) {
+    return;
+  }
+
+  const formattedSpecifiers = workspaceSpecifiers
+    .map(({ section, packageName, specifier }) => `${section}.${packageName}=${specifier}`)
+    .join(", ");
+  throw new Error(`${label} tarball still contains workspace protocol specifiers: ${formattedSpecifiers}`);
+}
+
+async function readTarballManifest(tarballPath) {
+  const { stdout } = await runCommand("tar", ["-xOf", tarballPath, "package/package.json"], {
+    cwd: repoRoot,
+  });
+  return JSON.parse(stdout);
+}
+
+function findLastTarballLine(stdout) {
+  return stdout
+    .trim()
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.endsWith(".tgz"))
+    .at(-1);
+}
+
+function runCommand(command, args, options) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+
+      reject(
+        new Error(
+          `${command} ${args.join(" ")} failed with exit code ${String(code)}.${stderr ? ` ${stderr.trim()}` : ""}`,
+        ),
+      );
+    });
+  });
+}

--- a/scripts/package-manifest-utils.mjs
+++ b/scripts/package-manifest-utils.mjs
@@ -65,7 +65,10 @@ export function rewriteWorkspaceProtocolSpecifiers(manifest, workspacePackageVer
       if (!updatedDependencies) {
         updatedDependencies = { ...sourceDependencies };
       }
-      updatedDependencies[packageName] = resolveWorkspaceProtocolSpecifier(specifier, packageVersion);
+      updatedDependencies[packageName] = resolveWorkspaceProtocolSpecifier(
+        specifier,
+        packageVersion,
+      );
     }
 
     if (updatedDependencies) {

--- a/scripts/package-manifest-utils.mjs
+++ b/scripts/package-manifest-utils.mjs
@@ -106,6 +106,9 @@ function isDependencyMap(value) {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
+// Mirrors pnpm publish/pack rewriting for direct version and semver-range forms.
+// We intentionally reject alias and relative-path workspace specs here because
+// the runtime artifact builder only rewrites direct installable registry ranges.
 function resolveWorkspaceProtocolSpecifier(specifier, packageVersion) {
   const workspaceRange = specifier.slice("workspace:".length).trim();
   if (workspaceRange === "" || workspaceRange === "*") {
@@ -114,12 +117,18 @@ function resolveWorkspaceProtocolSpecifier(specifier, packageVersion) {
   if (workspaceRange === "^" || workspaceRange === "~") {
     return `${workspaceRange}${packageVersion}`;
   }
-  if (workspaceRange === packageVersion) {
-    return packageVersion;
-  }
-  if (workspaceRange === `^${packageVersion}` || workspaceRange === `~${packageVersion}`) {
+
+  if (isWorkspacePublishRange(workspaceRange)) {
     return workspaceRange;
   }
 
   throw new Error(`Unsupported workspace protocol specifier "${specifier}".`);
+}
+
+function isWorkspacePublishRange(workspaceRange) {
+  if (workspaceRange.includes("/") || workspaceRange.includes("@")) {
+    return false;
+  }
+
+  return /^(?:<=|>=|[~^<>=])?\d/.test(workspaceRange);
 }

--- a/scripts/package-manifest-utils.mjs
+++ b/scripts/package-manifest-utils.mjs
@@ -1,0 +1,122 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const dependencySections = [
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies",
+];
+
+export async function readWorkspacePackageVersions(repoRoot) {
+  const packagesDir = path.join(repoRoot, "packages");
+  const entries = await readdir(packagesDir, { withFileTypes: true });
+  const versions = new Map();
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const packageJsonPath = path.join(packagesDir, entry.name, "package.json");
+    let packageJson;
+    try {
+      packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
+    } catch (error) {
+      if (error?.code === "ENOENT") {
+        continue;
+      }
+      throw error;
+    }
+
+    if (typeof packageJson.name === "string" && typeof packageJson.version === "string") {
+      versions.set(packageJson.name, packageJson.version);
+    }
+  }
+
+  return versions;
+}
+
+export function rewriteWorkspaceProtocolSpecifiers(manifest, workspacePackageVersions) {
+  const output = {
+    ...manifest,
+  };
+
+  for (const section of dependencySections) {
+    const sourceDependencies = manifest[section];
+    if (!isDependencyMap(sourceDependencies)) {
+      continue;
+    }
+
+    let updatedDependencies;
+    for (const [packageName, specifier] of Object.entries(sourceDependencies)) {
+      if (typeof specifier !== "string" || !specifier.startsWith("workspace:")) {
+        continue;
+      }
+
+      const packageVersion =
+        workspacePackageVersions instanceof Map
+          ? workspacePackageVersions.get(packageName)
+          : workspacePackageVersions?.[packageName];
+      if (typeof packageVersion !== "string" || packageVersion.length === 0) {
+        throw new Error(`Missing workspace version for ${packageName}.`);
+      }
+
+      if (!updatedDependencies) {
+        updatedDependencies = { ...sourceDependencies };
+      }
+      updatedDependencies[packageName] = resolveWorkspaceProtocolSpecifier(specifier, packageVersion);
+    }
+
+    if (updatedDependencies) {
+      output[section] = updatedDependencies;
+    }
+  }
+
+  return output;
+}
+
+export function collectWorkspaceProtocolSpecifiers(manifest) {
+  const matches = [];
+
+  for (const section of dependencySections) {
+    const dependencies = manifest[section];
+    if (!isDependencyMap(dependencies)) {
+      continue;
+    }
+
+    for (const [packageName, specifier] of Object.entries(dependencies)) {
+      if (typeof specifier === "string" && specifier.startsWith("workspace:")) {
+        matches.push({
+          section,
+          packageName,
+          specifier,
+        });
+      }
+    }
+  }
+
+  return matches;
+}
+
+function isDependencyMap(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function resolveWorkspaceProtocolSpecifier(specifier, packageVersion) {
+  const workspaceRange = specifier.slice("workspace:".length).trim();
+  if (workspaceRange === "" || workspaceRange === "*") {
+    return packageVersion;
+  }
+  if (workspaceRange === "^" || workspaceRange === "~") {
+    return `${workspaceRange}${packageVersion}`;
+  }
+  if (workspaceRange === packageVersion) {
+    return packageVersion;
+  }
+  if (workspaceRange === `^${packageVersion}` || workspaceRange === `~${packageVersion}`) {
+    return workspaceRange;
+  }
+
+  throw new Error(`Unsupported workspace protocol specifier "${specifier}".`);
+}

--- a/tests/opensteer/package-manifest-utils.test.ts
+++ b/tests/opensteer/package-manifest-utils.test.ts
@@ -40,6 +40,45 @@ describe("package manifest utils", () => {
     });
   });
 
+  test("preserves explicit workspace semver ranges during rewrite", () => {
+    const manifest = {
+      dependencies: {
+        "@opensteer/runtime-core": "workspace:^0.1.7",
+        "@opensteer/browser-core": "workspace:~0.7.7",
+        "@opensteer/protocol": "workspace:0.7.7",
+      },
+    };
+
+    const rewritten = rewriteWorkspaceProtocolSpecifiers(manifest, {
+      "@opensteer/runtime-core": "0.1.7",
+      "@opensteer/browser-core": "0.7.7",
+      "@opensteer/protocol": "0.7.7",
+    });
+
+    expect(rewritten).toEqual({
+      dependencies: {
+        "@opensteer/runtime-core": "^0.1.7",
+        "@opensteer/browser-core": "~0.7.7",
+        "@opensteer/protocol": "0.7.7",
+      },
+    });
+  });
+
+  test("rejects unsupported alias workspace specifiers", () => {
+    expect(() =>
+      rewriteWorkspaceProtocolSpecifiers(
+        {
+          dependencies: {
+            "@opensteer/runtime-core": "workspace:@opensteer/runtime-core@*",
+          },
+        },
+        {
+          "@opensteer/runtime-core": "0.1.7",
+        },
+      ),
+    ).toThrow('Unsupported workspace protocol specifier "workspace:@opensteer/runtime-core@*".');
+  });
+
   test("collects workspace protocol specifiers across dependency sections", () => {
     expect(
       collectWorkspaceProtocolSpecifiers({

--- a/tests/opensteer/package-manifest-utils.test.ts
+++ b/tests/opensteer/package-manifest-utils.test.ts
@@ -10,7 +10,7 @@ describe("package manifest utils", () => {
     const manifest = {
       dependencies: {
         "@opensteer/runtime-core": "workspace:*",
-        "sharp": "^0.34.5",
+        sharp: "^0.34.5",
       },
       peerDependencies: {
         "@opensteer/engine-abp": "workspace:*",
@@ -29,7 +29,7 @@ describe("package manifest utils", () => {
     expect(rewritten).toEqual({
       dependencies: {
         "@opensteer/runtime-core": "0.1.7",
-        "sharp": "^0.34.5",
+        sharp: "^0.34.5",
       },
       peerDependencies: {
         "@opensteer/engine-abp": "0.8.7",

--- a/tests/opensteer/package-manifest-utils.test.ts
+++ b/tests/opensteer/package-manifest-utils.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  collectWorkspaceProtocolSpecifiers,
+  rewriteWorkspaceProtocolSpecifiers,
+} from "../../scripts/package-manifest-utils.mjs";
+
+describe("package manifest utils", () => {
+  test("rewrites workspace protocol specifiers to concrete package versions", () => {
+    const manifest = {
+      dependencies: {
+        "@opensteer/runtime-core": "workspace:*",
+        "sharp": "^0.34.5",
+      },
+      peerDependencies: {
+        "@opensteer/engine-abp": "workspace:*",
+      },
+      optionalDependencies: {
+        "@opensteer/browser-core": "workspace:^",
+      },
+    };
+
+    const rewritten = rewriteWorkspaceProtocolSpecifiers(manifest, {
+      "@opensteer/runtime-core": "0.1.7",
+      "@opensteer/engine-abp": "0.8.7",
+      "@opensteer/browser-core": "0.7.7",
+    });
+
+    expect(rewritten).toEqual({
+      dependencies: {
+        "@opensteer/runtime-core": "0.1.7",
+        "sharp": "^0.34.5",
+      },
+      peerDependencies: {
+        "@opensteer/engine-abp": "0.8.7",
+      },
+      optionalDependencies: {
+        "@opensteer/browser-core": "^0.7.7",
+      },
+    });
+  });
+
+  test("collects workspace protocol specifiers across dependency sections", () => {
+    expect(
+      collectWorkspaceProtocolSpecifiers({
+        dependencies: {
+          opensteer: "0.8.17",
+        },
+        peerDependencies: {
+          "@opensteer/engine-abp": "workspace:*",
+        },
+      }),
+    ).toEqual([
+      {
+        packageName: "@opensteer/engine-abp",
+        section: "peerDependencies",
+        specifier: "workspace:*",
+      },
+    ]);
+  });
+});

--- a/tests/opensteer/request-plan-replay.test.ts
+++ b/tests/opensteer/request-plan-replay.test.ts
@@ -72,6 +72,55 @@ describe.sequential("network capture and fetch", () => {
       await opensteer.close().catch(() => undefined);
     }
   }, 60_000);
+
+  test("preserves plain string fetch bodies as text payloads", async () => {
+    const opensteer = new Opensteer({
+      workspace: "sdk-fetch-string-body",
+    });
+
+    try {
+      const response = await opensteer.fetch(`${baseUrl}/api/echo-body`, {
+        method: "POST",
+        transport: "direct",
+        cookies: false,
+        body: "42",
+      });
+
+      await expect(response.json()).resolves.toMatchObject({
+        method: "POST",
+        contentType: "text/plain; charset=utf-8",
+        body: "42",
+      });
+    } finally {
+      await opensteer.disconnect().catch(() => undefined);
+    }
+  }, 60_000);
+
+  test("accepts structured runtime request bodies through SDK fetch", async () => {
+    const opensteer = new Opensteer({
+      workspace: "sdk-fetch-structured-body",
+    });
+
+    try {
+      const response = await opensteer.fetch(`${baseUrl}/api/echo-body`, {
+        method: "POST",
+        transport: "direct",
+        cookies: false,
+        body: {
+          text: "query=opensteer&limit=10",
+          contentType: "application/x-www-form-urlencoded",
+        },
+      });
+
+      await expect(response.json()).resolves.toMatchObject({
+        method: "POST",
+        contentType: "application/x-www-form-urlencoded",
+        body: "query=opensteer&limit=10",
+      });
+    } finally {
+      await opensteer.disconnect().catch(() => undefined);
+    }
+  }, 60_000);
 });
 
 async function handleRequest(request: IncomingMessage, response: ServerResponse): Promise<void> {
@@ -113,6 +162,19 @@ async function handleRequest(request: IncomingMessage, response: ServerResponse)
         echoedQuery: parsed.query ?? null,
         echoedLimit: parsed.limit ?? null,
         contentType: request.headers["content-type"] ?? null,
+      }),
+    );
+    return;
+  }
+
+  if (url.pathname === "/api/echo-body") {
+    const body = await readBody(request);
+    response.setHeader("content-type", "application/json; charset=utf-8");
+    response.end(
+      JSON.stringify({
+        method: request.method ?? "GET",
+        contentType: request.headers["content-type"] ?? null,
+        body,
       }),
     );
     return;

--- a/tests/protocol/public-contract.test.ts
+++ b/tests/protocol/public-contract.test.ts
@@ -217,6 +217,15 @@ describe("semantic protocol validation", () => {
     ).not.toThrow();
   });
 
+  test("accepts transport probing on network.detail", () => {
+    expect(() =>
+      assertValidSemanticOperationInput("network.detail", {
+        recordId: "rec_1",
+        probe: true,
+      }),
+    ).not.toThrow();
+  });
+
   test("accepts dom.extract with schema-only and named replay inputs", () => {
     expect(() =>
       assertValidSemanticOperationInput("dom.extract", {


### PR DESCRIPTION
**Summary**
- rewrite `workspace:*` dependency specifiers to concrete versions when building the runtime artifact tarball
- add a packed-manifest validation step to `package:check` so publishable tarballs cannot ship workspace-only placeholders again
- centralize `network.detail` input typing in protocol/runtime layers and allow the optional `probe` flag in semantic validation
- update SDK fetch typing/body normalization so string bodies stay text payloads while structured request bodies remain supported
- add coverage for packaged manifest rewriting, `network.detail` validation, and fetch body handling

**Testing**
- `pnpm vitest run tests/opensteer/package-manifest-utils.test.ts --config vitest.unit.config.ts`
- `pnpm run package:check`
- `pnpm run check`