### PR TITLE
Update local view auto-open and support executable path from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ OPENSTEER_API_KEY=osk_your_api_key_here
 OPENSTEER_BASE_URL=https://api.opensteer.dev
 # Required for `opensteer record --provider cloud` so the CLI can hand you to the browser session UI.
 OPENSTEER_CLOUD_APP_BASE_URL=https://app.opensteer.dev
+# Optional local browser override. Prefer setting this in `.env.local` because it is usually machine-specific.
+# OPENSTEER_EXECUTABLE_PATH=/Applications/Google Chrome.app/Contents/MacOS/Google Chrome

--- a/packages/opensteer/src/browser-manager.ts
+++ b/packages/opensteer/src/browser-manager.ts
@@ -42,6 +42,7 @@ import {
   writePersistedSessionRecord,
   type PersistedLocalBrowserSessionRecord,
 } from "./live-session.js";
+import type { OpensteerEnvironment } from "./env.js";
 import {
   bestEffortRegisterLocalViewSession,
   bestEffortUnregisterLocalViewSession,
@@ -109,6 +110,7 @@ export interface OpensteerBrowserManagerOptions {
   readonly rootPath?: string;
   readonly workspace?: string;
   readonly engineName?: OpensteerEngineName;
+  readonly environment?: OpensteerEnvironment;
   readonly browser?: OpensteerBrowserOptions;
   readonly launch?: OpensteerBrowserLaunchOptions;
   readonly context?: OpensteerBrowserContextOptions;
@@ -130,7 +132,7 @@ export class OpensteerBrowserManager {
     this.workspace = normalizeWorkspace(options.workspace);
     this.mode = resolveBrowserMode(this.workspace, options.browser);
     this.browserOptions = isAttachBrowserOptions(options.browser) ? options.browser : undefined;
-    this.launchOptions = options.launch;
+    this.launchOptions = resolveLaunchOptions(options.launch, options.environment ?? process.env);
     this.contextOptions = normalizeBrowserContextOptions(options.context);
     this.engineName = options.engineName ?? DEFAULT_OPENSTEER_ENGINE;
     assertSupportedEngineOptions({
@@ -739,6 +741,35 @@ export class OpensteerBrowserManager {
 function normalizeWorkspace(workspace: string | undefined): string | undefined {
   const normalized = workspace?.trim();
   return normalized === undefined || normalized.length === 0 ? undefined : normalized;
+}
+
+function resolveLaunchOptions(
+  launch: OpensteerBrowserLaunchOptions | undefined,
+  environment: OpensteerEnvironment,
+): OpensteerBrowserLaunchOptions | undefined {
+  if (launch?.executablePath !== undefined) {
+    return launch;
+  }
+
+  const executablePath = normalizeConfiguredExecutablePath(
+    environment.OPENSTEER_EXECUTABLE_PATH,
+  );
+  if (executablePath === undefined) {
+    return launch;
+  }
+
+  return {
+    ...(launch ?? {}),
+    executablePath,
+  };
+}
+
+function normalizeConfiguredExecutablePath(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? undefined : trimmed;
 }
 
 function toPersistedLocalBrowserSessionRecord(

--- a/packages/opensteer/src/cli/view.ts
+++ b/packages/opensteer/src/cli/view.ts
@@ -12,8 +12,14 @@ import {
 import { buildLocalViewSessionId } from "../local-view/session-manifest.js";
 import { resolveFilesystemWorkspacePath } from "../root.js";
 import type { ParsedCommandLine } from "./parse.js";
+import { openBrowserUrl, type BrowserUrlOpener } from "./open-browser.js";
 
-export async function handleViewCommand(parsed: ParsedCommandLine): Promise<void> {
+export async function handleViewCommand(
+  parsed: ParsedCommandLine,
+  options: {
+    readonly openUrl?: BrowserUrlOpener;
+  } = {},
+): Promise<void> {
   const subcommand = parsed.command[1];
 
   if (subcommand === "serve") {
@@ -56,6 +62,16 @@ export async function handleViewCommand(parsed: ParsedCommandLine): Promise<void
     url,
     ...(sessionId === undefined ? {} : { sessionId }),
   });
+
+  if (parsed.options.json !== true) {
+    try {
+      await (options.openUrl ?? openBrowserUrl)(url);
+    } catch {
+      process.stderr.write(
+        `Could not automatically open the local view. Open it manually: ${url}\n`,
+      );
+    }
+  }
 }
 
 async function resolveWorkspaceSessionId(input: {

--- a/packages/opensteer/src/sdk/opensteer.ts
+++ b/packages/opensteer/src/sdk/opensteer.ts
@@ -206,6 +206,7 @@ export class Opensteer {
         ...(runtimeOptions.rootPath === undefined ? {} : { rootPath: runtimeOptions.rootPath }),
         ...(runtimeOptions.workspace === undefined ? {} : { workspace: runtimeOptions.workspace }),
         ...(engineName === undefined ? {} : { engineName }),
+        environment,
         ...(runtimeOptions.browser === undefined ? {} : { browser: runtimeOptions.browser }),
         ...(runtimeOptions.launch === undefined ? {} : { launch: runtimeOptions.launch }),
         ...(runtimeOptions.context === undefined ? {} : { context: runtimeOptions.context }),

--- a/packages/opensteer/src/sdk/runtime-resolution.ts
+++ b/packages/opensteer/src/sdk/runtime-resolution.ts
@@ -57,9 +57,10 @@ export function createOpensteerSemanticRuntime(
 ): OpensteerDisconnectableRuntime {
   const runtimeOptions = input.runtimeOptions ?? {};
   const engine = input.engine ?? runtimeOptions.engineName ?? DEFAULT_OPENSTEER_ENGINE;
+  const environment = input.environment ?? process.env;
   const config = resolveOpensteerRuntimeConfig({
     ...(input.provider === undefined ? {} : { provider: input.provider }),
-    ...(input.environment === undefined ? {} : { environment: input.environment }),
+    environment,
   });
   assertProviderSupportsEngine(config.provider.mode, engine);
 
@@ -81,5 +82,6 @@ export function createOpensteerSemanticRuntime(
   return new OpensteerRuntime({
     ...runtimeOptions,
     engineName: engine,
+    environment,
   });
 }

--- a/packages/opensteer/src/sdk/runtime.ts
+++ b/packages/opensteer/src/sdk/runtime.ts
@@ -25,6 +25,7 @@ import {
   DEFAULT_OPENSTEER_ENGINE,
   type OpensteerEngineName,
 } from "../internal/engine-selection.js";
+import type { OpensteerEnvironment } from "../env.js";
 import type { OpensteerPolicy } from "../policy/index.js";
 import { resolveFilesystemWorkspacePath } from "../root.js";
 
@@ -35,6 +36,7 @@ export interface OpensteerRuntimeOptions {
   readonly rootDir?: string;
   readonly rootPath?: string;
   readonly engineName?: OpensteerEngineName;
+  readonly environment?: OpensteerEnvironment;
   readonly browser?: OpensteerBrowserOptions;
   readonly launch?: OpensteerBrowserLaunchOptions;
   readonly context?: OpensteerBrowserContextOptions;
@@ -54,6 +56,7 @@ export interface OpensteerSessionRuntimeOptions {
   readonly rootDir?: string;
   readonly rootPath?: string;
   readonly engineName?: OpensteerEngineName;
+  readonly environment?: OpensteerEnvironment;
   readonly browser?: OpensteerBrowserOptions;
   readonly launch?: OpensteerBrowserLaunchOptions;
   readonly context?: OpensteerBrowserContextOptions;
@@ -91,8 +94,10 @@ export class OpensteerRuntime extends SharedOpensteerSessionRuntime {
     super(
       buildSharedRuntimeOptions({
         name: publicWorkspace ?? "default",
+        ...(options.rootDir === undefined ? {} : { rootDir: options.rootDir }),
         rootPath,
         ...(publicWorkspace === undefined ? {} : { workspaceName: publicWorkspace }),
+        ...(options.environment === undefined ? {} : { environment: options.environment }),
         ...(options.browser === undefined ? {} : { browser: options.browser }),
         ...(options.launch === undefined ? {} : { launch: options.launch }),
         ...(options.context === undefined ? {} : { context: options.context }),
@@ -134,7 +139,9 @@ export class OpensteerSessionRuntime extends SharedOpensteerSessionRuntime {
     super(
       buildSharedRuntimeOptions({
         name: options.name,
+        ...(options.rootDir === undefined ? {} : { rootDir: options.rootDir }),
         rootPath,
+        ...(options.environment === undefined ? {} : { environment: options.environment }),
         ...(options.browser === undefined ? {} : { browser: options.browser }),
         ...(options.launch === undefined ? {} : { launch: options.launch }),
         ...(options.context === undefined ? {} : { context: options.context }),
@@ -163,8 +170,10 @@ export class OpensteerSessionRuntime extends SharedOpensteerSessionRuntime {
 
 function buildSharedRuntimeOptions(input: {
   readonly name: string;
+  readonly rootDir?: string;
   readonly rootPath: string;
   readonly workspaceName?: string;
+  readonly environment?: OpensteerEnvironment;
   readonly browser?: OpensteerBrowserOptions;
   readonly launch?: OpensteerBrowserLaunchOptions;
   readonly context?: OpensteerBrowserContextOptions;
@@ -184,9 +193,11 @@ function buildSharedRuntimeOptions(input: {
     input.engineFactory ??
     ((factoryOptions: OpensteerEngineFactoryOptions) =>
       new OpensteerBrowserManager({
+        ...(input.rootDir === undefined ? {} : { rootDir: input.rootDir }),
         rootPath: input.rootPath,
         ...(input.workspaceName === undefined ? {} : { workspace: input.workspaceName }),
         engineName: input.engineName,
+        ...(input.environment === undefined ? {} : { environment: input.environment }),
         ...((factoryOptions.browser ?? input.browser) === undefined
           ? {}
           : { browser: factoryOptions.browser ?? input.browser }),

--- a/tests/opensteer/browser-manager.test.ts
+++ b/tests/opensteer/browser-manager.test.ts
@@ -141,6 +141,7 @@ function createInspectedEndpoint(port: number, label: string) {
 describe("OpensteerBrowserManager", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
     state.spawn.mockImplementation(() => state.createMockChild());
     state.resolveChromeExecutablePath.mockReturnValue("/mock/chromium");
     state.readDevToolsActivePort.mockReturnValue(null);
@@ -167,6 +168,71 @@ describe("OpensteerBrowserManager", () => {
     expect(state.createPlaywrightBrowserCoreEngine).toHaveBeenCalledTimes(1);
     expect(state.engineDispose).toHaveBeenCalledTimes(1);
     expect(state.browser.close).toHaveBeenCalledTimes(1);
+  });
+
+  test("uses OPENSTEER_EXECUTABLE_PATH as the default browser executable", async () => {
+    const rootPath = await mkdtemp(path.join(tmpdir(), "opensteer-browser-manager-env-path-"));
+
+    try {
+      vi.stubEnv("OPENSTEER_EXECUTABLE_PATH", "/env/chromium");
+      state.readDevToolsActivePort.mockReturnValue({
+        port: 54513,
+        webSocketPath: "/devtools/browser/env-path",
+      });
+      state.inspectCdpEndpoint.mockImplementation(async ({ endpoint }) => {
+        if (endpoint === "http://127.0.0.1:54513") {
+          return createInspectedEndpoint(54513, "env-path");
+        }
+        throw new Error(`Unexpected CDP endpoint: ${endpoint}`);
+      });
+
+      const manager = new OpensteerBrowserManager({
+        rootPath,
+        workspace: "env-path",
+      });
+
+      const engine = await manager.createEngine();
+      await engine.dispose?.();
+
+      expect(state.resolveChromeExecutablePath).toHaveBeenCalledWith("/env/chromium");
+    } finally {
+      await rm(rootPath, { recursive: true, force: true });
+    }
+  });
+
+  test("prefers explicit launch executablePath over OPENSTEER_EXECUTABLE_PATH", async () => {
+    const rootPath = await mkdtemp(
+      path.join(tmpdir(), "opensteer-browser-manager-explicit-path-"),
+    );
+
+    try {
+      vi.stubEnv("OPENSTEER_EXECUTABLE_PATH", "/env/chromium");
+      state.readDevToolsActivePort.mockReturnValue({
+        port: 54513,
+        webSocketPath: "/devtools/browser/explicit-path",
+      });
+      state.inspectCdpEndpoint.mockImplementation(async ({ endpoint }) => {
+        if (endpoint === "http://127.0.0.1:54513") {
+          return createInspectedEndpoint(54513, "explicit-path");
+        }
+        throw new Error(`Unexpected CDP endpoint: ${endpoint}`);
+      });
+
+      const manager = new OpensteerBrowserManager({
+        rootPath,
+        workspace: "explicit-path",
+        launch: {
+          executablePath: "/flag/chromium",
+        },
+      });
+
+      const engine = await manager.createEngine();
+      await engine.dispose?.();
+
+      expect(state.resolveChromeExecutablePath).toHaveBeenCalledWith("/flag/chromium");
+    } finally {
+      await rm(rootPath, { recursive: true, force: true });
+    }
   });
 
   test("launches persistent browsers with a caller-supplied fixed remote debugging port", async () => {

--- a/tests/opensteer/env-loader.test.ts
+++ b/tests/opensteer/env-loader.test.ts
@@ -12,6 +12,7 @@ afterEach(() => {
   delete process.env.OPENSTEER_PROVIDER;
   delete process.env.OPENSTEER_BASE_URL;
   delete process.env.OPENSTEER_API_KEY;
+  delete process.env.OPENSTEER_EXECUTABLE_PATH;
   delete process.env.DATABASE_URL;
   delete process.env.PORT;
 });
@@ -30,15 +31,24 @@ describe("CLI env loading", () => {
           "OPENSTEER_PROVIDER=local",
           "OPENSTEER_BASE_URL=https://parent.example",
           "OPENSTEER_API_KEY=parent-key",
+          "OPENSTEER_EXECUTABLE_PATH=/Applications/Parent Chrome",
         ].join("\n"),
       );
       await writeFile(
         path.join(childDir, ".env"),
-        ["OPENSTEER_PROVIDER=cloud", "OPENSTEER_BASE_URL=https://child.example"].join("\n"),
+        [
+          "OPENSTEER_PROVIDER=cloud",
+          "OPENSTEER_BASE_URL=https://child.example",
+          "OPENSTEER_EXECUTABLE_PATH=/Applications/Child Chrome",
+        ].join("\n"),
       );
       await writeFile(
         path.join(childDir, ".env.local"),
-        "OPENSTEER_BASE_URL=https://child-local.example\nPORT=4000\n",
+        [
+          "OPENSTEER_BASE_URL=https://child-local.example",
+          "OPENSTEER_EXECUTABLE_PATH=/Applications/Child Local Chrome",
+          "PORT=4000",
+        ].join("\n"),
       );
 
       vi.stubEnv("OPENSTEER_API_KEY", "protected-key");
@@ -49,6 +59,7 @@ describe("CLI env loading", () => {
       expect(process.env.OPENSTEER_PROVIDER).toBe("cloud");
       expect(process.env.OPENSTEER_BASE_URL).toBe("https://child-local.example");
       expect(process.env.OPENSTEER_API_KEY).toBe("protected-key");
+      expect(process.env.OPENSTEER_EXECUTABLE_PATH).toBe("/Applications/Child Local Chrome");
       expect(process.env.PORT).toBe("4000");
     } finally {
       await rm(rootDir, { recursive: true, force: true });
@@ -67,6 +78,7 @@ describe("CLI env loading", () => {
           "DATABASE_URL=postgres://host-app",
           "OPENSTEER_PROVIDER=cloud",
           "OPENSTEER_BASE_URL=https://cloud.example",
+          "OPENSTEER_EXECUTABLE_PATH=/Applications/Cloud Chrome",
         ].join("\n"),
       );
 
@@ -75,6 +87,7 @@ describe("CLI env loading", () => {
       expect(environment).toEqual({
         OPENSTEER_PROVIDER: "cloud",
         OPENSTEER_BASE_URL: "https://cloud.example",
+        OPENSTEER_EXECUTABLE_PATH: "/Applications/Cloud Chrome",
       });
       expect(process.env.DATABASE_URL).toBeUndefined();
     } finally {

--- a/tests/opensteer/runtime-resolution.test.ts
+++ b/tests/opensteer/runtime-resolution.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  opensteerRuntimeCtor: vi.fn(function MockOpensteerRuntime(this: object) {
+    return this;
+  }),
+}));
+
+vi.mock("../../packages/opensteer/src/sdk/runtime.js", () => ({
+  OpensteerRuntime: state.opensteerRuntimeCtor,
+}));
+
+import { createOpensteerSemanticRuntime } from "../../packages/opensteer/src/sdk/runtime-resolution.js";
+
+describe("runtime resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  test("passes explicit environment into the local runtime", () => {
+    createOpensteerSemanticRuntime({
+      runtimeOptions: {
+        rootDir: "/tmp/opensteer",
+        workspace: "docs",
+        launch: {
+          headless: false,
+        },
+      },
+      environment: {
+        OPENSTEER_EXECUTABLE_PATH: "/env/chromium",
+      },
+    });
+
+    expect(state.opensteerRuntimeCtor).toHaveBeenCalledWith({
+      rootDir: "/tmp/opensteer",
+      workspace: "docs",
+      launch: {
+        headless: false,
+      },
+      engineName: "playwright",
+      environment: {
+        OPENSTEER_EXECUTABLE_PATH: "/env/chromium",
+      },
+    });
+  });
+
+  test("falls back to process env when no explicit environment is provided", () => {
+    vi.stubEnv("OPENSTEER_EXECUTABLE_PATH", "/process/chromium");
+
+    createOpensteerSemanticRuntime({
+      runtimeOptions: {
+        rootDir: "/tmp/opensteer",
+      },
+    });
+
+    expect(state.opensteerRuntimeCtor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rootDir: "/tmp/opensteer",
+        engineName: "playwright",
+        environment: expect.objectContaining({
+          OPENSTEER_EXECUTABLE_PATH: "/process/chromium",
+        }),
+      }),
+    );
+  });
+});

--- a/tests/opensteer/sdk-surface.test.ts
+++ b/tests/opensteer/sdk-surface.test.ts
@@ -123,6 +123,7 @@ describe("Opensteer v2 SDK surface", () => {
     expect(state.browserManagerCtor).toHaveBeenCalledWith({
       workspace: "github-sync",
       browser: "persistent",
+      environment: {},
       launch: {
         headless: false,
       },
@@ -149,6 +150,25 @@ describe("Opensteer v2 SDK surface", () => {
     });
     expect(state.runtime.open).toHaveBeenCalledWith({
       url: "https://example.com",
+    });
+  });
+
+  test("passes root-scoped executable path env to the browser manager", () => {
+    state.environmentByRoot.set("/tmp/opensteer", {
+      OPENSTEER_EXECUTABLE_PATH: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    });
+
+    new Opensteer({
+      workspace: "github-sync",
+      rootDir: "/tmp/opensteer",
+    });
+
+    expect(state.browserManagerCtor).toHaveBeenCalledWith({
+      workspace: "github-sync",
+      rootDir: "/tmp/opensteer",
+      environment: {
+        OPENSTEER_EXECUTABLE_PATH: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      },
     });
   });
 
@@ -283,11 +303,13 @@ describe("Opensteer v2 SDK surface", () => {
       OPENSTEER_PROVIDER: "cloud",
       OPENSTEER_API_KEY: "osk_a",
       OPENSTEER_BASE_URL: "https://a.example",
+      OPENSTEER_EXECUTABLE_PATH: "/Applications/Google Chrome A.app/Contents/MacOS/Google Chrome",
     });
     state.environmentByRoot.set("/tmp/opensteer-b", {
       OPENSTEER_PROVIDER: "cloud",
       OPENSTEER_API_KEY: "osk_b",
       OPENSTEER_BASE_URL: "https://b.example",
+      OPENSTEER_EXECUTABLE_PATH: "/Applications/Google Chrome B.app/Contents/MacOS/Google Chrome",
     });
     state.runtimeConfig.provider = {
       mode: "cloud",
@@ -310,6 +332,8 @@ describe("Opensteer v2 SDK surface", () => {
           OPENSTEER_PROVIDER: "cloud",
           OPENSTEER_API_KEY: "osk_a",
           OPENSTEER_BASE_URL: "https://a.example",
+          OPENSTEER_EXECUTABLE_PATH:
+            "/Applications/Google Chrome A.app/Contents/MacOS/Google Chrome",
         },
         runtimeOptions: {
           rootDir: "/tmp/opensteer-a",
@@ -320,6 +344,8 @@ describe("Opensteer v2 SDK surface", () => {
           OPENSTEER_PROVIDER: "cloud",
           OPENSTEER_API_KEY: "osk_b",
           OPENSTEER_BASE_URL: "https://b.example",
+          OPENSTEER_EXECUTABLE_PATH:
+            "/Applications/Google Chrome B.app/Contents/MacOS/Google Chrome",
         },
         runtimeOptions: {
           rootDir: "/tmp/opensteer-b",

--- a/tests/opensteer/view-command.test.ts
+++ b/tests/opensteer/view-command.test.ts
@@ -94,6 +94,94 @@ describe("view command", () => {
     }
   });
 
+  test("opens the local view URL in a browser for non-json output", async () => {
+    const previousOpensteerHome = process.env.OPENSTEER_HOME;
+    const stateHome = await mkdtemp(path.join(tmpdir(), "opensteer-view-command-open-"));
+    process.env.OPENSTEER_HOME = stateHome;
+
+    try {
+      let openedUrl: string | undefined;
+      const output = await captureStdout(async () => {
+        await handleViewCommand(parseCommandLine(["view"]), {
+          openUrl: async (url) => {
+            openedUrl = url;
+          },
+        });
+      });
+
+      expect(openedUrl).toBeDefined();
+      expect(openedUrl).toContain("127.0.0.1");
+      expect(output).toBe(`${openedUrl}\n`);
+    } finally {
+      await stopLocalViewService().catch(() => undefined);
+      await rm(stateHome, { recursive: true, force: true }).catch(() => undefined);
+      if (previousOpensteerHome === undefined) {
+        delete process.env.OPENSTEER_HOME;
+      } else {
+        process.env.OPENSTEER_HOME = previousOpensteerHome;
+      }
+    }
+  });
+
+  test("does not auto-open the local view for json output", async () => {
+    const previousOpensteerHome = process.env.OPENSTEER_HOME;
+    const stateHome = await mkdtemp(path.join(tmpdir(), "opensteer-view-command-json-"));
+    process.env.OPENSTEER_HOME = stateHome;
+
+    try {
+      let opened = false;
+      const output = JSON.parse(
+        await captureStdout(async () => {
+          await handleViewCommand(parseCommandLine(["view", "--json"]), {
+            openUrl: async () => {
+              opened = true;
+            },
+          });
+        }),
+      ) as { readonly url: string };
+
+      expect(output.url).toContain("127.0.0.1");
+      expect(opened).toBe(false);
+    } finally {
+      await stopLocalViewService().catch(() => undefined);
+      await rm(stateHome, { recursive: true, force: true }).catch(() => undefined);
+      if (previousOpensteerHome === undefined) {
+        delete process.env.OPENSTEER_HOME;
+      } else {
+        process.env.OPENSTEER_HOME = previousOpensteerHome;
+      }
+    }
+  });
+
+  test("continues when automatically opening the local view fails", async () => {
+    const previousOpensteerHome = process.env.OPENSTEER_HOME;
+    const stateHome = await mkdtemp(path.join(tmpdir(), "opensteer-view-command-open-fail-"));
+    process.env.OPENSTEER_HOME = stateHome;
+
+    try {
+      const stderr = await captureStderr(async () => {
+        const stdout = await captureStdout(async () => {
+          await handleViewCommand(parseCommandLine(["view"]), {
+            openUrl: async () => {
+              throw new Error("open failed");
+            },
+          });
+        });
+        expect(stdout).toContain("127.0.0.1");
+      });
+
+      expect(stderr).toContain("Could not automatically open the local view.");
+    } finally {
+      await stopLocalViewService().catch(() => undefined);
+      await rm(stateHome, { recursive: true, force: true }).catch(() => undefined);
+      if (previousOpensteerHome === undefined) {
+        delete process.env.OPENSTEER_HOME;
+      } else {
+        process.env.OPENSTEER_HOME = previousOpensteerHome;
+      }
+    }
+  });
+
   test("reports stop=false when the service is already stopped", async () => {
     const previousOpensteerHome = process.env.OPENSTEER_HOME;
     const stateHome = await mkdtemp(path.join(tmpdir(), "opensteer-view-command-idle-"));
@@ -121,18 +209,29 @@ describe("view command", () => {
 });
 
 async function captureStdout(task: () => Promise<void>): Promise<string> {
+  return captureWrite(process.stdout, task);
+}
+
+async function captureStderr(task: () => Promise<void>): Promise<string> {
+  return captureWrite(process.stderr, task);
+}
+
+async function captureWrite(
+  stream: Pick<NodeJS.WriteStream, "write">,
+  task: () => Promise<void>,
+): Promise<string> {
   let output = "";
-  const originalWrite = process.stdout.write.bind(process.stdout);
-  process.stdout.write = ((chunk) => {
+  const originalWrite = stream.write.bind(stream);
+  stream.write = ((chunk) => {
     output += String(chunk);
     return true;
-  }) as typeof process.stdout.write;
+  }) as typeof stream.write;
 
   try {
     await task();
     return output;
   } finally {
-    process.stdout.write = originalWrite;
+    stream.write = originalWrite;
   }
 }
 


### PR DESCRIPTION
## Summary
- read `OPENSTEER_EXECUTABLE_PATH` from the resolved environment and pass it through the runtime/browser manager stack
- document the optional executable path override in `.env.example`
- auto-open the local view URL for `opensteer view` while preserving JSON output and manual fallback behavior
- add coverage for env loading, runtime resolution, browser manager executable selection, SDK plumbing, and view command auto-open behavior

## Testing
- `pnpm --filter opensteer typecheck`
- `pnpm vitest run tests/opensteer/view-command.test.ts tests/opensteer/local-view.test.ts tests/opensteer/cli-surface.test.ts --config vitest.unit.config.ts`
- `pnpm run typecheck && pnpm run test && pnpm run build && pnpm run package:check && pnpm run skills:check`
- `pnpm check` still stops at `format:check` because of unrelated existing Prettier drift in the repo