### PR TITLE
chore: version packages

### DIFF
--- a/packages/browser-core/package.json
+++ b/packages/browser-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opensteer/browser-core",
   "private": false,
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Engine-neutral primitives and contracts for Opensteer browser backends.",
   "license": "MIT",
   "type": "module",

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opensteer/conformance",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Reusable conformance cases for Opensteer local and cloud runtimes.",
   "license": "MIT",
   "type": "module",

--- a/packages/opensteer/package.json
+++ b/packages/opensteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensteer",
-  "version": "0.8.18",
+  "version": "0.9.0",
   "description": "Opensteer browser automation, replay, and reverse-engineering toolkit.",
   "license": "MIT",
   "type": "module",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opensteer/protocol",
   "private": false,
-  "version": "0.7.7",
+  "version": "0.8.0",
   "description": "Public wire schemas and versioned envelopes for Opensteer APIs.",
   "license": "MIT",
   "type": "module",

--- a/packages/runtime-core/package.json
+++ b/packages/runtime-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensteer/runtime-core",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "Shared semantic runtime for Opensteer local and cloud execution.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump the publishable package versions for the post-0.8.18 cloud and OSS release-readiness work
- carry the protocol, runtime-core, and opensteer API changes forward with minor bumps
- patch browser-core metadata/docs and the private conformance package version

## Verification
- pnpm run check