### PR TITLE
Release opensteer 0.9.4: tighten public API surface and fix settle timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "opensteer:local": "node scripts/opensteer-local.mjs",
-    "package:check": "publint packages/browser-core && publint packages/engine-abp && publint packages/engine-playwright && publint packages/opensteer && publint packages/protocol && publint packages/runtime-core && node scripts/check-packed-manifests.mjs && node scripts/check-packed-secrets.mjs",
+    "package:check": "node scripts/sync-package-readme.mjs --check && publint packages/browser-core && publint packages/engine-abp && publint packages/engine-playwright && publint packages/opensteer && publint packages/protocol && publint packages/runtime-core && node scripts/check-packed-manifests.mjs && node scripts/check-packed-secrets.mjs",
     "release:publish": "node scripts/publish-npm.mjs",
     "skills:check": "skills add . --list",
     "test": "vitest run --config vitest.config.ts --passWithNoTests",

--- a/packages/conformance/src/index.ts
+++ b/packages/conformance/src/index.ts
@@ -18,13 +18,12 @@ import type {
   OpensteerPageListOutput,
   OpensteerPageNewInput,
   OpensteerPageNewOutput,
-  OpensteerSnapshotMode,
 } from "@opensteer/protocol";
 
 export const opensteerConformanceFamilies = [
   "session-page-lifecycle",
   "evaluate-init-script",
-  "dom-actions-extract-snapshot",
+  "dom-actions-extract",
   "cookies-storage",
   "network-capture",
   "route-intercept",
@@ -55,7 +54,6 @@ export interface OpensteerConformanceTarget {
   goto(url: string, options?: { readonly captureNetwork?: string }): Promise<unknown>;
   evaluate(input: string | OpensteerPageEvaluateInput): Promise<unknown>;
   addInitScript(input: string | OpensteerAddInitScriptInput): Promise<OpensteerAddInitScriptOutput>;
-  snapshot(input?: OpensteerSnapshotMode): Promise<string>;
   click(input: {
     readonly selector?: string;
     readonly element?: number;
@@ -289,8 +287,8 @@ export const opensteerCoreConformanceCases: readonly OpensteerConformanceCase[] 
     },
   },
   {
-    id: "dom-actions-extract-snapshot",
-    family: "dom-actions-extract-snapshot",
+    id: "dom-actions-extract",
+    family: "dom-actions-extract",
     description: "executes DOM actions and extracts stable page state",
     async run({ target, urls }) {
       await target.open(urls.main);
@@ -306,12 +304,6 @@ export const opensteerCoreConformanceCases: readonly OpensteerConformanceCase[] 
       );
       assertEqual(extracted.status, "clicked");
       assertEqual(extracted.mirror, "typed-value");
-
-      const snapshot = await target.snapshot();
-      assert(
-        snapshot.includes("typed-value"),
-        "expected snapshot() to include current page content",
-      );
     },
   },
   {

--- a/packages/opensteer/README.md
+++ b/packages/opensteer/README.md
@@ -1,226 +1,204 @@
-# Opensteer
+<!-- This file is generated from the repository README. Run `node scripts/sync-package-readme.mjs`. -->
 
-`opensteer` is a browser-backed toolkit for agents exploring websites.
+<p align="center">
+  <strong>Opensteer</strong><br/>
+  <em>AI Browser Automation Framework</em>
+</p>
 
-It focuses on the parts normal code cannot do reliably on its own:
+<p align="center">
+  <a href="https://www.npmjs.com/package/opensteer"><img src="https://img.shields.io/npm/v/opensteer.svg" alt="npm version" /></a>
+  <a href="https://www.npmjs.com/package/opensteer"><img src="https://img.shields.io/npm/dm/opensteer.svg" alt="npm downloads" /></a>
+  <a href="https://github.com/steerlabs/opensteer/blob/main/LICENSE"><img src="https://img.shields.io/github/license/steerlabs/opensteer.svg" alt="license" /></a>
+  <a href="https://github.com/steerlabs/opensteer/stargazers"><img src="https://img.shields.io/github/stars/steerlabs/opensteer.svg" alt="stars" /></a>
+</p>
 
-- capture real browser traffic from real browser actions
-- inspect captured requests without dumping huge raw payloads
-- replay requests with browser-grade transports
-- read browser cookies, storage, and page state
-- turn discoveries into plain TypeScript with `session.fetch()`
+<p align="center">
+  <a href="https://opensteer.com">Website</a> &middot;
+  <a href="https://docs.opensteer.com">Docs</a> &middot;
+  <a href="https://github.com/steerlabs/opensteer">GitHub</a> &middot;
+  <a href="https://discord.gg/opensteer">Discord</a>
+</p>
 
-The goal is discovery first, code second. The artifact should usually be working code, not a custom registry abstraction.
+---
+
+Open-source browser automation framework for AI agents. CLI and TypeScript SDK that give coding agents a real Chromium browser with persistent sessions, network capture, and stealth -- so they can browse, inspect, and generate scrapers directly in your codebase.
 
 ## Install
 
 ```bash
-pnpm add opensteer
-pnpm exec playwright install chromium
+npm i -g opensteer
+```
 
-# npm
-npm install opensteer
+Then install Chromium for Playwright:
+
+```bash
 npx playwright install chromium
 ```
 
-The package uses the Playwright-backed local engine by default.
+## Agent Quickstart
 
-## CLI Quickstart
+> **Using Claude Code, Codex, or Cursor?** Point your agent at Opensteer with a single command -- no manual setup needed.
 
 ```bash
+opensteer skills install
+```
+
+This installs first-party skills that teach your AI agent how to use the Opensteer CLI and SDK. The agent can then open browsers, capture network traffic, extract structured data, and generate scrapers autonomously.
+
+Target specific agents:
+
+```bash
+opensteer skills install --agent codex --agent cursor --agent claude-code
+```
+
+## Quickstart
+
+### CLI
+
+```bash
+# Open a page in a persistent workspace
 opensteer open https://example.com --workspace demo
-opensteer goto https://example.com/search --workspace demo --capture-network search
-opensteer network query --workspace demo --capture search
-opensteer network detail rec_123 --workspace demo
-opensteer replay rec_123 --workspace demo
-opensteer cookies example.com --workspace demo
-opensteer storage example.com --workspace demo
-opensteer state example.com --workspace demo
+
+# Take a snapshot and list interactive elements
+opensteer snapshot action --workspace demo
+
+# Click an element by its annotated index
+opensteer click 3 --workspace demo --persist "cta"
+
+# Extract structured data from the page
+opensteer extract '{"title":{"element":3}}' --workspace demo
+
+# Close the workspace
 opensteer close --workspace demo
 ```
 
-For DOM exploration:
-
-```bash
-opensteer snapshot action --workspace demo
-opensteer input 5 laptop --workspace demo --persist "search input" --capture-network search
-opensteer click 7 --workspace demo --persist "search button" --capture-network search
-opensteer snapshot extraction --workspace demo
-opensteer extract '{"title":{"element":3}}' --workspace demo --persist "page summary"
-```
-
-## SDK Quickstart
+### SDK
 
 ```ts
 import { Opensteer } from "opensteer";
 
-const opensteer = new Opensteer({
-  workspace: "demo",
-  rootDir: process.cwd(),
-});
+const opensteer = new Opensteer({ workspace: "demo", rootDir: process.cwd() });
 
 await opensteer.open("https://example.com");
-await opensteer.goto("https://example.com/search", {
-  captureNetwork: "search",
-});
-
-const records = await opensteer.network.query({
-  capture: "search",
-  json: true,
-});
-
-const detail = await opensteer.network.detail(records.records[0]!.recordId, {
-  probe: true,
-});
-
-console.log(detail.summary.url);
-console.log(detail.transportProbe?.recommended);
+await opensteer.click({ persist: "cta" });
+const data = await opensteer.extract({ persist: "page summary" });
+await opensteer.close();
 ```
 
-## `session.fetch()`
+## Features
 
-After discovery, write ordinary TypeScript using `fetch()` on the session.
+<table>
+<tr>
+<td width="50%">
 
-```ts
-import { Opensteer } from "opensteer";
+### Persistent Sessions
 
-const opensteer = new Opensteer({
-  workspace: "target",
-  rootDir: process.cwd(),
-});
+Logins, cookies, and browser state survive across restarts. Each workspace is a full Chrome user-data directory.
 
-async function ensureTargetSession() {
-  const cookies = await opensteer.cookies(".target.com");
-  if (cookies.has("visitorId")) {
-    return;
-  }
-  await opensteer.goto("https://target.com");
-}
+### Profile Cloning
 
-export async function searchTarget(keyword: string, count = 24) {
-  await ensureTargetSession();
+Clone a real Chrome profile to start a workspace already logged in. Source browser doesn't need to close.
 
-  const response = await opensteer.fetch(
-    "https://redsky.target.com/redsky_aggregations/v1/web/plp_search_v2",
-    {
-      query: {
-        keyword,
-        count,
-        offset: 0,
-        channel: "WEB",
-        platform: "desktop",
-      },
-    },
-  );
+### Network Capture
 
-  return response.json();
-}
+Record traffic during any action, inspect requests, and replay APIs with browser-backed `fetch()`.
+
+### Script Analysis
+
+Capture, beautify, deobfuscate, and sandbox page JavaScript.
+
+</td>
+<td width="50%">
+
+### Computer Use
+
+Coordinate-based mouse and keyboard when DOM targeting isn't enough.
+
+### Stealth
+
+Anti-detection defaults: UA spoofing, fingerprint management, automation signal removal.
+
+### Local View
+
+Stream live screenshots from headless sessions to a browser-based viewer.
+
+### Local or Cloud
+
+Run browsers locally or on [Opensteer Cloud](https://opensteer.com). Same CLI, same SDK.
+
+</td>
+</tr>
+</table>
+
+## How It Works
+
+Opensteer follows a **discover-then-codify** workflow:
+
+1. **Capture** -- Open a real page, trigger actions, and record network traffic.
+2. **Inspect** -- Query captured traffic, check cookies/storage/state for auth context.
+3. **Probe** -- Test transport viability for captured requests before writing code.
+4. **Codify** -- Write plain TypeScript with `session.fetch()`. The code is the durable artifact.
+
+See the full [Workflow Guide](https://github.com/steerlabs/opensteer/blob/main/docs/workflows.md) for details.
+
+## Documentation
+
+| Resource                                           | Description                            |
+| -------------------------------------------------- | -------------------------------------- |
+| [Package Guide](https://github.com/steerlabs/opensteer/blob/main/packages/opensteer/README.md)    | Full CLI and SDK reference             |
+| [Workflow Guide](https://github.com/steerlabs/opensteer/blob/main/docs/workflows.md)              | Discover-then-codify methodology       |
+| [Instrumentation Guide](https://github.com/steerlabs/opensteer/blob/main/docs/instrumentation.md) | Tracing and observability              |
+| [Skills Guide](https://github.com/steerlabs/opensteer/blob/main/skills/README.md)                 | Agent skill installation and authoring |
+
+## FAQ
+
+<details>
+<summary><strong>Which AI agents are supported?</strong></summary>
+
+Opensteer ships first-party skills for [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview), [Codex](https://openai.com/index/introducing-codex/), [Cursor](https://www.cursor.com/), and any agent compatible with the [skills.sh](https://skills.sh) standard.
+
+</details>
+
+<details>
+<summary><strong>Do I need to install a browser separately?</strong></summary>
+
+Yes. After installing Opensteer, run `npx playwright install chromium` to download a compatible Chromium build. This is a one-time step.
+
+</details>
+
+<details>
+<summary><strong>Can I use my existing Chrome login sessions?</strong></summary>
+
+Yes. Use profile cloning to copy your real Chrome profile into an Opensteer workspace. Your logins, cookies, and extensions carry over without closing your main browser.
+
+</details>
+
+<details>
+<summary><strong>Does it work in headless mode?</strong></summary>
+
+Yes. Opensteer runs headless by default. Use the Local View feature to stream live screenshots from headless sessions to a browser-based viewer for debugging.
+
+</details>
+
+<details>
+<summary><strong>What Node.js version is required?</strong></summary>
+
+Node.js 22 or later.
+
+</details>
+
+## Development
+
+```bash
+pnpm install
+pnpm run build
+pnpm run typecheck
+pnpm run test
 ```
 
-Transport is selected automatically by default. Force it only when discovery showed a specific requirement:
+## Community
 
-```ts
-const response = await opensteer.fetch("https://api.example.com/search", {
-  query: { keyword: "laptop" },
-  transport: "matched-tls",
-});
-```
-
-## Browser State
-
-Opensteer exposes the browser state agents need for request tracing:
-
-```ts
-const cookies = await opensteer.cookies("example.com");
-const localStorage = await opensteer.storage("example.com", "local");
-const sessionStorage = await opensteer.storage("example.com", "session");
-const state = await opensteer.state("example.com");
-```
-
-`cookies()` returns a lightweight cookie jar:
-
-```ts
-cookies.has("session");
-cookies.get("session");
-cookies.getAll();
-cookies.serialize();
-```
-
-## DOM Automation
-
-```ts
-await opensteer.click({ persist: "search button", captureNetwork: "search" });
-await opensteer.input({
-  persist: "search input",
-  text: "laptop",
-  pressEnter: true,
-  captureNetwork: "search",
-});
-
-const data = await opensteer.extract({
-  persist: "page summary",
-  schema: {
-    title: { selector: "title" },
-    url: { source: "current_url" },
-  },
-});
-```
-
-Use `snapshot("action")` or `snapshot("extraction")` during exploration. The snapshot result is the filtered HTML string, not a huge raw DOM object.
-
-## Humanized Input
-
-Humanized cursor movement, typing cadence, and wheel ticks are opt-in:
-
-```ts
-const opensteer = new Opensteer({
-  workspace: "demo",
-  context: {
-    humanize: true,
-  },
-});
-```
-
-You can also set `OPENSTEER_HUMANIZE=1` to turn it on for local runs without changing code.
-
-## Public SDK Surface
-
-- `new Opensteer({ workspace?, rootDir?, browser?, provider? })`
-- `open(url | input?)`
-- `info()`
-- `listPages()`
-- `newPage()`
-- `activatePage()`
-- `closePage()`
-- `goto(url, { captureNetwork? })`
-- `evaluate(script | input)`
-- `addInitScript(input)`
-- `snapshot("action" | "extraction")`
-- `click({ element? | selector? | persist?, captureNetwork? })`
-- `hover({ element? | selector? | persist?, captureNetwork? })`
-- `input({ text, element? | selector? | persist?, captureNetwork? })`
-- `scroll({ direction, amount, element? | selector? | persist?, captureNetwork? })`
-- `extract({ schema } | { persist, schema? })`
-- `network.query(input?)`
-- `network.detail(recordId, { probe?: boolean })`
-- `waitForPage(input?)`
-- `cookies(domain?)`
-- `storage(domain?, "local" | "session")`
-- `state(domain?)`
-- `fetch(url, options?)`
-- `computerExecute(input)`
-- `route(input)`
-- `interceptScript(input)`
-- `browser.status()`
-- `browser.clone(input)`
-- `browser.reset()`
-- `browser.delete()`
-- `close()`
-- `disconnect()`
-
-## Design Notes
-
-- `network query` is intentionally summary-oriented. Use `network detail` for deep inspection.
-- `replay` is transport-aware and should usually replace manual probe logic.
-- `browser status` intentionally does not leak the raw browser websocket endpoint.
-- The package also exports advanced cloud and browser-management utilities, but the core agent workflow is the local discovery-first SDK and CLI shown above.
+- [Contributing](https://github.com/steerlabs/opensteer/blob/main/CONTRIBUTING.md)
+- [Code of Conduct](https://github.com/steerlabs/opensteer/blob/main/CODE_OF_CONDUCT.md)
+- [Security Policy](https://github.com/steerlabs/opensteer/blob/main/SECURITY.md)
+- [License](https://github.com/steerlabs/opensteer/blob/main/LICENSE) (MIT)

--- a/packages/opensteer/package.json
+++ b/packages/opensteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensteer",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Opensteer browser automation, replay, and reverse-engineering toolkit.",
   "license": "MIT",
   "type": "module",
@@ -76,9 +76,9 @@
     "@opensteer/protocol": "workspace:*"
   },
   "scripts": {
-    "build": "tsup && node ../../scripts/copy-opensteer-local-view-assets.mjs && node ../../scripts/sync-package-skills.mjs",
+    "build": "tsup && node ../../scripts/copy-opensteer-local-view-assets.mjs && node ../../scripts/sync-package-skills.mjs && node ../../scripts/sync-package-readme.mjs",
     "clean": "rimraf dist skills",
-    "prepack": "node ../../scripts/copy-opensteer-local-view-assets.mjs && node ../../scripts/sync-package-skills.mjs",
+    "prepack": "node ../../scripts/copy-opensteer-local-view-assets.mjs && node ../../scripts/sync-package-skills.mjs && node ../../scripts/sync-package-readme.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   }
 }

--- a/packages/opensteer/src/index.ts
+++ b/packages/opensteer/src/index.ts
@@ -204,7 +204,6 @@ export type {
   OpensteerRuntimeWorkspace,
   OpensteerSessionRuntimeOptions,
 } from "./sdk/runtime.js";
-export { OpensteerRuntime, OpensteerSessionRuntime } from "./sdk/runtime.js";
 export type {
   OpensteerCloudProviderOptions,
   OpensteerLocalProviderOptions,
@@ -218,14 +217,7 @@ export {
   normalizeOpensteerProviderMode,
   resolveOpensteerProvider,
 } from "./provider/config.js";
-export {
-  createOpensteerSemanticRuntime,
-  resolveOpensteerRuntimeConfig,
-} from "./sdk/runtime-resolution.js";
-export type {
-  OpensteerDisconnectableRuntime,
-  OpensteerSemanticRuntime,
-} from "./sdk/semantic-runtime.js";
+export { resolveOpensteerRuntimeConfig } from "./sdk/runtime-resolution.js";
 export type {
   OpensteerBrowserManagerOptions,
   OpensteerBrowserStatus,
@@ -276,9 +268,7 @@ export {
   type SyncBrowserProfileCookiesInput,
 } from "./cloud/client.js";
 export {
-  CloudSessionProxy,
   readPersistedCloudSessionRecord,
-  type CloudSessionProxyOptions,
   type PersistedCloudSessionRecord,
 } from "./cloud/session-proxy.js";
 export type {
@@ -295,7 +285,6 @@ export {
   resolveLiveSessionRecordPath,
   writePersistedSessionRecord,
 } from "./live-session.js";
-export { dispatchSemanticOperation } from "./cli/dispatch.js";
 export type {
   InspectedCdpEndpoint,
   LocalCdpBrowserCandidate,

--- a/packages/opensteer/src/sdk/opensteer.ts
+++ b/packages/opensteer/src/sdk/opensteer.ts
@@ -30,7 +30,6 @@ import type {
   OpensteerSessionCloseOutput,
   OpensteerSessionFetchInput,
   OpensteerSessionInfo,
-  OpensteerSnapshotMode,
   OpensteerStateQueryOutput,
   OpensteerStorageArea,
   OpensteerStorageDomainSnapshot,
@@ -353,10 +352,6 @@ export class Opensteer {
       }
       await delay(pollIntervalMs);
     }
-  }
-
-  async snapshot(mode: OpensteerSnapshotMode = "action"): Promise<string> {
-    return (await this.runtime.snapshot({ mode })).html;
   }
 
   async cookies(domain?: string): Promise<OpensteerCookieJar> {

--- a/packages/runtime-core/src/policy/defaults.ts
+++ b/packages/runtime-core/src/policy/defaults.ts
@@ -138,6 +138,7 @@ const defaultNavigationSettleObserver: SettleObserver = {
     }
 
     try {
+      const startedAt = Date.now();
       await input.engine.waitForPostLoadQuiet({
         pageRef: input.pageRef,
         timeoutMs: effectiveTimeout,
@@ -145,9 +146,13 @@ const defaultNavigationSettleObserver: SettleObserver = {
         captureWindowMs: Math.min(NAVIGATION_POST_LOAD_CAPTURE_WINDOW_MS, effectiveTimeout),
         signal: input.signal,
       });
+      const visualTimeout = Math.max(0, effectiveTimeout - (Date.now() - startedAt));
+      if (visualTimeout <= 0) {
+        return true;
+      }
       await input.engine.waitForVisualStability({
         pageRef: input.pageRef,
-        timeoutMs: effectiveTimeout,
+        timeoutMs: visualTimeout,
         settleMs: profile.settleMs,
         scope: profile.scope,
       });

--- a/scripts/sync-package-readme.mjs
+++ b/scripts/sync-package-readme.mjs
@@ -1,0 +1,34 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const sourcePath = path.join(repoRoot, "README.md");
+const targetPath = path.join(repoRoot, "packages", "opensteer", "README.md");
+const repoBlobBaseUrl = "https://github.com/steerlabs/opensteer/blob/main";
+const generatedBanner =
+  "<!-- This file is generated from the repository README. Run `node scripts/sync-package-readme.mjs`. -->";
+
+const sourceReadme = await readFile(sourcePath, "utf8");
+const syncedReadme = `${generatedBanner}\n\n${rewriteRelativeLinks(sourceReadme)}`;
+
+if (process.argv.includes("--check")) {
+  const currentReadme = await readFile(targetPath, "utf8");
+  if (currentReadme !== syncedReadme) {
+    console.error("packages/opensteer/README.md is out of sync with README.md");
+    process.exitCode = 1;
+  } else {
+    console.log("packages/opensteer/README.md is in sync with README.md");
+  }
+} else {
+  await writeFile(targetPath, syncedReadme, "utf8");
+}
+
+function rewriteRelativeLinks(markdown) {
+  return markdown.replaceAll(/\]\((\.\/[^)]+)\)/g, (match, relativePath) => {
+    const normalizedPath = relativePath.slice(2);
+    return `](${repoBlobBaseUrl}/${normalizedPath})`;
+  });
+}

--- a/skills/opensteer/SKILL.md
+++ b/skills/opensteer/SKILL.md
@@ -416,7 +416,6 @@ opensteer artifact read <artifactId> --workspace demo
 ## SDK Surface
 
 - `open(url)`, `goto(url, { captureNetwork? })`, `close()`
-- `snapshot("action" | "extraction")`
 - `click()`, `hover()`, `input()`, `scroll()`
 - `extract({ persist })` — replay-only, no inline templates
 - `listPages()`, `newPage()`, `activatePage()`, `closePage()`

--- a/tests/opensteer/computer-use.test.ts
+++ b/tests/opensteer/computer-use.test.ts
@@ -17,10 +17,9 @@ import {
   createScrollOffset,
   createSize,
 } from "../../packages/browser-core/src/index.js";
+import { OpensteerRuntime, OpensteerSessionRuntime } from "../../packages/opensteer/src/sdk/runtime.js";
 import {
   Opensteer,
-  OpensteerRuntime,
-  OpensteerSessionRuntime,
   defaultPolicy,
   runWithPolicyTimeout,
 } from "../../packages/opensteer/src/index.js";

--- a/tests/opensteer/conformance-local.test.ts
+++ b/tests/opensteer/conformance-local.test.ts
@@ -11,7 +11,8 @@ import {
   type OpensteerConformanceHarness,
   type OpensteerConformanceUrls,
 } from "../../packages/conformance/src/index.js";
-import { Opensteer, OpensteerRuntime } from "../../packages/opensteer/src/index.js";
+import { OpensteerRuntime } from "../../packages/opensteer/src/sdk/runtime.js";
+import { Opensteer } from "../../packages/opensteer/src/index.js";
 
 let urls: OpensteerConformanceUrls;
 let closeServer: (() => Promise<void>) | undefined;

--- a/tests/opensteer/local-view.test.ts
+++ b/tests/opensteer/local-view.test.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 import { chromium, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 
-import { OpensteerSessionRuntime } from "../../packages/opensteer/src/index.js";
+import { OpensteerSessionRuntime } from "../../packages/opensteer/src/sdk/runtime.js";
 import { bestEffortRegisterLocalViewSession } from "../../packages/opensteer/src/local-view/registration.js";
 import {
   resolveLocalViewMode,

--- a/tests/opensteer/navigation-network-capture.test.ts
+++ b/tests/opensteer/navigation-network-capture.test.ts
@@ -20,12 +20,12 @@ import {
   OpensteerProtocolError,
   resolveDomActionBridge,
 } from "../../packages/protocol/src/index.js";
+import { OpensteerRuntime } from "../../packages/opensteer/src/sdk/runtime.js";
 import {
   createDomRuntime,
   createFilesystemOpensteerWorkspace,
   defaultPolicy,
   Opensteer,
-  OpensteerRuntime,
   type OpensteerPolicy,
   type SettleObserver,
 } from "../../packages/opensteer/src/index.js";

--- a/tests/opensteer/network-probe.test.ts
+++ b/tests/opensteer/network-probe.test.ts
@@ -5,9 +5,9 @@ import path from "node:path";
 import { afterAll, describe, expect, test } from "vitest";
 
 import { createFakeBrowserCoreEngine } from "../../packages/browser-core/src/index.js";
+import { OpensteerSessionRuntime } from "../../packages/opensteer/src/sdk/runtime.js";
 import {
   createFilesystemOpensteerWorkspace,
-  OpensteerSessionRuntime,
   runWithPolicyTimeout,
 } from "../../packages/opensteer/src/index.js";
 

--- a/tests/opensteer/observability-playwright.test.ts
+++ b/tests/opensteer/observability-playwright.test.ts
@@ -6,10 +6,8 @@ import { chromium } from "playwright";
 import { describe, expect, test } from "vitest";
 
 import { createPlaywrightBrowserCoreEngine } from "../../packages/engine-playwright/src/index.js";
-import {
-  OpensteerSessionRuntime,
-  createFilesystemOpensteerWorkspace,
-} from "../../packages/opensteer/src/index.js";
+import { OpensteerSessionRuntime } from "../../packages/opensteer/src/sdk/runtime.js";
+import { createFilesystemOpensteerWorkspace } from "../../packages/opensteer/src/index.js";
 
 function dataUrl(body: string, title: string): string {
   return `data:text/html,${encodeURIComponent(`<!doctype html>

--- a/tests/opensteer/sdk-surface.test.ts
+++ b/tests/opensteer/sdk-surface.test.ts
@@ -29,13 +29,6 @@ const state = vi.hoisted(() => {
         path: "/tmp/screenshot.png",
       },
     })),
-    snapshot: vi.fn(async (input = {}) => ({
-      url: "https://example.com",
-      title: "Workspace Runtime",
-      mode: (input as { readonly mode?: string }).mode ?? "action",
-      html: "<html></html>",
-      counters: [],
-    })),
     close: vi.fn(async () => ({ closed: true })),
     disconnect: vi.fn(async () => undefined),
   };
@@ -93,6 +86,7 @@ vi.mock("../../packages/opensteer/src/env.js", () => ({
   ),
 }));
 
+import * as publicOpensteer from "../../packages/opensteer/src/index.js";
 import { Opensteer } from "../../packages/opensteer/src/sdk/opensteer.js";
 
 describe("Opensteer v2 SDK surface", () => {
@@ -208,17 +202,20 @@ describe("Opensteer v2 SDK surface", () => {
     expect(state.browserManager.delete).toHaveBeenCalledTimes(1);
   });
 
-  test("snapshot forwards string shorthand modes to the runtime", async () => {
+  test("does not expose snapshot on the public Opensteer instance", () => {
     const opensteer = new Opensteer({
       workspace: "github-sync",
     });
 
-    const snapshot = await opensteer.snapshot("action");
+    expect("snapshot" in opensteer).toBe(false);
+  });
 
-    expect(state.runtime.snapshot).toHaveBeenCalledWith({
-      mode: "action",
-    });
-    expect(snapshot).toBe("<html></html>");
+  test("does not export low-level runtime entrypoints from the package root", () => {
+    expect("OpensteerRuntime" in publicOpensteer).toBe(false);
+    expect("OpensteerSessionRuntime" in publicOpensteer).toBe(false);
+    expect("createOpensteerSemanticRuntime" in publicOpensteer).toBe(false);
+    expect("dispatchSemanticOperation" in publicOpensteer).toBe(false);
+    expect("CloudSessionProxy" in publicOpensteer).toBe(false);
   });
 
   test("computerExecute forwards computer actions to the semantic runtime", async () => {


### PR DESCRIPTION
## Summary
- Bump opensteer to 0.9.4
- Remove `snapshot()` from public SDK surface, conformance suite, and SKILL.md docs
- Hide internal runtime exports (`OpensteerRuntime`, `OpensteerSessionRuntime`, `createOpensteerSemanticRuntime`, `CloudSessionProxy`, `dispatchSemanticOperation`) from package root — tests import from internal paths
- Fix navigation settle observer to subtract elapsed post-load-quiet time from visual stability timeout, preventing up to 2x overshoot

## Test plan
- [ ] Verify tests pass with internal import paths for `OpensteerSessionRuntime` and `OpensteerRuntime`
- [ ] Confirm `snapshot` is no longer accessible on `Opensteer` instances
- [ ] Validate settle timeout fix doesn't regress navigation behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)