### PR TITLE
Update persist-based extraction and snapshot boundary handling

### DIFF
--- a/packages/conformance/src/index.ts
+++ b/packages/conformance/src/index.ts
@@ -84,10 +84,7 @@ export interface OpensteerConformanceTarget {
     readonly direction: "up" | "down" | "left" | "right";
     readonly amount: number;
   }): Promise<OpensteerActionResult>;
-  extract(input: {
-    readonly persist: string;
-    readonly schema?: Record<string, unknown>;
-  }): Promise<unknown>;
+  extract(input: { readonly persist: string }): Promise<unknown>;
   cookies(domain?: string): Promise<{
     has(name: string): boolean;
     get(name: string): string | undefined;
@@ -304,10 +301,6 @@ export const opensteerCoreConformanceCases: readonly OpensteerConformanceCase[] 
       const extracted = asRecord(
         await target.extract({
           persist: "conformance fixture state",
-          schema: {
-            status: { selector: "#status" },
-            mirror: { selector: "#mirror" },
-          },
         }),
         "expected extract() to produce an object",
       );
@@ -458,9 +451,6 @@ export const opensteerCoreConformanceCases: readonly OpensteerConformanceCase[] 
       const status = asRecord(
         await target.extract({
           persist: "conformance computer status",
-          schema: {
-            status: { selector: "#status" },
-          },
         }),
         "expected extract() to return the computer action status",
       );

--- a/packages/opensteer/README.md
+++ b/packages/opensteer/README.md
@@ -46,7 +46,7 @@ opensteer snapshot action --workspace demo
 opensteer input 5 laptop --workspace demo --persist "search input" --capture-network search
 opensteer click 7 --workspace demo --persist "search button" --capture-network search
 opensteer snapshot extraction --workspace demo
-opensteer extract '{"title":{"element":3}}' --workspace demo --persist "page summary"
+opensteer extract '{"title":3,"productUrl":{"c":7,"attr":"href"},"url":{"source":"current_url"}}' --workspace demo --persist "page summary"
 ```
 
 ## SDK Quickstart
@@ -159,11 +159,14 @@ await opensteer.input({
 
 const data = await opensteer.extract({
   persist: "page summary",
-  schema: {
-    title: { selector: "title" },
-    url: { source: "current_url" },
-  },
 });
+```
+
+Author extraction templates from the CLI. Bare numbers target counters, `{ c, attr }` reads an
+attribute from a counter-backed element, and `{ source: "current_url" }` reads page metadata.
+
+```bash
+opensteer extract '{"title":3,"productUrl":{"c":7,"attr":"href"},"url":{"source":"current_url"}}' --workspace demo --persist "page summary"
 ```
 
 Use `snapshot("action")` or `snapshot("extraction")` during exploration. The snapshot result is the filtered HTML string, not a huge raw DOM object.
@@ -200,7 +203,7 @@ You can also set `OPENSTEER_HUMANIZE=1` to turn it on for local runs without cha
 - `hover({ element? | selector? | persist?, captureNetwork? })`
 - `input({ text, element? | selector? | persist?, captureNetwork? })`
 - `scroll({ direction, amount, element? | selector? | persist?, captureNetwork? })`
-- `extract({ schema } | { persist, schema? })`
+- `extract({ persist })`
 - `network.query(input?)`
 - `network.detail(recordId, { probe?: boolean })`
 - `waitForPage(input?)`

--- a/packages/opensteer/README.md
+++ b/packages/opensteer/README.md
@@ -162,8 +162,7 @@ const data = await opensteer.extract({
 });
 ```
 
-Author extraction templates from the CLI. Bare numbers target counters, `{ c, attr }` reads an
-attribute from a counter-backed element, and `{ source: "current_url" }` reads page metadata.
+Author extraction templates from the CLI. Bare numbers reference element numbers from the snapshot (`c="N"` attributes), `{ c, attr }` reads an attribute from that element, and `{ source: "current_url" }` reads page metadata.
 
 ```bash
 opensteer extract '{"title":3,"productUrl":{"c":7,"attr":"href"},"url":{"source":"current_url"}}' --workspace demo --persist "page summary"

--- a/packages/opensteer/src/cli/help.ts
+++ b/packages/opensteer/src/cli/help.ts
@@ -15,11 +15,11 @@ Navigation:
 
 DOM:
   snapshot [action|extraction]
-  click <element> [--button left|middle|right] [--persist <key>] [--capture-network <label>]
-  hover <element> [--persist <key>] [--capture-network <label>]
-  input <element> <text> [--press-enter] [--persist <key>] [--capture-network <label>]
-  scroll <direction> <amount> [--element <n>] [--persist <key>] [--capture-network <label>]
-  extract <schema> [--persist <key>]
+  click <element> --persist <key> [--button left|middle|right] [--capture-network <label>]
+  hover <element> --persist <key> [--capture-network <label>]
+  input <element> <text> --persist <key> [--press-enter] [--capture-network <label>]
+  scroll <direction> <amount> --persist <key> [--element <n>] [--capture-network <label>]
+  extract <template> --persist <key>
   evaluate <script>
   init-script <script>
 

--- a/packages/opensteer/src/cli/operation-input.ts
+++ b/packages/opensteer/src/cli/operation-input.ts
@@ -134,12 +134,12 @@ export async function buildOperationInput(
     }
     case "dom.extract": {
       if (parsed.rest[0] === undefined) {
-        throw new Error("extract requires a schema.");
+        throw new Error("extract requires a template.");
       }
-      const persist = readExtractPersistKey(parsed);
+      const persist = readPersistKey(parsed, "extract");
       return {
-        schema: parseRequiredJsonObjectArgument(joinRest(parsed.rest, 0), "extract schema"),
-        ...(persist === undefined ? {} : { persist }),
+        persist,
+        template: parseRequiredJsonObjectArgument(joinRest(parsed.rest, 0), "extract template"),
       };
     }
     case "network.query": {
@@ -357,7 +357,7 @@ function buildElementTargetInput(
       kind: "element",
       element,
     },
-    ...(persist === undefined ? {} : { persist }),
+    persist,
     ...(captureNetwork === undefined ? {} : { captureNetwork }),
   };
 }
@@ -586,28 +586,14 @@ function readKeyModifiers(
 
 function readPersistKey(
   parsed: ParsedCommandLine,
-  verb: "click" | "hover" | "input" | "scroll",
-): string | undefined {
+  verb: "click" | "hover" | "input" | "scroll" | "extract",
+): string {
   const value = readSingle(parsed.rawOptions, "persist");
   if (value === undefined) {
-    return undefined;
+    throw new Error(`${verb} requires "--persist <key>".`);
   }
   if (value === "true" || value === "false") {
-    throw new Error(`${verb} requires "--persist <key>" when using --persist.`);
-  }
-  if (verb === "scroll" && readOptionalNumber(parsed.rawOptions, "element") === undefined) {
-    throw new Error('scroll requires "--element <n>" when using "--persist <key>".');
-  }
-  return value;
-}
-
-function readExtractPersistKey(parsed: ParsedCommandLine): string | undefined {
-  const value = readSingle(parsed.rawOptions, "persist");
-  if (value === undefined) {
-    return undefined;
-  }
-  if (value === "true" || value === "false") {
-    throw new Error('extract requires "--persist <key>" when using --persist.');
+    throw new Error(`${verb} requires "--persist <key>".`);
   }
   return value;
 }

--- a/packages/opensteer/src/cli/operation-input.ts
+++ b/packages/opensteer/src/cli/operation-input.ts
@@ -128,7 +128,7 @@ export async function buildOperationInput(
               },
         direction,
         amount,
-        ...(persist === undefined ? {} : { persist }),
+        persist,
         ...(captureNetwork === undefined ? {} : { captureNetwork }),
       };
     }

--- a/packages/opensteer/src/sdk/opensteer.ts
+++ b/packages/opensteer/src/sdk/opensteer.ts
@@ -80,15 +80,9 @@ export interface OpensteerScrollOptions extends OpensteerTargetOptions {
   readonly amount: number;
 }
 
-export type OpensteerExtractOptions =
-  | {
-      readonly persist: string;
-      readonly schema?: Record<string, unknown>;
-    }
-  | {
-      readonly persist?: string;
-      readonly schema: Record<string, unknown>;
-    };
+export interface OpensteerExtractOptions {
+  readonly persist: string;
+}
 
 export interface OpensteerWaitForPageOptions {
   readonly openerPageRef?: string;

--- a/packages/protocol/src/semantic.ts
+++ b/packages/protocol/src/semantic.ts
@@ -406,7 +406,7 @@ export interface OpensteerDomScrollInput {
 
 export interface OpensteerDomExtractInput {
   readonly persist?: string;
-  readonly schema?: Readonly<Record<string, unknown>>;
+  readonly template?: Readonly<Record<string, unknown>>;
 }
 
 export interface OpensteerDomExtractOutput {
@@ -1196,10 +1196,10 @@ const opensteerDomScrollInputSchema: JsonSchema = objectSchema(
   },
 );
 
-const opensteerExtractSchemaSchema: JsonSchema = objectSchema(
+const opensteerExtractTemplateSchema: JsonSchema = objectSchema(
   {},
   {
-    title: "OpensteerExtractSchema",
+    title: "OpensteerExtractTemplate",
     additionalProperties: true,
   },
 );
@@ -1208,13 +1208,13 @@ const opensteerDomExtractInputSchema: JsonSchema = defineSchema({
   ...objectSchema(
     {
       persist: stringSchema(),
-      schema: opensteerExtractSchemaSchema,
+      template: opensteerExtractTemplateSchema,
     },
     {
       title: "OpensteerDomExtractInput",
     },
   ),
-  anyOf: [defineSchema({ required: ["persist"] }), defineSchema({ required: ["schema"] })],
+  anyOf: [defineSchema({ required: ["persist"] }), defineSchema({ required: ["template"] })],
 });
 
 const jsonValueSchema: JsonSchema = recordSchema({}, { title: "JsonValueRecord" });

--- a/packages/runtime-core/src/sdk/extraction.ts
+++ b/packages/runtime-core/src/sdk/extraction.ts
@@ -24,29 +24,29 @@ import {
   joinDataPath,
 } from "./extraction-data-path.js";
 
-interface OpensteerSchemaFieldByElement {
-  readonly element: number;
+interface OpensteerTemplateFieldByCounter {
+  readonly counter: number;
   readonly attribute?: string;
 }
 
-interface OpensteerSchemaFieldBySelector {
+interface OpensteerTemplateFieldBySelector {
   readonly selector: string;
   readonly attribute?: string;
 }
 
-interface OpensteerSchemaFieldBySource {
+interface OpensteerTemplateFieldBySource {
   readonly source: "current_url";
 }
 
-type OpensteerSchemaField =
-  | OpensteerSchemaFieldByElement
-  | OpensteerSchemaFieldBySelector
-  | OpensteerSchemaFieldBySource;
+type OpensteerTemplateField =
+  | OpensteerTemplateFieldByCounter
+  | OpensteerTemplateFieldBySelector
+  | OpensteerTemplateFieldBySource;
 
-type OpensteerSchemaNode =
-  | OpensteerSchemaField
-  | readonly OpensteerSchemaNode[]
-  | { readonly [key: string]: OpensteerSchemaNode };
+type OpensteerTemplateNode =
+  | OpensteerTemplateField
+  | readonly OpensteerTemplateNode[]
+  | { readonly [key: string]: OpensteerTemplateNode };
 
 interface OpensteerExtractionPathFieldTarget {
   readonly key: string;
@@ -99,7 +99,7 @@ export interface OpensteerExtractionDescriptorPayload {
   readonly kind: "dom-extraction";
   readonly persist: string;
   readonly root: PersistedOpensteerExtractionPayload;
-  readonly schemaHash?: string;
+  readonly templateHash?: string;
   readonly sourceUrl?: string;
 }
 
@@ -119,7 +119,7 @@ export interface OpensteerExtractionDescriptorStore {
   write(input: {
     readonly persist: string;
     readonly root: PersistedOpensteerExtractionPayload;
-    readonly schemaHash?: string;
+    readonly templateHash?: string;
     readonly sourceUrl?: string;
     readonly createdAt?: number;
     readonly updatedAt?: number;
@@ -150,12 +150,18 @@ interface MergedVariantRow {
   readonly value: JsonValue;
 }
 
-export function assertValidOpensteerExtractionSchemaRoot(schema: unknown): asserts schema is {
-  readonly [key: string]: OpensteerSchemaNode;
+export function assertValidOpensteerExtractionTemplateRoot(template: unknown): asserts template is {
+  readonly [key: string]: OpensteerTemplateNode;
 } {
-  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
-    throw new Error("Invalid extraction schema: expected a JSON object at the top level.");
+  if (!template || typeof template !== "object" || Array.isArray(template)) {
+    throw new Error("Invalid extraction template: expected a JSON object at the top level.");
   }
+}
+
+export function assertValidOpensteerExtractionSchemaRoot(schema: unknown): asserts schema is {
+  readonly [key: string]: OpensteerTemplateNode;
+} {
+  assertValidOpensteerExtractionTemplateRoot(schema);
 }
 
 export function isPersistedOpensteerExtractionValueNode(
@@ -188,16 +194,25 @@ export function isPersistedOpensteerExtractionArrayNode(
   return "$array" in value;
 }
 
-export async function compileOpensteerExtractionPayload(options: {
-  readonly pageRef: PageRef;
-  readonly schema: Record<string, unknown>;
-  readonly dom: DomRuntime;
-}): Promise<PersistedOpensteerExtractionPayload> {
-  assertValidOpensteerExtractionSchemaRoot(options.schema);
+export async function compileOpensteerExtractionPayload(
+  options: {
+    readonly pageRef: PageRef;
+    readonly dom: DomRuntime;
+  } & (
+    | {
+        readonly template: Record<string, unknown>;
+      }
+    | {
+        readonly schema: Record<string, unknown>;
+      }
+  ),
+): Promise<PersistedOpensteerExtractionPayload> {
+  const template = readExtractionTemplate(options);
+  assertValidOpensteerExtractionTemplateRoot(template);
   const fieldTargets = await compileOpensteerExtractionFieldTargets({
     dom: options.dom,
     pageRef: options.pageRef,
-    schema: options.schema,
+    template,
   });
   return compilePersistedOpensteerExtractionPayloadFromFieldTargets({
     pageRef: options.pageRef,
@@ -206,17 +221,26 @@ export async function compileOpensteerExtractionPayload(options: {
   });
 }
 
-export async function compileOpensteerExtractionFieldTargets(options: {
-  readonly pageRef: PageRef;
-  readonly schema: Record<string, unknown>;
-  readonly dom: DomRuntime;
-}): Promise<readonly OpensteerExtractionFieldTarget[]> {
-  assertValidOpensteerExtractionSchemaRoot(options.schema);
+export async function compileOpensteerExtractionFieldTargets(
+  options: {
+    readonly pageRef: PageRef;
+    readonly dom: DomRuntime;
+  } & (
+    | {
+        readonly template: Record<string, unknown>;
+      }
+    | {
+        readonly schema: Record<string, unknown>;
+      }
+  ),
+): Promise<readonly OpensteerExtractionFieldTarget[]> {
+  const template = readExtractionTemplate(options);
+  assertValidOpensteerExtractionTemplateRoot(template);
   const fields: OpensteerExtractionFieldTarget[] = [];
-  await collectFieldTargetsFromSchemaObject({
+  await collectFieldTargetsFromTemplateObject({
     dom: options.dom,
     pageRef: options.pageRef,
-    value: options.schema,
+    value: template,
     path: "",
     fields,
     insideArray: false,
@@ -292,7 +316,19 @@ export function createOpensteerExtractionDescriptorStore(options: {
   return new MemoryOpensteerExtractionDescriptorStore(namespace);
 }
 
-async function collectFieldTargetsFromSchemaObject(options: {
+function readExtractionTemplate(
+  options:
+    | {
+        readonly template: Record<string, unknown>;
+      }
+    | {
+        readonly schema: Record<string, unknown>;
+      },
+): Record<string, unknown> {
+  return "template" in options ? options.template : options.schema;
+}
+
+async function collectFieldTargetsFromTemplateObject(options: {
   readonly dom: DomRuntime;
   readonly pageRef: PageRef;
   readonly value: Record<string, unknown>;
@@ -306,7 +342,7 @@ async function collectFieldTargetsFromSchemaObject(options: {
       continue;
     }
 
-    await collectFieldTargetsFromSchemaValue({
+    await collectFieldTargetsFromTemplateValue({
       dom: options.dom,
       pageRef: options.pageRef,
       value: childValue,
@@ -317,7 +353,7 @@ async function collectFieldTargetsFromSchemaObject(options: {
   }
 }
 
-async function collectFieldTargetsFromSchemaValue(options: {
+async function collectFieldTargetsFromTemplateValue(options: {
   readonly dom: DomRuntime;
   readonly pageRef: PageRef;
   readonly value: unknown;
@@ -325,7 +361,7 @@ async function collectFieldTargetsFromSchemaValue(options: {
   readonly fields: OpensteerExtractionFieldTarget[];
   readonly insideArray: boolean;
 }): Promise<void> {
-  const normalizedField = normalizeSchemaField(options.value);
+  const normalizedField = normalizeTemplateField(options.value);
   if (normalizedField !== null) {
     options.fields.push(
       await compileFieldTarget({
@@ -341,12 +377,12 @@ async function collectFieldTargetsFromSchemaValue(options: {
   if (Array.isArray(options.value)) {
     if (options.insideArray) {
       throw new Error(
-        `Nested arrays are not supported in extraction schema at "${labelForPath(options.path)}".`,
+        `Nested arrays are not supported in extraction template at "${labelForPath(options.path)}".`,
       );
     }
     if (options.value.length === 0) {
       throw new Error(
-        `Extraction array "${labelForPath(options.path)}" must include at least one representative item.`,
+        `Extraction array "${labelForPath(options.path)}" must include at least one representative template item.`,
       );
     }
 
@@ -359,7 +395,7 @@ async function collectFieldTargetsFromSchemaValue(options: {
       }
 
       const fieldCountBeforeItem = options.fields.length;
-      await collectFieldTargetsFromSchemaObject({
+      await collectFieldTargetsFromTemplateObject({
         dom: options.dom,
         pageRef: options.pageRef,
         value: itemValue as Record<string, unknown>,
@@ -371,7 +407,7 @@ async function collectFieldTargetsFromSchemaValue(options: {
       const itemFields = options.fields.slice(fieldCountBeforeItem);
       if (!itemFields.some((field) => !("source" in field))) {
         throw new Error(
-          `Extraction array "${labelForPath(options.path)}" item ${String(index)} must include at least one element- or selector-backed field.`,
+          `Extraction array "${labelForPath(options.path)}" item ${String(index)} must include at least one counter- or selector-backed field.`,
         );
       }
     }
@@ -380,11 +416,11 @@ async function collectFieldTargetsFromSchemaValue(options: {
 
   if (!options.value || typeof options.value !== "object") {
     throw new Error(
-      `Invalid extraction schema value at "${labelForPath(options.path)}": expected an object, array, or field descriptor.`,
+      `Invalid extraction template value at "${labelForPath(options.path)}": expected an object, array, or field descriptor.`,
     );
   }
 
-  await collectFieldTargetsFromSchemaObject({
+  await collectFieldTargetsFromTemplateObject({
     dom: options.dom,
     pageRef: options.pageRef,
     value: options.value as Record<string, unknown>,
@@ -397,7 +433,7 @@ async function collectFieldTargetsFromSchemaValue(options: {
 async function compileFieldTarget(options: {
   readonly dom: DomRuntime;
   readonly pageRef: PageRef;
-  readonly field: OpensteerSchemaField;
+  readonly field: OpensteerTemplateField;
   readonly path: string;
 }): Promise<OpensteerExtractionFieldTarget> {
   if ("source" in options.field) {
@@ -424,7 +460,7 @@ async function compileFieldTarget(options: {
     path: await resolveSelectorFieldPath({
       dom: options.dom,
       pageRef: options.pageRef,
-      selector: `[c="${String(options.field.element)}"]`,
+      selector: `[c="${String(options.field.counter)}"]`,
     }),
     ...(options.field.attribute === undefined ? {} : { attribute: options.field.attribute }),
   };
@@ -858,27 +894,37 @@ function countNonNullLeaves(value: JsonValue): number {
   return Object.values(value).reduce<number>((sum, item) => sum + countNonNullLeaves(item), 0);
 }
 
-function normalizeSchemaField(value: unknown): OpensteerSchemaField | null {
+function normalizeTemplateField(value: unknown): OpensteerTemplateField | null {
+  if (typeof value === "number") {
+    return {
+      counter: normalizeExtractionCounter(value),
+    };
+  }
+
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return null;
   }
 
   const raw = value as Record<string, unknown>;
-  const hasElement = raw.element !== undefined;
+  const hasCounter = raw.c !== undefined || raw.element !== undefined;
   const hasSelector = raw.selector !== undefined;
   const hasSource = raw.source !== undefined;
-  const targetCount = Number(hasElement) + Number(hasSelector) + Number(hasSource);
+  const targetCount = Number(hasCounter) + Number(hasSelector) + Number(hasSource);
   if (targetCount === 0) {
     return null;
   }
   if (targetCount !== 1) {
     throw new Error(
-      "Extraction field descriptors must specify exactly one of element, selector, or source.",
+      "Extraction field descriptors must specify exactly one of c/element, selector, or source.",
     );
   }
 
   const attribute =
-    raw.attribute === undefined ? undefined : normalizeNonEmptyString("attribute", raw.attribute);
+    raw.attr !== undefined
+      ? normalizeNonEmptyString("attr", raw.attr)
+      : raw.attribute === undefined
+        ? undefined
+        : normalizeNonEmptyString("attribute", raw.attribute);
 
   if (hasSource) {
     if (raw.source !== "current_url") {
@@ -896,17 +942,20 @@ function normalizeSchemaField(value: unknown): OpensteerSchemaField | null {
     };
   }
 
-  const element = Number(raw.element);
-  if (!Number.isInteger(element) || element < 1) {
-    throw new Error(
-      `Extraction field element must be a positive integer, received ${String(raw.element)}.`,
-    );
-  }
-
   return {
-    element,
+    counter: normalizeExtractionCounter(raw.c ?? raw.element),
     ...(attribute === undefined ? {} : { attribute }),
   };
+}
+
+function normalizeExtractionCounter(value: unknown): number {
+  const counter = Number(value);
+  if (!Number.isInteger(counter) || counter < 1) {
+    throw new Error(
+      `Extraction field counter must be a positive integer, received ${String(value)}.`,
+    );
+  }
+  return counter;
 }
 
 function normalizeNamespace(namespace: string | undefined): string {
@@ -946,7 +995,11 @@ export function parseExtractionDescriptorRecord(
       kind: "dom-extraction",
       persist: raw.persist,
       root,
-      ...(typeof raw.schemaHash === "string" ? { schemaHash: raw.schemaHash } : {}),
+      ...(typeof raw.templateHash === "string"
+        ? { templateHash: raw.templateHash }
+        : typeof raw.schemaHash === "string"
+          ? { templateHash: raw.schemaHash }
+          : {}),
       ...(typeof raw.sourceUrl === "string" ? { sourceUrl: raw.sourceUrl } : {}),
     },
   };
@@ -1056,7 +1109,7 @@ class FilesystemOpensteerExtractionDescriptorStore implements OpensteerExtractio
   async write(input: {
     readonly persist: string;
     readonly root: PersistedOpensteerExtractionPayload;
-    readonly schemaHash?: string;
+    readonly templateHash?: string;
     readonly sourceUrl?: string;
     readonly createdAt?: number;
     readonly updatedAt?: number;
@@ -1065,7 +1118,7 @@ class FilesystemOpensteerExtractionDescriptorStore implements OpensteerExtractio
       kind: "dom-extraction",
       persist: input.persist,
       root: input.root,
-      ...(input.schemaHash === undefined ? {} : { schemaHash: input.schemaHash }),
+      ...(input.templateHash === undefined ? {} : { templateHash: input.templateHash }),
       ...(input.sourceUrl === undefined ? {} : { sourceUrl: input.sourceUrl }),
     };
     const key = persistKey(this.namespace, input.persist);
@@ -1120,7 +1173,7 @@ class MemoryOpensteerExtractionDescriptorStore implements OpensteerExtractionDes
   async write(input: {
     readonly persist: string;
     readonly root: PersistedOpensteerExtractionPayload;
-    readonly schemaHash?: string;
+    readonly templateHash?: string;
     readonly sourceUrl?: string;
     readonly createdAt?: number;
     readonly updatedAt?: number;
@@ -1129,7 +1182,7 @@ class MemoryOpensteerExtractionDescriptorStore implements OpensteerExtractionDes
       kind: "dom-extraction",
       persist: input.persist,
       root: input.root,
-      ...(input.schemaHash === undefined ? {} : { schemaHash: input.schemaHash }),
+      ...(input.templateHash === undefined ? {} : { templateHash: input.templateHash }),
       ...(input.sourceUrl === undefined ? {} : { sourceUrl: input.sourceUrl }),
     };
     const key = persistKey(this.namespace, input.persist);

--- a/packages/runtime-core/src/sdk/extraction.ts
+++ b/packages/runtime-core/src/sdk/extraction.ts
@@ -25,7 +25,7 @@ import {
 } from "./extraction-data-path.js";
 
 interface OpensteerTemplateFieldByCounter {
-  readonly counter: number;
+  readonly c: number;
   readonly attribute?: string;
 }
 
@@ -158,12 +158,6 @@ export function assertValidOpensteerExtractionTemplateRoot(template: unknown): a
   }
 }
 
-export function assertValidOpensteerExtractionSchemaRoot(schema: unknown): asserts schema is {
-  readonly [key: string]: OpensteerTemplateNode;
-} {
-  assertValidOpensteerExtractionTemplateRoot(schema);
-}
-
 export function isPersistedOpensteerExtractionValueNode(
   value: unknown,
 ): value is PersistedOpensteerExtractionValueNode {
@@ -198,21 +192,14 @@ export async function compileOpensteerExtractionPayload(
   options: {
     readonly pageRef: PageRef;
     readonly dom: DomRuntime;
-  } & (
-    | {
-        readonly template: Record<string, unknown>;
-      }
-    | {
-        readonly schema: Record<string, unknown>;
-      }
-  ),
+    readonly template: Readonly<Record<string, unknown>>;
+  },
 ): Promise<PersistedOpensteerExtractionPayload> {
-  const template = readExtractionTemplate(options);
-  assertValidOpensteerExtractionTemplateRoot(template);
+  assertValidOpensteerExtractionTemplateRoot(options.template);
   const fieldTargets = await compileOpensteerExtractionFieldTargets({
     dom: options.dom,
     pageRef: options.pageRef,
-    template,
+    template: options.template,
   });
   return compilePersistedOpensteerExtractionPayloadFromFieldTargets({
     pageRef: options.pageRef,
@@ -225,22 +212,15 @@ export async function compileOpensteerExtractionFieldTargets(
   options: {
     readonly pageRef: PageRef;
     readonly dom: DomRuntime;
-  } & (
-    | {
-        readonly template: Record<string, unknown>;
-      }
-    | {
-        readonly schema: Record<string, unknown>;
-      }
-  ),
+    readonly template: Readonly<Record<string, unknown>>;
+  },
 ): Promise<readonly OpensteerExtractionFieldTarget[]> {
-  const template = readExtractionTemplate(options);
-  assertValidOpensteerExtractionTemplateRoot(template);
+  assertValidOpensteerExtractionTemplateRoot(options.template);
   const fields: OpensteerExtractionFieldTarget[] = [];
   await collectFieldTargetsFromTemplateObject({
     dom: options.dom,
     pageRef: options.pageRef,
-    value: template,
+    value: options.template,
     path: "",
     fields,
     insideArray: false,
@@ -316,22 +296,10 @@ export function createOpensteerExtractionDescriptorStore(options: {
   return new MemoryOpensteerExtractionDescriptorStore(namespace);
 }
 
-function readExtractionTemplate(
-  options:
-    | {
-        readonly template: Record<string, unknown>;
-      }
-    | {
-        readonly schema: Record<string, unknown>;
-      },
-): Record<string, unknown> {
-  return "template" in options ? options.template : options.schema;
-}
-
 async function collectFieldTargetsFromTemplateObject(options: {
   readonly dom: DomRuntime;
   readonly pageRef: PageRef;
-  readonly value: Record<string, unknown>;
+  readonly value: Readonly<Record<string, unknown>>;
   readonly path: string;
   readonly fields: OpensteerExtractionFieldTarget[];
   readonly insideArray: boolean;
@@ -407,7 +375,7 @@ async function collectFieldTargetsFromTemplateValue(options: {
       const itemFields = options.fields.slice(fieldCountBeforeItem);
       if (!itemFields.some((field) => !("source" in field))) {
         throw new Error(
-          `Extraction array "${labelForPath(options.path)}" item ${String(index)} must include at least one counter- or selector-backed field.`,
+          `Extraction array "${labelForPath(options.path)}" item ${String(index)} must include at least one element number or selector field.`,
         );
       }
     }
@@ -460,7 +428,7 @@ async function compileFieldTarget(options: {
     path: await resolveSelectorFieldPath({
       dom: options.dom,
       pageRef: options.pageRef,
-      selector: `[c="${String(options.field.counter)}"]`,
+      selector: `[c="${String(options.field.c)}"]`,
     }),
     ...(options.field.attribute === undefined ? {} : { attribute: options.field.attribute }),
   };
@@ -897,7 +865,7 @@ function countNonNullLeaves(value: JsonValue): number {
 function normalizeTemplateField(value: unknown): OpensteerTemplateField | null {
   if (typeof value === "number") {
     return {
-      counter: normalizeExtractionCounter(value),
+      c: normalizeExtractionCounter(value),
     };
   }
 
@@ -943,7 +911,7 @@ function normalizeTemplateField(value: unknown): OpensteerTemplateField | null {
   }
 
   return {
-    counter: normalizeExtractionCounter(raw.c ?? raw.element),
+    c: normalizeExtractionCounter(raw.c ?? raw.element),
     ...(attribute === undefined ? {} : { attribute }),
   };
 }
@@ -952,7 +920,7 @@ function normalizeExtractionCounter(value: unknown): number {
   const counter = Number(value);
   if (!Number.isInteger(counter) || counter < 1) {
     throw new Error(
-      `Extraction field counter must be a positive integer, received ${String(value)}.`,
+      `Extraction element number must be a positive integer, received ${String(value)}.`,
     );
   }
   return counter;

--- a/packages/runtime-core/src/sdk/runtime.ts
+++ b/packages/runtime-core/src/sdk/runtime.ts
@@ -178,7 +178,7 @@ import { NetworkHistory } from "../network/history.js";
 import type { SavedNetworkQueryInput } from "../network/saved-store.js";
 import { executeMatchedTlsTransportRequest as executeMatchedTlsTransportRequestWithCurl } from "../requests/execution/matched-tls/index.js";
 import {
-  assertValidOpensteerExtractionSchemaRoot,
+  assertValidOpensteerExtractionTemplateRoot,
   compileOpensteerExtractionFieldTargets,
   compilePersistedOpensteerExtractionPayloadFromFieldTargets,
   createOpensteerExtractionDescriptorStore,
@@ -1151,12 +1151,12 @@ export class OpensteerSessionRuntime {
         async (timeout) => {
           let descriptor: OpensteerExtractionDescriptorRecord | undefined;
           let data: JsonValue;
-          if (input.schema !== undefined) {
-            assertValidOpensteerExtractionSchemaRoot(input.schema);
+          if (input.template !== undefined) {
+            assertValidOpensteerExtractionTemplateRoot(input.template);
             const fieldTargets = await timeout.runStep(() =>
               compileOpensteerExtractionFieldTargets({
                 pageRef,
-                schema: input.schema as Record<string, unknown>,
+                template: input.template as Record<string, unknown>,
                 dom: this.requireDom(),
               }),
             );
@@ -1188,7 +1188,7 @@ export class OpensteerSessionRuntime {
                 descriptors.write({
                   persist,
                   root: payload,
-                  schemaHash: canonicalJsonString(input.schema),
+                  templateHash: canonicalJsonString(input.template),
                   sourceUrl: pageInfo.url,
                 }),
               );
@@ -1250,9 +1250,9 @@ export class OpensteerSessionRuntime {
         artifacts,
         data: {
           ...(input.persist === undefined ? {} : { persist: input.persist }),
-          ...(descriptor?.payload.schemaHash === undefined
+          ...(descriptor?.payload.templateHash === undefined
             ? {}
-            : { schemaHash: descriptor.payload.schemaHash }),
+            : { templateHash: descriptor.payload.templateHash }),
           data: output.data,
         },
         context: buildRuntimeTraceContext({

--- a/packages/runtime-core/src/sdk/snapshot/cleaner.ts
+++ b/packages/runtime-core/src/sdk/snapshot/cleaner.ts
@@ -439,7 +439,10 @@ function serializeForExtraction($: CheerioAPI, root: AnyNode): string {
   }
 
   traverse(root, 0);
-  return lines.join("\n");
+  return lines
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+    .join("");
 }
 
 function isClickable($: CheerioAPI, el: Cheerio<Element>, context: ClickableContext): boolean {

--- a/packages/runtime-core/src/sdk/snapshot/cleaner.ts
+++ b/packages/runtime-core/src/sdk/snapshot/cleaner.ts
@@ -22,10 +22,19 @@ import {
 const STRIP_TAGS = new Set(["script", "style", "noscript", "meta", "link", "template"]);
 
 const TEXT_ATTR_MAX = 150;
-const URL_ATTR_MAX = 500;
-const URL_ATTRS = new Set(["href", "src", "srcset"]);
+const SRCSET_ATTR_MAX = 160;
+const MIDDLE_TRUNCATED_URL_ATTRS = new Set(["href", "src"]);
 const TEXT_ATTRS = new Set(["alt", "title", "aria-label", "placeholder", "value"]);
-const TRUNCATION_SUFFIX = " [truncated]";
+const TRUNCATION_SUFFIX = "...";
+const MIDDLE_TRUNCATION_MARKER = "...";
+const MIDDLE_TRUNCATION_HEAD_MAX = 40;
+const MIDDLE_TRUNCATION_TAIL_MAX = 20;
+const SRCSET_CANDIDATE_HEAD_MAX = 36;
+const SRCSET_CANDIDATE_TAIL_MAX = 12;
+const SRCSET_COMPACT_CANDIDATE_HEAD_MAX = 20;
+const SRCSET_COMPACT_CANDIDATE_TAIL_MAX = 8;
+const SRCSET_FALLBACK_HEAD_MAX = 56;
+const SRCSET_FALLBACK_TAIL_MAX = 20;
 
 const NOISE_SELECTORS = [
   `[${OPENSTEER_HIDDEN_ATTR}]`,
@@ -36,6 +45,13 @@ const NOISE_SELECTORS = [
 
 interface ClickableContext {
   readonly hasPreMarked: boolean;
+}
+
+interface SrcsetCandidateSummary {
+  readonly url: string;
+  readonly descriptorText: string;
+  readonly width: number | null;
+  readonly density: number | null;
 }
 
 function compactHtml(html: string): string {
@@ -116,9 +132,64 @@ function truncateValue(value: string, max: number): string {
   return `${head}${TRUNCATION_SUFFIX}`;
 }
 
+function takeValueWithinSerializedLengthFromEnd(value: string, max: number): string {
+  let serializedLength = 0;
+  const chars: string[] = [];
+
+  for (let index = value.length - 1; index >= 0; index -= 1) {
+    const char = value[index];
+    if (char === undefined) {
+      continue;
+    }
+
+    let nextLength = 1;
+    if (char === "&") {
+      nextLength = 5;
+    } else if (char === "<" || char === ">") {
+      nextLength = 4;
+    } else if (char === '"') {
+      nextLength = 6;
+    }
+
+    if (serializedLength + nextLength > max) {
+      break;
+    }
+
+    chars.push(char);
+    serializedLength += nextLength;
+  }
+
+  return chars.reverse().join("");
+}
+
+function truncateValueInMiddle(
+  value: string,
+  headMax: number,
+  tailMax: number,
+  marker: string = MIDDLE_TRUNCATION_MARKER,
+): string {
+  const markerLength = getSerializedLength(marker);
+  const max = headMax + markerLength + tailMax;
+  if (getSerializedLength(value) <= max) {
+    return value;
+  }
+
+  const head = takeValueWithinSerializedLength(value, headMax).replace(/\s+$/u, "");
+  const tail = takeValueWithinSerializedLengthFromEnd(value, tailMax).replace(/^\s+/u, "");
+
+  if (head.length === 0) {
+    return tail.length === 0 ? marker : `${marker}${tail}`;
+  }
+  if (tail.length === 0) {
+    return `${head}${marker}`;
+  }
+
+  return `${head}${marker}${tail}`;
+}
+
 function getAttrLimit(attr: string): number | undefined {
-  if (URL_ATTRS.has(attr)) {
-    return URL_ATTR_MAX;
+  if (attr === "srcset") {
+    return SRCSET_ATTR_MAX;
   }
   if (TEXT_ATTRS.has(attr)) {
     return TEXT_ATTR_MAX;
@@ -126,9 +197,291 @@ function getAttrLimit(attr: string): number | undefined {
   return undefined;
 }
 
+function shouldBoundAttr(attr: string): boolean {
+  return MIDDLE_TRUNCATED_URL_ATTRS.has(attr) || getAttrLimit(attr) !== undefined;
+}
+
 function setBoundedAttr(el: Cheerio<Element>, attr: string, value: string): void {
+  if (MIDDLE_TRUNCATED_URL_ATTRS.has(attr)) {
+    el.attr(
+      attr,
+      truncateValueInMiddle(value, MIDDLE_TRUNCATION_HEAD_MAX, MIDDLE_TRUNCATION_TAIL_MAX),
+    );
+    return;
+  }
+
   const limit = getAttrLimit(attr);
+  if (attr === "srcset" && limit !== undefined) {
+    el.attr(attr, truncateSrcsetValue(value, limit));
+    return;
+  }
+
   el.attr(attr, limit === undefined ? value : truncateValue(value, limit));
+}
+
+function truncateSrcsetValue(value: string, max: number): string {
+  if (getSerializedLength(value) <= max) {
+    return value;
+  }
+
+  const candidates = parseSrcsetCandidates(value);
+  if (candidates.length === 0) {
+    return truncateValueInMiddle(value, SRCSET_FALLBACK_HEAD_MAX, SRCSET_FALLBACK_TAIL_MAX);
+  }
+
+  for (const [headMax, tailMax, includeBest] of [
+    [SRCSET_CANDIDATE_HEAD_MAX, SRCSET_CANDIDATE_TAIL_MAX, true],
+    [SRCSET_COMPACT_CANDIDATE_HEAD_MAX, SRCSET_COMPACT_CANDIDATE_TAIL_MAX, true],
+    [SRCSET_COMPACT_CANDIDATE_HEAD_MAX, SRCSET_COMPACT_CANDIDATE_TAIL_MAX, false],
+  ] as const) {
+    const compact = buildTruncatedSrcsetValue(candidates, headMax, tailMax, includeBest);
+    if (getSerializedLength(compact) <= max) {
+      return compact;
+    }
+  }
+
+  return truncateValueInMiddle(value, SRCSET_FALLBACK_HEAD_MAX, SRCSET_FALLBACK_TAIL_MAX);
+}
+
+function buildTruncatedSrcsetValue(
+  candidates: readonly SrcsetCandidateSummary[],
+  headMax: number,
+  tailMax: number,
+  includeBest: boolean,
+): string {
+  const kept = getPreferredSrcsetCandidateIndices(candidates, includeBest);
+  const parts: string[] = [];
+
+  for (let index = 0; index < kept.length; index += 1) {
+    const candidateIndex = kept[index];
+    if (candidateIndex === undefined) {
+      continue;
+    }
+
+    const previousIndex = index > 0 ? kept[index - 1] : undefined;
+    if (previousIndex !== undefined && candidateIndex - previousIndex > 1) {
+      parts.push(MIDDLE_TRUNCATION_MARKER);
+    }
+
+    const candidate = candidates[candidateIndex];
+    if (!candidate) {
+      continue;
+    }
+
+    parts.push(formatSrcsetCandidate(candidate, headMax, tailMax));
+  }
+
+  return parts.join(", ");
+}
+
+function getPreferredSrcsetCandidateIndices(
+  candidates: readonly SrcsetCandidateSummary[],
+  includeBest: boolean,
+): number[] {
+  if (candidates.length === 0) {
+    return [];
+  }
+
+  const kept = new Set<number>([0, candidates.length - 1]);
+  if (includeBest) {
+    kept.add(pickBestSrcsetCandidateIndex(candidates));
+  }
+
+  return [...kept].filter((index) => index >= 0 && index < candidates.length).sort((a, b) => a - b);
+}
+
+function pickBestSrcsetCandidateIndex(candidates: readonly SrcsetCandidateSummary[]): number {
+  let bestWidthIndex = -1;
+  let bestWidth = -1;
+  let bestDensityIndex = -1;
+  let bestDensity = -1;
+
+  for (let index = 0; index < candidates.length; index += 1) {
+    const candidate = candidates[index];
+    if (!candidate) {
+      continue;
+    }
+
+    if (
+      typeof candidate.width === "number" &&
+      Number.isFinite(candidate.width) &&
+      candidate.width > bestWidth
+    ) {
+      bestWidth = candidate.width;
+      bestWidthIndex = index;
+    }
+
+    if (
+      typeof candidate.density === "number" &&
+      Number.isFinite(candidate.density) &&
+      candidate.density > bestDensity
+    ) {
+      bestDensity = candidate.density;
+      bestDensityIndex = index;
+    }
+  }
+
+  if (bestWidthIndex >= 0) {
+    return bestWidthIndex;
+  }
+  if (bestDensityIndex >= 0) {
+    return bestDensityIndex;
+  }
+
+  return candidates.length - 1;
+}
+
+function formatSrcsetCandidate(
+  candidate: SrcsetCandidateSummary,
+  headMax: number,
+  tailMax: number,
+): string {
+  const url = truncateValueInMiddle(candidate.url, headMax, tailMax);
+  return candidate.descriptorText ? `${url} ${candidate.descriptorText}` : url;
+}
+
+function parseSrcsetCandidates(raw: string): SrcsetCandidateSummary[] {
+  const text = String(raw || "").trim();
+  if (!text) {
+    return [];
+  }
+
+  const out: SrcsetCandidateSummary[] = [];
+  let index = 0;
+
+  while (index < text.length) {
+    index = skipSrcsetSeparators(text, index);
+    if (index >= text.length) {
+      break;
+    }
+
+    const urlToken = readSrcsetUrlToken(text, index);
+    index = urlToken.nextIndex;
+    const url = urlToken.value.trim();
+    if (!url) {
+      continue;
+    }
+
+    index = skipSrcsetWhitespace(text, index);
+    const descriptors: string[] = [];
+    while (index < text.length && text[index] !== ",") {
+      const descriptorToken = readSrcsetDescriptorToken(text, index);
+      if (!descriptorToken.value) {
+        index = descriptorToken.nextIndex;
+        continue;
+      }
+      descriptors.push(descriptorToken.value);
+      index = descriptorToken.nextIndex;
+      index = skipSrcsetWhitespace(text, index);
+    }
+    if (index < text.length && text[index] === ",") {
+      index += 1;
+    }
+
+    let width: number | null = null;
+    let density: number | null = null;
+    for (const descriptor of descriptors) {
+      const token = descriptor.trim().toLowerCase();
+      if (!token) {
+        continue;
+      }
+
+      const widthMatch = token.match(/^(\d+)w$/);
+      if (widthMatch) {
+        const parsed = Number.parseInt(widthMatch[1]!, 10);
+        if (Number.isFinite(parsed)) {
+          width = parsed;
+        }
+        continue;
+      }
+
+      const densityMatch = token.match(/^(\d*\.?\d+)x$/);
+      if (densityMatch) {
+        const parsed = Number.parseFloat(densityMatch[1]!);
+        if (Number.isFinite(parsed)) {
+          density = parsed;
+        }
+      }
+    }
+
+    out.push({
+      url,
+      descriptorText: descriptors.join(" "),
+      width,
+      density,
+    });
+  }
+
+  return out;
+}
+
+function skipSrcsetWhitespace(value: string, index: number): number {
+  let cursor = index;
+  while (cursor < value.length && /\s/u.test(value[cursor]!)) {
+    cursor += 1;
+  }
+  return cursor;
+}
+
+function skipSrcsetSeparators(value: string, index: number): number {
+  let cursor = skipSrcsetWhitespace(value, index);
+  while (cursor < value.length && value[cursor] === ",") {
+    cursor += 1;
+    cursor = skipSrcsetWhitespace(value, cursor);
+  }
+  return cursor;
+}
+
+function readSrcsetUrlToken(value: string, index: number): { value: string; nextIndex: number } {
+  let cursor = index;
+  let out = "";
+  const isDataUrl = value
+    .slice(index, index + 5)
+    .toLowerCase()
+    .startsWith("data:");
+
+  while (cursor < value.length) {
+    const char = value[cursor]!;
+    if (/\s/u.test(char)) {
+      break;
+    }
+    if (char === "," && !isDataUrl) {
+      break;
+    }
+    out += char;
+    cursor += 1;
+  }
+
+  if (isDataUrl && out.endsWith(",") && cursor < value.length) {
+    out = out.slice(0, -1);
+  }
+
+  return {
+    value: out,
+    nextIndex: cursor,
+  };
+}
+
+function readSrcsetDescriptorToken(
+  value: string,
+  index: number,
+): { value: string; nextIndex: number } {
+  let cursor = skipSrcsetWhitespace(value, index);
+  let out = "";
+
+  while (cursor < value.length) {
+    const char = value[cursor]!;
+    if (char === "," || /\s/u.test(char)) {
+      break;
+    }
+    out += char;
+    cursor += 1;
+  }
+
+  return {
+    value: out.trim(),
+    nextIndex: cursor,
+  };
 }
 
 function removeNoise($: CheerioAPI): void {
@@ -161,39 +514,76 @@ function markInlineSelfHiddenFallback($: CheerioAPI): void {
 }
 
 function pruneSelfHiddenNodes($: CheerioAPI): void {
-  const nodes: Cheerio<Element>[] = [];
-  $(`[${OPENSTEER_SELF_HIDDEN_ATTR}]`).each(function collectSelfHiddenNodes() {
-    nodes.push($(this as Element));
-  });
-  nodes.sort((left, right) => right.parents().length - left.parents().length);
-
-  for (const el of nodes) {
-    if (!el[0]) {
+  for (const node of getElementsInReverseDocumentOrder($)) {
+    if (node.attribs?.[OPENSTEER_SELF_HIDDEN_ATTR] === undefined) {
       continue;
     }
 
+    const el = $(node);
     el.contents().each(function removeSelfHiddenText(this: AnyNode) {
       if (this.type === "text") {
         $(this).remove();
       }
     });
 
-    if (el.children().length === 0) {
+    if (!hasElementChildren(node)) {
       el.remove();
     }
   }
 }
 
-function hasDirectText($: CheerioAPI, el: Cheerio<Element>): boolean {
-  return (
-    el.contents().filter(function hasDirectNodeText(this: AnyNode) {
-      return this.type === "text" && $(this).text().trim() !== "";
-    }).length > 0
-  );
+function getChildNodes(node: AnyNode | undefined): readonly AnyNode[] {
+  return (node as { readonly children?: readonly AnyNode[] } | undefined)?.children ?? [];
 }
 
-function hasTextDeep(el: Cheerio<Element>): boolean {
-  return el.text().trim().length > 0;
+function isElementLikeNode(node: AnyNode | undefined): node is Element {
+  return node?.type === "tag" || node?.type === "script" || node?.type === "style";
+}
+
+function hasDirectText(node: Element | undefined): boolean {
+  if (!node) {
+    return false;
+  }
+
+  for (const child of getChildNodes(node)) {
+    if (child.type === "text" && ((child as { readonly data?: string }).data || "").trim() !== "") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasElementChildren(node: Element | undefined): boolean {
+  if (!node) {
+    return false;
+  }
+
+  for (const child of getChildNodes(node)) {
+    if (isElementLikeNode(child)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasTextDeepNode(node: AnyNode | undefined): boolean {
+  if (!node) {
+    return false;
+  }
+
+  if (node.type === "text") {
+    return ((node as { readonly data?: string }).data || "").trim() !== "";
+  }
+
+  for (const child of getChildNodes(node)) {
+    if (hasTextDeepNode(child)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function hasActionLabel(attrs: Record<string, string | undefined>): boolean {
@@ -208,7 +598,7 @@ function hasActionLabel(attrs: Record<string, string | undefined>): boolean {
 }
 
 function unwrapActionNode($: CheerioAPI, el: Cheerio<Element>): void {
-  if (hasTextDeep(el)) {
+  if (hasTextDeepNode(el[0])) {
     if (el.prev().length > 0) {
       el.before(" ");
     }
@@ -233,7 +623,7 @@ function stripToAttrs(el: Cheerio<Element>, keep: Set<string>): void {
       continue;
     }
 
-    if (getAttrLimit(attr) !== undefined) {
+    if (shouldBoundAttr(attr)) {
       setBoundedAttr(el, attr, value);
     }
   }
@@ -256,6 +646,12 @@ function deduplicateImages(html: string): string {
   const seen = new Set<string>();
 
   return html.replace(/<img\b([^>]*)>/gi, (full, attrContent) => {
+    // Counter-tagged elements are distinct tracked elements — never deduplicate by src.
+    // src values may be middle-truncated, making different images appear identical.
+    if (/\bc\s*=/.test(attrContent)) {
+      return full;
+    }
+
     const srcMatch = attrContent.match(/\bsrc\s*=\s*(["']?)(.*?)\1/);
     const srcsetMatch = attrContent.match(/\bsrcset\s*=\s*(["'])(.*?)\1/);
 
@@ -278,72 +674,215 @@ function deduplicateImages(html: string): string {
   });
 }
 
-function isPreservedImageElement($: CheerioAPI, el: Cheerio<Element>): boolean {
-  const tag = ((el[0] as Element | undefined)?.tagName || "").toLowerCase();
+function hasAttribute(node: Element | undefined, attr: string): boolean {
+  return node?.attribs?.[attr] !== undefined;
+}
+
+function hasPictureAncestor(node: Element | undefined): boolean {
+  let current = node?.parent;
+  while (current) {
+    if (isElementLikeNode(current) && (current.tagName || "").toLowerCase() === "picture") {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+function pictureHasPreservedDescendant(node: Element | undefined): boolean {
+  if (!node) {
+    return false;
+  }
+
+  for (const child of getChildNodes(node)) {
+    if (!isElementLikeNode(child)) {
+      continue;
+    }
+
+    const tag = (child.tagName || "").toLowerCase();
+    if (tag === "img") {
+      return true;
+    }
+    if (
+      tag === "source" &&
+      typeof child.attribs?.src === "string" &&
+      child.attribs.src.trim() !== ""
+    ) {
+      return true;
+    }
+    if (
+      tag === "source" &&
+      typeof child.attribs?.srcset === "string" &&
+      child.attribs.srcset.trim() !== ""
+    ) {
+      return true;
+    }
+    if (pictureHasPreservedDescendant(child)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isPreservedImageElement(node: Element | undefined): boolean {
+  const tag = (node?.tagName || "").toLowerCase();
   if (tag === "img") {
     return true;
   }
 
   if (tag === "picture") {
-    const hasImg = el.find("img").length > 0;
-    const hasSource = el.find("source[src], source[srcset]").length > 0;
-    return hasImg || hasSource;
+    return pictureHasPreservedDescendant(node);
   }
 
   if (tag === "source") {
-    const inPicture = el.parents("picture").length > 0;
+    const inPicture = hasPictureAncestor(node);
     const hasSrc =
-      (el.attr("src") != null && el.attr("src")!.trim() !== "") ||
-      (el.attr("srcset") != null && el.attr("srcset")!.trim() !== "");
+      (typeof node?.attribs?.src === "string" && node.attribs.src.trim() !== "") ||
+      (typeof node?.attribs?.srcset === "string" && node.attribs.srcset.trim() !== "");
     return inPicture && hasSrc;
   }
 
   return false;
 }
 
+function getElementsInReverseDocumentOrder($: CheerioAPI): Element[] {
+  return $.root()
+    .find("*")
+    .toArray()
+    .reverse()
+    .filter((node): node is Element => node.type === "tag");
+}
+
+function getNodeDepth(node: AnyNode): number {
+  let depth = 0;
+  let current = node.parent;
+  while (current) {
+    depth++;
+    current = current.parent;
+  }
+  return depth;
+}
+
+function getElementsByDepthDescending($: CheerioAPI): Element[] {
+  const elements = $.root()
+    .find("*")
+    .toArray()
+    .filter((node): node is Element => node.type === "tag");
+
+  const depths = new Map<Element, number>();
+  for (const el of elements) {
+    depths.set(el, getNodeDepth(el));
+  }
+
+  return elements.sort((a, b) => (depths.get(b) ?? 0) - (depths.get(a) ?? 0));
+}
+
 function flattenExtractionTree($: CheerioAPI): void {
-  const flatten = (root: Cheerio<AnyNode>): void => {
-    root.find("*").each(function flattenNode() {
-      const el = $(this as Element);
-      const node = el[0];
-      if (!node) {
-        return;
-      }
+  for (const node of getElementsInReverseDocumentOrder($)) {
+    const el = $(node);
+    const tag = (node.tagName || "").toLowerCase();
+    if (ROOT_TAGS.has(tag) || isBoundaryTag(tag) || isPreservedImageElement(node)) {
+      continue;
+    }
 
-      const tag = (node.tagName || "").toLowerCase();
-      if (ROOT_TAGS.has(tag) || isBoundaryTag(tag)) {
-        return;
-      }
+    if (tag === "a" || hasDirectText(node)) {
+      continue;
+    }
 
-      if (isPreservedImageElement($, el)) {
-        return;
-      }
+    if (!hasElementChildren(node)) {
+      el.remove();
+      continue;
+    }
 
-      if (tag === "a") {
-        el.children().each(function flattenAnchorChild() {
-          flatten($(this as Element));
-        });
-        return;
-      }
+    el.replaceWith(el.contents());
+  }
+}
 
-      const hasText = hasDirectText($, el);
-      if (hasText) {
-        return;
-      }
+function hasMarkedAncestor(el: Cheerio<Element>, attr: string): boolean {
+  let current = el[0]?.parent;
+  while (current) {
+    if (!isElementLikeNode(current)) {
+      return false;
+    }
+    if (current.attribs?.[attr] !== undefined) {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
+}
 
-      if (el.children().length === 0) {
-        el.remove();
-        return;
-      }
+function isIndicatorImage(node: Element | undefined): boolean {
+  return (
+    (node?.tagName || "").toLowerCase() === "img" &&
+    (hasAttribute(node, "alt") || hasAttribute(node, "src") || hasAttribute(node, "srcset"))
+  );
+}
 
-      el.children().each(function flattenChild() {
-        flatten($(this as Element));
-      });
-      el.replaceWith(el.contents());
-    });
+function isIndicatorPictureSource(node: Element | undefined): boolean {
+  return (
+    (node?.tagName || "").toLowerCase() === "source" &&
+    hasPictureAncestor(node) &&
+    (hasAttribute(node, "src") || hasAttribute(node, "srcset"))
+  );
+}
+
+function isSemanticIndicator(node: Element | undefined): boolean {
+  const tag = (node?.tagName || "").toLowerCase();
+  if (tag === "svg") {
+    return true;
+  }
+
+  return (
+    hasAttribute(node, "aria-label") ||
+    hasAttribute(node, "title") ||
+    hasAttribute(node, "data-icon") ||
+    node?.attribs?.role === "img"
+  );
+}
+
+function findIndicatorDescendant(root: Element | undefined): Element | undefined {
+  if (!root) {
+    return undefined;
+  }
+
+  let firstImage: Element | undefined;
+  let firstSource: Element | undefined;
+  let firstSemantic: Element | undefined;
+
+  const visit = (node: AnyNode): boolean => {
+    if (!isElementLikeNode(node)) {
+      return false;
+    }
+
+    if (isIndicatorImage(node)) {
+      firstImage = node;
+      return true;
+    }
+    if (firstSource === undefined && isIndicatorPictureSource(node)) {
+      firstSource = node;
+    }
+    if (firstSemantic === undefined && isSemanticIndicator(node)) {
+      firstSemantic = node;
+    }
+
+    for (const child of getChildNodes(node)) {
+      if (visit(child)) {
+        return true;
+      }
+    }
+
+    return false;
   };
 
-  flatten($.root());
+  for (const child of getChildNodes(root)) {
+    if (visit(child)) {
+      return firstImage;
+    }
+  }
+
+  return firstImage ?? firstSource ?? firstSemantic;
 }
 
 function serializeForExtraction($: CheerioAPI, root: AnyNode): string {
@@ -596,27 +1135,13 @@ export function cleanForAction(html: string): string {
   $(`[${clickableMark}]`).each(function markIndicators() {
     const el = $(this as Element);
     const wrapperAttrs = el.attr() || {};
-    if (hasTextDeep(el) || hasActionLabel(wrapperAttrs)) {
+    if (hasTextDeepNode(el[0]) || hasActionLabel(wrapperAttrs)) {
       return;
     }
 
-    const imageIndicator = el.find("img[alt], img[src], img[srcset]").first();
-    if (imageIndicator.length) {
-      imageIndicator.attr(indicatorMark, "1");
-      return;
-    }
-
-    const pictureSourceIndicator = el.find("picture source[src], picture source[srcset]").first();
-    if (pictureSourceIndicator.length) {
-      pictureSourceIndicator.attr(indicatorMark, "1");
-      return;
-    }
-
-    const semanticIndicator = el
-      .find('[aria-label], [title], [data-icon], [role="img"], svg')
-      .first();
-    if (semanticIndicator.length) {
-      semanticIndicator.attr(indicatorMark, "1");
+    const indicatorNode = findIndicatorDescendant(el[0]);
+    if (indicatorNode !== undefined) {
+      $(indicatorNode).attr(indicatorMark, "1");
     }
   });
 
@@ -627,7 +1152,7 @@ export function cleanForAction(html: string): string {
     if (NATIVE_INTERACTIVE_TAGS.has(tag) || tag === "a") {
       return;
     }
-    if (el.children().length > 0 || hasDirectText($, el)) {
+    if (hasElementChildren(node) || hasDirectText(node)) {
       return;
     }
 
@@ -659,53 +1184,36 @@ export function cleanForAction(html: string): string {
     }
   });
 
-  let changed = true;
-  while (changed) {
-    changed = false;
-    const nodes: Cheerio<Element>[] = [];
-    $("*").each(function collectNodes() {
-      nodes.push($(this as Element));
-    });
-    nodes.sort((left, right) => right.parents().length - left.parents().length);
+  for (const node of getElementsByDepthDescending($)) {
+    const el = $(node);
+    const tag = (node.tagName || "").toLowerCase();
+    if (ROOT_TAGS.has(tag) || isBoundaryTag(tag)) {
+      continue;
+    }
 
-    for (const el of nodes) {
-      const node = el[0];
-      if (!node) {
-        continue;
-      }
+    if (el.attr(clickableMark) !== undefined || el.attr(indicatorMark) !== undefined) {
+      continue;
+    }
 
-      const tag = (node.tagName || "").toLowerCase();
-      if (ROOT_TAGS.has(tag) || isBoundaryTag(tag)) {
-        continue;
-      }
+    const insideClickable = hasMarkedAncestor(el, clickableMark);
+    const preserveBranch = el.attr(branchMark) !== undefined;
+    const hasContent = hasElementChildren(node) || hasDirectText(node);
 
-      if (el.attr(clickableMark) !== undefined || el.attr(indicatorMark) !== undefined) {
-        continue;
-      }
-
-      const insideClickable = el.parents(`[${clickableMark}]`).length > 0;
-      const preserveBranch = el.attr(branchMark) !== undefined;
-      const hasContent = el.children().length > 0 || hasDirectText($, el);
-
-      if (insideClickable || preserveBranch) {
-        if (!hasContent) {
-          el.remove();
-        } else {
-          unwrapActionNode($, el);
-        }
-        changed = true;
-        continue;
-      }
-
+    if (insideClickable || preserveBranch) {
       if (!hasContent) {
         el.remove();
-        changed = true;
-        continue;
+      } else {
+        unwrapActionNode($, el);
       }
-
-      unwrapActionNode($, el);
-      changed = true;
+      continue;
     }
+
+    if (!hasContent) {
+      el.remove();
+      continue;
+    }
+
+    unwrapActionNode($, el);
   }
 
   $.root()
@@ -816,12 +1324,6 @@ export function cleanForAction(html: string): string {
         "placeholder",
         "value",
         "aria-label",
-        "aria-labelledby",
-        "aria-describedby",
-        "aria-expanded",
-        "aria-pressed",
-        "aria-selected",
-        "aria-haspopup",
       ]) {
         keep.add(attr);
       }

--- a/packages/runtime-core/src/sdk/snapshot/cleaner.ts
+++ b/packages/runtime-core/src/sdk/snapshot/cleaner.ts
@@ -137,10 +137,7 @@ function takeValueWithinSerializedLengthFromEnd(value: string, max: number): str
   const chars: string[] = [];
 
   for (let index = value.length - 1; index >= 0; index -= 1) {
-    const char = value[index];
-    if (char === undefined) {
-      continue;
-    }
+    const char = value[index]!;
 
     let nextLength = 1;
     if (char === "&") {
@@ -251,24 +248,15 @@ function buildTruncatedSrcsetValue(
 ): string {
   const kept = getPreferredSrcsetCandidateIndices(candidates, includeBest);
   const parts: string[] = [];
+  let previousIndex: number | undefined;
 
-  for (let index = 0; index < kept.length; index += 1) {
-    const candidateIndex = kept[index];
-    if (candidateIndex === undefined) {
-      continue;
-    }
-
-    const previousIndex = index > 0 ? kept[index - 1] : undefined;
+  for (const candidateIndex of kept) {
     if (previousIndex !== undefined && candidateIndex - previousIndex > 1) {
       parts.push(MIDDLE_TRUNCATION_MARKER);
     }
 
-    const candidate = candidates[candidateIndex];
-    if (!candidate) {
-      continue;
-    }
-
-    parts.push(formatSrcsetCandidate(candidate, headMax, tailMax));
+    parts.push(formatSrcsetCandidate(candidates[candidateIndex]!, headMax, tailMax));
+    previousIndex = candidateIndex;
   }
 
   return parts.join(", ");
@@ -297,10 +285,7 @@ function pickBestSrcsetCandidateIndex(candidates: readonly SrcsetCandidateSummar
   let bestDensity = -1;
 
   for (let index = 0; index < candidates.length; index += 1) {
-    const candidate = candidates[index];
-    if (!candidate) {
-      continue;
-    }
+    const candidate = candidates[index]!;
 
     if (
       typeof candidate.width === "number" &&
@@ -341,7 +326,7 @@ function formatSrcsetCandidate(
 }
 
 function parseSrcsetCandidates(raw: string): SrcsetCandidateSummary[] {
-  const text = String(raw || "").trim();
+  const text = raw.trim();
   if (!text) {
     return [];
   }
@@ -646,8 +631,6 @@ function deduplicateImages(html: string): string {
   const seen = new Set<string>();
 
   return html.replace(/<img\b([^>]*)>/gi, (full, attrContent) => {
-    // Counter-tagged elements are distinct tracked elements — never deduplicate by src.
-    // src values may be middle-truncated, making different images appear identical.
     if (/\bc\s*=/.test(attrContent)) {
       return full;
     }
@@ -1104,7 +1087,12 @@ export function cleanForExtraction(html: string): string {
   });
 
   flattenExtractionTree($clean);
-  return deduplicateImages(serializeForExtraction($clean, $clean.root()[0] as unknown as AnyNode));
+  const root = $clean.root()[0];
+  if (root === undefined) {
+    return "";
+  }
+
+  return deduplicateImages(serializeForExtraction($clean, root));
 }
 
 export function cleanForAction(html: string): string {

--- a/skills/opensteer/SKILL.md
+++ b/skills/opensteer/SKILL.md
@@ -6,25 +6,48 @@ argument-hint: "[goal]"
 
 # Opensteer
 
-Opensteer gives AI agents a real Chromium browser — local or cloud. Use it when normal code is not enough because the task depends on a live browser session.
+Opensteer gives AI agents a real Chromium browser. Use it when the task depends on a live browser session — clicks, forms, extraction, cookies, network capture, or browser-backed fetch.
 
-Default workflow:
+## Core Workflow
 
-1. CLI to explore the site and discover behavior.
-2. Save stable targets with `persist`.
-3. SDK to write the final reusable TypeScript.
+Follow this order. Do not skip steps.
 
-Do not stop at manual exploration if the user needs automation.
+1. **Open** a browser in a workspace.
+2. **Snapshot** to see the page and get element numbers.
+3. **Interact** using element numbers from the latest snapshot. Every action requires `--persist <key>`.
+4. **Re-snapshot** after navigation or UI changes before reusing element numbers.
+5. **Extract** data using a template with `--persist <key>`.
+6. **Write SDK code** that replays persisted targets — no templates in the SDK, only persist keys.
+7. **Close** the browser when done.
+
+```bash
+opensteer open https://example.com --workspace demo
+opensteer snapshot action --workspace demo
+opensteer input 5 "laptop" --workspace demo --press-enter --persist "search input"
+opensteer click 7 --workspace demo --persist "search button"
+opensteer snapshot extraction --workspace demo
+opensteer extract '{"items":[{"title":13,"price":14},{"title":22,"price":23},{"title":31,"price":32}]}' --workspace demo --persist "search results"
+```
+
+```ts
+import { Opensteer } from "opensteer";
+
+const opensteer = new Opensteer({ workspace: "demo", rootDir: process.cwd() });
+
+await opensteer.open("https://example.com");
+await opensteer.input({ persist: "search input", text: "laptop", pressEnter: true });
+await opensteer.click({ persist: "search button" });
+const data = await opensteer.extract({ persist: "search results" });
+await opensteer.close();
+```
 
 ## Setup
-
-Install the Opensteer skill so the coding agent can use it:
 
 ```bash
 opensteer skills install
 ```
 
-This registers the skill with the agent's tool system. Only needed once per environment.
+Only needed once per environment.
 
 ## When To Use
 
@@ -36,17 +59,6 @@ This registers the skill with the agent's tool system. Only needed once per envi
 - Need to reuse a real user's logged-in browser profile.
 
 If the user wants to manually drive a browser and record the flow, use the `recorder` skill instead.
-
-## Core Rules
-
-1. Always use a workspace for stateful commands: `--workspace <id>` or `OPENSTEER_WORKSPACE`.
-2. Re-snapshot after navigation or big UI changes before reusing element numbers.
-3. CLI to discover, SDK for the final implementation.
-4. Use `persist` for stable reusable targets and extraction payloads.
-5. Use `exec` for SDK code and API experiments. Use `evaluate` only for page-context JavaScript.
-6. If `fetch()` fails with auth errors, inspect `state()`, `cookies()`, and `storage()` before changing transport.
-7. Keep output simple. Prefer ordinary TypeScript with `Opensteer`, no extra abstraction.
-8. Close the browser when done. Do not leave headed browsers running. Use `opensteer browser delete --workspace <id>` or SDK cleanup when the session does not need to stay open.
 
 ## Choose A Path
 
@@ -67,26 +79,86 @@ What does the task need?
 
 Use this when the goal is clicking, typing, navigating, or extracting visible data.
 
-### CLI exploration
+### Persist is required
+
+Every `click`, `hover`, `input`, `scroll`, and `extract` command requires `--persist <key>`. This saves a stable element descriptor so the action is replayable across sessions. Name the key after what the element is:
 
 ```bash
-opensteer open https://example.com --workspace demo
-opensteer snapshot action --workspace demo
-opensteer input 5 "laptop" --workspace demo --press-enter --persist "search input"
 opensteer click 7 --workspace demo --persist "search button"
-opensteer snapshot extraction --workspace demo
-opensteer extract '{"items":[{"name":{"element":13},"price":{"element":14}}]}' \
-  --workspace demo \
-  --persist "search results"
+opensteer input 5 "laptop" --workspace demo --press-enter --persist "search input"
+opensteer scroll down 500 --workspace demo --persist "page scroll"
 ```
 
-Element numbers come from `c="N"` markers in the snapshot HTML.
+### Element numbers
+
+Element numbers come from `c="N"` markers in the snapshot HTML. They are only valid for the current snapshot. After navigation or DOM changes, snapshot again to get fresh numbers.
+
+```bash
+opensteer snapshot action --workspace demo      # for interactions
+opensteer snapshot extraction --workspace demo  # for data extraction
+```
+
+Read the full snapshot output. Do not pipe it through `head`, `grep`, or `sed` — filtering destroys the structural context you need to identify which elements belong to the same card.
+
+### Extraction templates
+
+The `extract` command takes a JSON template that describes the fields in one or more items. Opensteer merges the structural pattern across all provided examples and generalizes to every matching item on the page.
+
+**Template format:**
+
+- Bare number: `13` reads text content of element `c="13"`.
+- Object with attribute: `{"c": 13, "attr": "href"}` reads an attribute from that element.
+- Selector: `{"selector": "#price"}` targets by CSS selector.
+- Page source: `{"source": "current_url"}` reads page metadata.
+
+**How many items to include:**
+
+**Lazy — 3 items from 3 different positions (recommended for reusable SDK descriptors).** Give one entry per card for 3 different cards. Opensteer compares the 3 examples, cancels out position noise, and produces a descriptor that matches all similar items. Use this when the goal is a persist key the SDK can replay later.
+
+```bash
+opensteer extract '{
+  "products": [
+    {"title": 47, "price": 51, "url": {"c": 47, "attr": "href"}},
+    {"title": 62, "price": 66, "url": {"c": 62, "attr": "href"}},
+    {"title": 78, "price": 83, "url": {"c": 78, "attr": "href"}}
+  ]
+}' --workspace demo --persist "search results"
+```
+
+**Eager — all visible items (use when you need the full data immediately).** Include every item visible in the snapshot. This returns all data in one shot from the current session. The descriptor is still saved under `--persist` and can be replayed, but the generalization is weaker than the 3-item approach.
+
+```bash
+opensteer extract '{
+  "products": [
+    {"title": 47, "price": 51, "url": {"c": 47, "attr": "href"}},
+    {"title": 62, "price": 66, "url": {"c": 62, "attr": "href"}},
+    {"title": 78, "price": 83, "url": {"c": 78, "attr": "href"}},
+    ...continue for every visible card...
+  ]
+}' --workspace demo --persist "search results"
+```
+
+**Rule: all fields in each array entry must come from the same card.** Never take a field from card 1 and another field from card 2 within the same entry — that produces a broken descriptor.
+
+Wrong — title from card 1, price from card 2 mixed in the same entry:
+
+```bash
+# DO NOT DO THIS — fields across cards in one entry
+opensteer extract '{"products":[{"title":47,"price":66}]}' --workspace demo --persist "search results"
+```
+
+For non-array fields at the top level, point to the elements directly:
+
+```bash
+opensteer extract '{"pageTitle":3,"totalResults":8,"url":{"source":"current_url"}}' \
+  --workspace demo --persist "page metadata"
+```
 
 ### SDK implementation
 
-```ts
-import { Opensteer } from "opensteer";
+The SDK `extract()` method replays a previously persisted template. It does not accept inline templates — those belong in the CLI exploration phase.
 
+```ts
 const opensteer = new Opensteer({ workspace: "demo", rootDir: process.cwd() });
 
 await opensteer.open("https://example.com");
@@ -95,7 +167,7 @@ await opensteer.click({ persist: "search button" });
 const data = await opensteer.extract({ persist: "search results" });
 ```
 
-Use `selector` in SDK code only when a stable CSS selector is cleaner than `persist`.
+Use `selector` in SDK action code only when a stable CSS selector is cleaner than persist.
 
 ## Network Path
 
@@ -106,7 +178,7 @@ Use this when the goal is to find or replay a site API.
 ```bash
 opensteer open https://example.com --workspace demo
 opensteer goto https://example.com/search --workspace demo --capture-network page-load
-opensteer input 5 "laptop" --workspace demo --press-enter --capture-network search
+opensteer input 5 "laptop" --workspace demo --press-enter --persist "search input" --capture-network search
 opensteer network query --workspace demo --capture search --json
 opensteer network detail rec_123 --workspace demo --probe
 ```
@@ -174,10 +246,7 @@ Flags: `--inline`, `--external`, `--dynamic`, `--workers` to filter by source ty
 ### Beautify and deobfuscate
 
 ```bash
-# Format minified code
 opensteer scripts beautify <artifactId> --workspace demo --persist
-
-# Deobfuscate packed/obfuscated code
 opensteer scripts deobfuscate <artifactId> --workspace demo --persist
 ```
 
@@ -208,7 +277,7 @@ opensteer scripts sandbox art_ghi789 --workspace demo
 
 ## Computer-Use
 
-Use this only when DOM targeting is not enough.
+Use this only when DOM targeting is not enough — canvas, WebGL, or elements that cannot be reached by selector.
 
 ```bash
 opensteer computer click 245 380 --workspace demo --capture-network action
@@ -230,11 +299,10 @@ After coordinate-based actions, switch back to normal extraction or request anal
 Use when handling OAuth popups, multi-page flows, or any task that opens new tabs.
 
 ```bash
-opensteer tab list --workspace demo              # List all open tabs
-opensteer tab new https://example.com --workspace demo   # Open new tab
+opensteer tab list --workspace demo
+opensteer tab new https://example.com --workspace demo
 opensteer tab 2 --workspace demo                 # Switch to tab 2
-opensteer tab close 3 --workspace demo           # Close tab 3
-opensteer tab close --workspace demo             # Close current tab
+opensteer tab close 3 --workspace demo
 ```
 
 ```ts
@@ -250,11 +318,11 @@ Re-snapshot after switching tabs — element numbers are per-page.
 
 Each workspace has one browser. Three modes:
 
-| Mode                     | What it does                                    | Data persists?                                                        |
-| ------------------------ | ----------------------------------------------- | --------------------------------------------------------------------- |
-| **Persistent** (default) | Browser tied to workspace, survives restarts    | Yes — cookies, localStorage, logins, history, extensions all retained |
-| **Temporary**            | Headless browser in `/tmp`, cleaned up on close | No                                                                    |
-| **Attach**               | Connects to an already-running browser via CDP  | Depends on that browser                                               |
+| Mode | What it does | Data persists? |
+| --- | --- | --- |
+| **Persistent** (default) | Browser tied to workspace, survives restarts | Yes |
+| **Temporary** | Headless browser in `/tmp`, cleaned up on close | No |
+| **Attach** | Connects to an already-running browser via CDP | Depends on that browser |
 
 ### Headless vs headed
 
@@ -266,99 +334,69 @@ opensteer open https://example.com --workspace demo --headless false
 
 Use headed mode for debugging or when the user wants to watch. For hands-free automation, keep headless and use `opensteer view` if a human needs to observe.
 
-### Persistent sessions
-
-When you `opensteer open` with a workspace, the browser's full Chrome user-data directory lives at `~/.opensteer/workspaces/<id>/browser/user-data/`. Everything Chrome normally persists (cookies, localStorage, IndexedDB, history, extensions) survives between runs.
-
-Re-running `opensteer open --workspace demo` reconnects to the existing browser if it's still alive, or launches a fresh one with the same profile if it died.
-
 ### Profile cloning
 
 Clone a real user's Chrome profile to start a workspace with their logins already active:
 
 ```bash
-# Discover available local browsers and profiles
 opensteer browser discover
-
-# Clone a profile into a workspace
 opensteer browser clone --workspace demo \
   --source-user-data-dir "$HOME/Library/Application Support/Google/Chrome" \
   --source-profile-directory Default
 ```
 
-This copies cookies, localStorage, extensions, and settings from the source browser. Caches and lock files are skipped. The source browser does not need to be closed — cloning while running is safe.
-
-### Attach to an existing browser
-
-```bash
-opensteer open https://example.com --workspace demo --attach-endpoint http://localhost:9222
-```
+This copies cookies, localStorage, extensions, and settings. The source browser does not need to be closed.
 
 ### Workspace lifecycle
 
 ```bash
-opensteer browser status --workspace demo    # Check if browser is running
+opensteer browser status --workspace demo
 opensteer browser reset --workspace demo     # Wipe browser data, keep workspace
 opensteer browser delete --workspace demo    # Delete workspace entirely
 ```
 
 ## Cloud Mode
 
-Run the browser on Opensteer's cloud infrastructure instead of locally. Use cloud mode when you need browsers that run 24/7, or when the local machine should not run Chromium.
-
-### Setup
+Run the browser on Opensteer's cloud infrastructure instead of locally.
 
 ```bash
-export OPENSTEER_API_KEY=osk_your_key_here    # Required
-export OPENSTEER_PROVIDER=cloud               # Or use --provider cloud per command
+export OPENSTEER_API_KEY=osk_your_key_here
+export OPENSTEER_PROVIDER=cloud
 ```
-
-### Usage
 
 All CLI commands work the same with `--provider cloud`:
 
 ```bash
 opensteer open https://example.com --workspace demo --provider cloud
 opensteer snapshot action --workspace demo
-opensteer click 5 --workspace demo
+opensteer click 5 --workspace demo --persist "nav link"
 ```
 
-### Export local browser profile to cloud
-
-Sync a local browser's cookies to a cloud browser profile so the cloud session starts logged in:
+Export a local profile to cloud:
 
 ```bash
-# Reads cookies from local Chrome, decrypts them, uploads to cloud
 opensteer browser clone --workspace demo \
   --source-user-data-dir "$HOME/Library/Application Support/Google/Chrome" \
   --source-profile-directory Default \
   --provider cloud
 ```
 
-The cookies are extracted from the local SQLite database, decrypted, packaged into a portable format, and uploaded. The cloud browser then starts with those cookies applied.
-
 ## Local View
 
-When Opensteer runs headless, a human cannot see what the browser is doing. Local view streams live screenshots from headless sessions to a browser-based viewer.
+Stream live screenshots from headless sessions to a browser-based viewer.
 
 ```bash
 opensteer view                   # Start viewer service, print URL
 opensteer view stop              # Stop the viewer service
-opensteer view --auto            # Auto-start viewer on every browser launch
-opensteer view --no-auto         # Only start viewer when manually requested
+opensteer view --auto            # Auto-start on every browser launch
+opensteer view --no-auto         # Only start when manually requested
 ```
 
-The viewer is a local web UI that shows:
-
-- Live JPEG stream of the active browser tab
-- Tab bar with switching
-- Navigation controls (back, forward, reload, URL bar)
-
-Local view is a passive observer — it connects to the browser's existing CDP endpoint. Starting or stopping it has zero impact on running browser sessions.
+Local view is a passive observer. Starting or stopping it has zero impact on running sessions.
 
 ## Interaction Capture & Replay
 
-Record a trace of browser interactions (clicks, typing, network, DOM changes) and replay them deterministically. Useful for building repeatable test flows or comparing behavior across runs.
+Record browser interactions and replay them deterministically.
 
 ```bash
 opensteer interaction capture --workspace demo --key "login-flow" --duration 30000
@@ -375,14 +413,12 @@ Commands that use `--persist` save artifacts to the workspace. Read them back wi
 opensteer artifact read <artifactId> --workspace demo
 ```
 
-Artifacts are created by `extract --persist`, `scripts capture --persist`, `scripts beautify --persist`, and other persist-enabled commands.
-
-## Useful SDK Surface
+## SDK Surface
 
 - `open(url)`, `goto(url, { captureNetwork? })`, `close()`
 - `snapshot("action" | "extraction")`
 - `click()`, `hover()`, `input()`, `scroll()`
-- `extract()`
+- `extract({ persist })` — replay-only, no inline templates
 - `listPages()`, `newPage()`, `activatePage()`, `closePage()`
 - `network.query()`, `network.detail()`
 - `waitForPage()`
@@ -395,8 +431,13 @@ Artifacts are created by `extract --persist`, `scripts capture --persist`, `scri
 
 ## Guardrails
 
-- Snapshot before using element numbers. Snapshot again after UI changes.
+- Always snapshot before using element numbers. Snapshot again after UI changes.
+- Always include `--persist <key>` on click, hover, input, scroll, and extract.
+- Extraction templates: use 3 items from 3 different positions for reusable descriptors; use all visible items when you need the full data immediately. All fields in each array entry must come from the same card/row.
+- Do not pass templates to the SDK `extract()` — use persist keys only.
+- Re-snapshot after navigation before reusing element numbers.
 - Do not use `evaluate` for API work — use `exec` or `fetch`.
+- If `fetch()` fails with auth errors, check `state()`, `cookies()`, `storage()` first.
 - Do not keep the result as a manual-only workflow if the user needs reusable automation.
 - Prefer a small final script over a large framework.
 - Close browsers when done. Do not leave headed browser windows open.

--- a/tests/opensteer/cli-surface.test.ts
+++ b/tests/opensteer/cli-surface.test.ts
@@ -46,20 +46,36 @@ describe("CLI surface parsing", () => {
   });
 
   test("builds input text from positional args", async () => {
-    const parsed = parseCommandLine(["input", "5", "laptop pro", "--press-enter"]);
+    const parsed = parseCommandLine([
+      "input",
+      "5",
+      "laptop pro",
+      "--persist",
+      "search input",
+      "--press-enter",
+    ]);
 
     await expect(buildOperationInput("dom.input", parsed, DUMMY_RUNTIME)).resolves.toEqual({
       target: {
         kind: "element",
         element: 5,
       },
+      persist: "search input",
       text: "laptop pro",
       pressEnter: true,
     });
   });
 
   test("defaults scroll to the page root when no element is provided", async () => {
-    const parsed = parseCommandLine(["scroll", "down", "250", "--capture-network", "feed"]);
+    const parsed = parseCommandLine([
+      "scroll",
+      "down",
+      "250",
+      "--persist",
+      "page root scroll",
+      "--capture-network",
+      "feed",
+    ]);
 
     await expect(buildOperationInput("dom.scroll", parsed, DUMMY_RUNTIME)).resolves.toEqual({
       target: {
@@ -68,26 +84,38 @@ describe("CLI surface parsing", () => {
       },
       direction: "down",
       amount: 250,
+      persist: "page root scroll",
       captureNetwork: "feed",
     });
   });
 
-  test("builds extract input from positional schema and optional persist", async () => {
-    const parsed = parseCommandLine([
-      "extract",
-      '{"title":{"element":3}}',
-      "--persist",
-      "page summary",
-    ]);
+  test("builds extract input from positional template and required persist", async () => {
+    const parsed = parseCommandLine(["extract", '{"title":3}', "--persist", "page summary"]);
 
     await expect(buildOperationInput("dom.extract", parsed, DUMMY_RUNTIME)).resolves.toEqual({
       persist: "page summary",
-      schema: {
-        title: {
-          element: 3,
-        },
+      template: {
+        title: 3,
       },
     });
+  });
+
+  test("requires persist keys for CLI DOM actions and extract", async () => {
+    await expect(
+      buildOperationInput("dom.click", parseCommandLine(["click", "7"]), DUMMY_RUNTIME),
+    ).rejects.toThrow('click requires "--persist <key>".');
+
+    await expect(
+      buildOperationInput("dom.scroll", parseCommandLine(["scroll", "down", "250"]), DUMMY_RUNTIME),
+    ).rejects.toThrow('scroll requires "--persist <key>".');
+
+    await expect(
+      buildOperationInput(
+        "dom.extract",
+        parseCommandLine(["extract", '{"title":3}']),
+        DUMMY_RUNTIME,
+      ),
+    ).rejects.toThrow('extract requires "--persist <key>".');
   });
 
   test("builds fetch input with scoped JSON flags", async () => {

--- a/tests/opensteer/cli-v2.test.ts
+++ b/tests/opensteer/cli-v2.test.ts
@@ -51,7 +51,8 @@ describe("Opensteer v2 CLI", () => {
     expect(result.stdout).toContain(
       "open <url> [--workspace <id>] [--headless] [--provider local|cloud]",
     );
-    expect(result.stdout).toContain("extract <schema> [--persist <key>]");
+    expect(result.stdout).toContain("click <element> --persist <key>");
+    expect(result.stdout).toContain("extract <template> --persist <key>");
     expect(result.stdout).toContain("--body <json>");
     expect(result.stdout).toContain("--workspace <id>");
     expect(result.stdout).toContain("--json filters to JSON and GraphQL responses only");

--- a/tests/opensteer/computer-use.test.ts
+++ b/tests/opensteer/computer-use.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../../packages/browser-core/src/index.js";
 import {
   Opensteer,
+  OpensteerRuntime,
   OpensteerSessionRuntime,
   defaultPolicy,
   runWithPolicyTimeout,
@@ -50,6 +51,40 @@ afterEach(async () => {
 afterAll(async () => {
   await closeServer?.();
 });
+
+async function seedExtractionDescriptors(options: {
+  readonly rootDir: string;
+  readonly workspace: string;
+  readonly url: string;
+  readonly entries: ReadonlyArray<{
+    readonly persist: string;
+    readonly template: Record<string, unknown>;
+  }>;
+}): Promise<void> {
+  const runtime = new OpensteerRuntime({
+    workspace: options.workspace,
+    rootDir: options.rootDir,
+    cleanupRootOnClose: false,
+    browser: "temporary",
+    launch: {
+      headless: true,
+    },
+  });
+
+  try {
+    await runtime.open({
+      url: options.url,
+    });
+    for (const entry of options.entries) {
+      await runtime.extract({
+        persist: entry.persist,
+        template: entry.template,
+      });
+    }
+  } finally {
+    await runtime.close().catch(() => undefined);
+  }
+}
 
 describe("Phase 9 computer-use runtime", () => {
   test("executes computer-use actions, persists screenshot artifacts, and enriches traces", async () => {
@@ -201,9 +236,23 @@ describe("Phase 9 computer-use runtime", () => {
 
   test("exposes computerExecute through the public Opensteer SDK wrapper", async () => {
     const rootDir = await createPhase6TemporaryRoot();
+    await seedExtractionDescriptors({
+      rootDir,
+      workspace: "phase9-opensteer-wrapper",
+      url: `${baseUrl}/computer/main`,
+      entries: [
+        {
+          persist: "computer status through sdk wrapper",
+          template: {
+            status: { selector: "#status" },
+          },
+        },
+      ],
+    });
     const opensteer = new Opensteer({
       name: "phase9-opensteer-wrapper",
       rootDir,
+      workspace: "phase9-opensteer-wrapper",
       browser: "temporary",
       launch: {
         headless: true,
@@ -229,11 +278,6 @@ describe("Phase 9 computer-use runtime", () => {
 
       const extracted = await opensteer.extract({
         persist: "computer status through sdk wrapper",
-        schema: {
-          status: {
-            selector: "#status",
-          },
-        },
       });
       expect(extracted).toEqual({
         status: "clicked",
@@ -330,7 +374,7 @@ describe("Phase 9 computer-use runtime", () => {
 
       const currentUrl = await runtime.extract({
         persist: "popup current url",
-        schema: {
+        template: {
           currentUrl: { source: "current_url" },
         },
       });
@@ -558,7 +602,7 @@ describe("Phase 9 computer-use runtime", () => {
 async function extractStatus(runtime: OpensteerSessionRuntime): Promise<string> {
   const result = await runtime.extract({
     persist: "computer status",
-    schema: {
+    template: {
       status: {
         selector: "#status",
       },
@@ -570,7 +614,7 @@ async function extractStatus(runtime: OpensteerSessionRuntime): Promise<string> 
 async function extractMirror(runtime: OpensteerSessionRuntime): Promise<string> {
   const result = await runtime.extract({
     persist: "computer mirror",
-    schema: {
+    template: {
       mirror: {
         selector: "#mirror",
       },
@@ -582,7 +626,7 @@ async function extractMirror(runtime: OpensteerSessionRuntime): Promise<string> 
 async function extractDragValue(runtime: OpensteerSessionRuntime): Promise<string> {
   const result = await runtime.extract({
     persist: "computer drag value",
-    schema: {
+    template: {
       dragValue: {
         selector: "#drag-value",
       },

--- a/tests/opensteer/conformance-local.test.ts
+++ b/tests/opensteer/conformance-local.test.ts
@@ -11,7 +11,7 @@ import {
   type OpensteerConformanceHarness,
   type OpensteerConformanceUrls,
 } from "../../packages/conformance/src/index.js";
-import { Opensteer } from "../../packages/opensteer/src/index.js";
+import { Opensteer, OpensteerRuntime } from "../../packages/opensteer/src/index.js";
 
 let urls: OpensteerConformanceUrls;
 let closeServer: (() => Promise<void>) | undefined;
@@ -57,6 +57,7 @@ describe.sequential("Opensteer local conformance", () => {
 async function createHarness(): Promise<OpensteerConformanceHarness> {
   const rootDir = await mkdtemp(path.join(tmpdir(), "opensteer-conformance-"));
   temporaryRoots.push(rootDir);
+  await seedConformanceExtractionDescriptors(rootDir);
   const target = new Opensteer({
     workspace: "opensteer-local-conformance",
     rootDir,
@@ -77,6 +78,45 @@ async function createHarness(): Promise<OpensteerConformanceHarness> {
     urls,
     supports: () => true,
   };
+}
+
+async function seedConformanceExtractionDescriptors(rootDir: string): Promise<void> {
+  const runtime = new OpensteerRuntime({
+    workspace: "opensteer-local-conformance",
+    rootDir,
+    cleanupRootOnClose: false,
+    browser: "temporary",
+    launch: {
+      headless: true,
+    },
+    context: {
+      viewport: {
+        width: 800,
+        height: 600,
+      },
+    },
+  });
+
+  try {
+    await runtime.open({
+      url: urls.main,
+    });
+    await runtime.extract({
+      persist: "conformance fixture state",
+      template: {
+        status: { selector: "#status" },
+        mirror: { selector: "#mirror" },
+      },
+    });
+    await runtime.extract({
+      persist: "conformance computer status",
+      template: {
+        status: { selector: "#status" },
+      },
+    });
+  } finally {
+    await runtime.close().catch(() => undefined);
+  }
 }
 
 function htmlDocument(title: string, body: string): string {

--- a/tests/opensteer/dom-runtime.test.ts
+++ b/tests/opensteer/dom-runtime.test.ts
@@ -560,9 +560,9 @@ describe("Phase 5 snapshot integration", () => {
         const payload = await compileOpensteerExtractionPayload({
           dom,
           pageRef: created.data.pageRef,
-          schema: {
-            childShadow: { element: childShadowCounter.element },
-            nestedShadow: { element: nestedShadowCounter.element },
+          template: {
+            childShadow: childShadowCounter.element,
+            nestedShadow: nestedShadowCounter.element,
           },
         });
 

--- a/tests/opensteer/extraction-descriptor.test.ts
+++ b/tests/opensteer/extraction-descriptor.test.ts
@@ -177,7 +177,6 @@ describe("Extraction descriptor replay paths", () => {
       expect(srcsetMatch).not.toBeNull();
       expect(hrefMatch?.[1].length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(80);
       expect(srcsetMatch?.[1].length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(160);
-      // href uses middle truncation; srcset keeps compact candidate structure with the same marker
       expect(hrefMatch?.[1]).toContain("...");
       expect(srcsetMatch?.[1]).toContain("320w");
       expect(srcsetMatch?.[1]).toContain("2048w");

--- a/tests/opensteer/extraction-descriptor.test.ts
+++ b/tests/opensteer/extraction-descriptor.test.ts
@@ -175,10 +175,14 @@ describe("Extraction descriptor replay paths", () => {
       const srcsetMatch = snapshot.html.match(/srcset="([^"]*)"/);
       expect(hrefMatch).not.toBeNull();
       expect(srcsetMatch).not.toBeNull();
-      expect(hrefMatch?.[1].length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(500);
-      expect(srcsetMatch?.[1].length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(500);
-      expect(hrefMatch?.[1].endsWith(" [truncated]")).toBe(true);
-      expect(srcsetMatch?.[1].endsWith(" [truncated]")).toBe(true);
+      expect(hrefMatch?.[1].length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(80);
+      expect(srcsetMatch?.[1].length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(160);
+      // href uses middle truncation; srcset keeps compact candidate structure with the same marker
+      expect(hrefMatch?.[1]).toContain("...");
+      expect(srcsetMatch?.[1]).toContain("320w");
+      expect(srcsetMatch?.[1]).toContain("2048w");
+      expect(srcsetMatch?.[1]).toContain("...");
+      expect(srcsetMatch?.[1]).not.toContain("[truncated]");
 
       const linkCounter = snapshot.counters.find((candidate) =>
         candidate.pathHint.includes("#long-link"),

--- a/tests/opensteer/extraction-descriptor.test.ts
+++ b/tests/opensteer/extraction-descriptor.test.ts
@@ -62,8 +62,8 @@ describe("Extraction descriptor replay paths", () => {
       const payload = await compileOpensteerExtractionPayload({
         dom,
         pageRef: created.data.pageRef,
-        schema: {
-          counterValue: { element: counter.element },
+        template: {
+          counterValue: counter.element,
           selectorValue: { selector: "#selector-target" },
         },
       });
@@ -193,9 +193,9 @@ describe("Extraction descriptor replay paths", () => {
       const payload = await compileOpensteerExtractionPayload({
         dom,
         pageRef: created.data.pageRef,
-        schema: {
-          link: { element: linkCounter.element, attribute: "href" },
-          image: { element: imageCounter.element, attribute: "srcset" },
+        template: {
+          link: { c: linkCounter.element, attr: "href" },
+          image: { c: imageCounter.element, attr: "srcset" },
         },
       });
 
@@ -258,16 +258,16 @@ describe("Extraction descriptor replay paths", () => {
       const payload = await compileOpensteerExtractionPayload({
         dom,
         pageRef: created.data.pageRef,
-        schema: {
+        template: {
           items: [
             {
               title: { selector: "#products li:nth-child(1) a.title" },
-              url: { selector: "#products li:nth-child(1) a.title", attribute: "href" },
+              url: { selector: "#products li:nth-child(1) a.title", attr: "href" },
               price: { selector: "#products li:nth-child(1) .price" },
             },
             {
               title: { selector: "#products li:nth-child(2) a.title" },
-              url: { selector: "#products li:nth-child(2) a.title", attribute: "href" },
+              url: { selector: "#products li:nth-child(2) a.title", attr: "href" },
               price: { selector: "#products li:nth-child(2) .price" },
             },
           ],
@@ -323,16 +323,16 @@ describe("Extraction descriptor replay paths", () => {
       const payload = await compileOpensteerExtractionPayload({
         dom,
         pageRef: created.data.pageRef,
-        schema: {
+        template: {
           items: [
             {
               title: { selector: "#products li:nth-child(1) .title" },
-              url: { selector: "#products li:nth-child(1) .title", attribute: "href" },
+              url: { selector: "#products li:nth-child(1) .title", attr: "href" },
               price: { selector: "#products li:nth-child(1) .price" },
             },
             {
               title: { selector: "#products li:nth-child(2) .title" },
-              url: { selector: "#products li:nth-child(2) .title", attribute: "href" },
+              url: { selector: "#products li:nth-child(2) .title", attr: "href" },
               price: { selector: "#products li:nth-child(2) .price" },
             },
           ],
@@ -408,7 +408,7 @@ describe("Extraction descriptor replay paths", () => {
       const payload = await compileOpensteerExtractionPayload({
         dom,
         pageRef: created.data.pageRef,
-        schema: {
+        template: {
           items: [
             {
               title: { selector: "#products li:nth-child(1) [data-role='title']" },
@@ -520,17 +520,17 @@ describe("Extraction descriptor replay paths", () => {
       const payload = await compileOpensteerExtractionPayload({
         dom,
         pageRef: created.data.pageRef,
-        schema: {
+        template: {
           items: [
             {
-              title: { element: titleOne.element },
-              url: { element: titleOne.element, attribute: "href" },
-              price: { element: priceOne.element },
+              title: titleOne.element,
+              url: { c: titleOne.element, attr: "href" },
+              price: priceOne.element,
             },
             {
-              title: { element: titleTwo.element },
-              url: { element: titleTwo.element, attribute: "href" },
-              price: { element: priceTwo.element },
+              title: titleTwo.element,
+              url: { c: titleTwo.element, attr: "href" },
+              price: priceTwo.element,
             },
           ],
         },

--- a/tests/opensteer/navigation-network-capture.test.ts
+++ b/tests/opensteer/navigation-network-capture.test.ts
@@ -25,6 +25,7 @@ import {
   createFilesystemOpensteerWorkspace,
   defaultPolicy,
   Opensteer,
+  OpensteerRuntime,
   type OpensteerPolicy,
   type SettleObserver,
 } from "../../packages/opensteer/src/index.js";
@@ -43,6 +44,42 @@ function createLocalOpensteer(options: ConstructorParameters<typeof Opensteer>[0
       : {}),
     ...options,
   });
+}
+
+async function seedExtractionDescriptors(options: {
+  readonly workspace: string;
+  readonly url: string;
+  readonly entries: ReadonlyArray<{
+    readonly persist: string;
+    readonly template: Record<string, unknown>;
+  }>;
+  readonly rootDir?: string;
+  readonly rootPath?: string;
+}): Promise<void> {
+  const runtime = new OpensteerRuntime({
+    workspace: options.workspace,
+    ...(options.rootDir === undefined ? {} : { rootDir: options.rootDir }),
+    ...(options.rootPath === undefined ? {} : { rootPath: options.rootPath }),
+    cleanupRootOnClose: false,
+    browser: "temporary",
+    launch: {
+      headless: true,
+    },
+  });
+
+  try {
+    await runtime.open({
+      url: options.url,
+    });
+    for (const entry of options.entries) {
+      await runtime.extract({
+        persist: entry.persist,
+        template: entry.template,
+      });
+    }
+  } finally {
+    await runtime.close().catch(() => undefined);
+  }
 }
 
 describe.sequential("cross-document action boundary", () => {
@@ -322,6 +359,19 @@ describe.sequential("cross-document action boundary", () => {
   }, 60_000);
 
   test("captures named hydration requests after pressEnter navigation", async () => {
+    await seedExtractionDescriptors({
+      workspace: "navigation-network-capture",
+      rootDir: suiteRootDir,
+      url: `${baseUrl}/sdk/hydration-results?mode=enter`,
+      entries: [
+        {
+          persist: "hydration status",
+          template: {
+            status: { selector: "#hydration-status" },
+          },
+        },
+      ],
+    });
     const opensteer = createLocalOpensteer({
       workspace: "navigation-network-capture",
       browser: "temporary",
@@ -342,11 +392,6 @@ describe.sequential("cross-document action boundary", () => {
       await expect(
         opensteer.extract({
           persist: "hydration status",
-          schema: {
-            status: {
-              selector: "#hydration-status",
-            },
-          },
         }),
       ).resolves.toEqual({
         status: "hydrated",
@@ -363,6 +408,19 @@ describe.sequential("cross-document action boundary", () => {
   }, 60_000);
 
   test("reuses persisted input descriptors through the SDK wrapper", async () => {
+    await seedExtractionDescriptors({
+      workspace: "navigation-network-persisted-input",
+      rootDir: suiteRootDir,
+      url: `${baseUrl}/sdk/same-document-enter`,
+      entries: [
+        {
+          persist: "persisted input hydration status",
+          template: {
+            status: { selector: "#hydration-status" },
+          },
+        },
+      ],
+    });
     const opensteer = createLocalOpensteer({
       workspace: "navigation-network-persisted-input",
       browser: "temporary",
@@ -388,11 +446,6 @@ describe.sequential("cross-document action boundary", () => {
       await expect(
         opensteer.extract({
           persist: "persisted input hydration status",
-          schema: {
-            status: {
-              selector: "#hydration-status",
-            },
-          },
         }),
       ).resolves.toEqual({
         status: "hydrated",
@@ -409,6 +462,19 @@ describe.sequential("cross-document action boundary", () => {
   }, 60_000);
 
   test("pressEnter submits even when typing keeps bootstrap trackers noisy", async () => {
+    await seedExtractionDescriptors({
+      workspace: "navigation-network-noisy-enter",
+      rootDir: suiteRootDir,
+      url: `${baseUrl}/sdk/hydration-results?mode=noisy-enter`,
+      entries: [
+        {
+          persist: "noisy hydration status",
+          template: {
+            status: { selector: "#hydration-status" },
+          },
+        },
+      ],
+    });
     const opensteer = createLocalOpensteer({
       workspace: "navigation-network-noisy-enter",
       browser: "temporary",
@@ -434,11 +500,6 @@ describe.sequential("cross-document action boundary", () => {
       await expect(
         opensteer.extract({
           persist: "noisy hydration status",
-          schema: {
-            status: {
-              selector: "#hydration-status",
-            },
-          },
         }),
       ).resolves.toEqual({
         status: "hydrated",
@@ -455,6 +516,19 @@ describe.sequential("cross-document action boundary", () => {
   }, 60_000);
 
   test("click navigations succeed even when the destination page keeps scheduling timers", async () => {
+    await seedExtractionDescriptors({
+      workspace: "navigation-network-noisy-click",
+      rootDir: suiteRootDir,
+      url: `${baseUrl}/sdk/hydration-results?mode=noisy-click`,
+      entries: [
+        {
+          persist: "noisy click hydration status",
+          template: {
+            status: { selector: "#hydration-status" },
+          },
+        },
+      ],
+    });
     const opensteer = createLocalOpensteer({
       workspace: "navigation-network-noisy-click",
       browser: "temporary",
@@ -478,11 +552,6 @@ describe.sequential("cross-document action boundary", () => {
       await expect(
         opensteer.extract({
           persist: "noisy click hydration status",
-          schema: {
-            status: {
-              selector: "#hydration-status",
-            },
-          },
         }),
       ).resolves.toEqual({
         status: "hydrated",
@@ -500,6 +569,19 @@ describe.sequential("cross-document action boundary", () => {
 
   test("does not persist action-triggered network without captureNetwork", async () => {
     const rootPath = await mkdtemp(path.join(os.tmpdir(), "opensteer-no-capture-"));
+    await seedExtractionDescriptors({
+      workspace: "navigation-network-no-capture",
+      rootPath,
+      url: `${baseUrl}/sdk/hydration-results?mode=enter`,
+      entries: [
+        {
+          persist: "hydration status without capture",
+          template: {
+            status: { selector: "#hydration-status" },
+          },
+        },
+      ],
+    });
     const opensteer = createLocalOpensteer({
       workspace: "navigation-network-no-capture",
       rootPath,
@@ -521,11 +603,6 @@ describe.sequential("cross-document action boundary", () => {
       await expect(
         opensteer.extract({
           persist: "hydration status without capture",
-          schema: {
-            status: {
-              selector: "#hydration-status",
-            },
-          },
         }),
       ).resolves.toEqual({
         status: "hydrated",
@@ -587,6 +664,25 @@ describe.sequential("cross-document action boundary", () => {
   }, 60_000);
 
   test("waits for same-tab navigation hydration before returning computer-use clicks", async () => {
+    await seedExtractionDescriptors({
+      workspace: "computer-action-boundary",
+      rootDir: suiteRootDir,
+      url: `${baseUrl}/computer/hydration-results?mode=click`,
+      entries: [
+        {
+          persist: "computer hydration status",
+          template: {
+            status: { selector: "#hydration-status" },
+          },
+        },
+        {
+          persist: "computer current page",
+          template: {
+            url: { source: "current_url" },
+          },
+        },
+      ],
+    });
     const opensteer = createLocalOpensteer({
       workspace: "computer-action-boundary",
       browser: "temporary",
@@ -614,11 +710,6 @@ describe.sequential("cross-document action boundary", () => {
       await expect(
         opensteer.extract({
           persist: "computer hydration status",
-          schema: {
-            status: {
-              selector: "#hydration-status",
-            },
-          },
         }),
       ).resolves.toEqual({
         status: "hydrated",
@@ -627,11 +718,6 @@ describe.sequential("cross-document action boundary", () => {
       await expect(
         opensteer.extract({
           persist: "computer current page",
-          schema: {
-            url: {
-              source: "current_url",
-            },
-          },
         }),
       ).resolves.toEqual({
         url: `${baseUrl}/computer/hydration-results?mode=click`,

--- a/tests/opensteer/snapshot-cleaner.test.ts
+++ b/tests/opensteer/snapshot-cleaner.test.ts
@@ -68,8 +68,13 @@ describe("action snapshot cleaner", () => {
 
     const match = cleaned.match(/srcset="([^"]*)"/);
     expect(match).not.toBeNull();
-    expect(match?.[1].length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(500);
-    expect(match?.[1].endsWith(" [truncated]")).toBe(true);
+    expect(match?.[1].length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(160);
+    expect(match?.[1]).toContain("image-0.png");
+    expect(match?.[1]).toContain("160w");
+    expect(match?.[1]).toContain("image-11.png");
+    expect(match?.[1]).toContain("1920w");
+    expect(match?.[1]).toContain("...");
+    expect(match?.[1]).not.toContain("[truncated]");
   });
 
   test("truncates escaped action attributes by serialized length", () => {
@@ -96,10 +101,12 @@ describe("action snapshot cleaner", () => {
 
     expect(hrefMatch).not.toBeNull();
     expect(ariaLabelMatch).not.toBeNull();
-    expect(hrefMatch?.[1].length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(500);
+    expect(hrefMatch?.[1].length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(80);
     expect(ariaLabelMatch?.[1].length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(150);
-    expect(hrefMatch?.[1].endsWith(" [truncated]")).toBe(true);
-    expect(ariaLabelMatch?.[1].endsWith(" [truncated]")).toBe(true);
+    expect(hrefMatch?.[1]).toContain("...");
+    expect(hrefMatch?.[1].startsWith("https://example.com/")).toBe(true);
+    expect(ariaLabelMatch?.[1].endsWith("...")).toBe(true);
+    expect(ariaLabelMatch?.[1]).not.toContain("[truncated]");
   });
 
   test("strips unavailable iframe markers from public output", () => {
@@ -161,12 +168,17 @@ describe("action snapshot cleaner", () => {
     expect(hrefMatch).not.toBeNull();
     expect(srcMatch).not.toBeNull();
     expect(srcsetMatch).not.toBeNull();
-    expect(hrefMatch?.[1].length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(500);
-    expect(srcMatch?.[1].length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(500);
-    expect(srcsetMatch?.[1].length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(500);
-    expect(hrefMatch?.[1].endsWith(" [truncated]")).toBe(true);
-    expect(srcMatch?.[1].endsWith(" [truncated]")).toBe(true);
-    expect(srcsetMatch?.[1].endsWith(" [truncated]")).toBe(true);
+    expect(hrefMatch?.[1].length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(80);
+    expect(srcMatch?.[1].length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(80);
+    expect(srcsetMatch?.[1].length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(160);
+    expect(hrefMatch?.[1]).toContain("...");
+    expect(srcMatch?.[1]).toContain("...");
+    expect(srcsetMatch?.[1]).toContain("image-0.png");
+    expect(srcsetMatch?.[1]).toContain("320w");
+    expect(srcsetMatch?.[1]).toContain("image-7.png");
+    expect(srcsetMatch?.[1]).toContain("2560w");
+    expect(srcsetMatch?.[1]).toContain("...");
+    expect(srcsetMatch?.[1]).not.toContain("[truncated]");
   });
 
   test("preserves visible descendants from self-hidden wrappers while dropping hidden text", () => {
@@ -204,5 +216,166 @@ describe("action snapshot cleaner", () => {
     expect(extractionCleaned).not.toContain("Hidden image");
     expect(actionCleaned).not.toContain("hidden.png");
     expect(extractionCleaned).not.toContain("hidden.png");
+  });
+
+  test("merges adjacent extraction text nodes without reordering after comment removal", () => {
+    const cleaned = cleanForExtraction(`
+      <html>
+        <body>
+          <div c="1">a<!-- one -->b<!-- two -->c<!-- three -->d</div>
+        </body>
+      </html>
+    `);
+
+    expect(cleaned).toContain("<div c=\"1\">abcd</div>");
+    expect(cleaned).not.toContain("abdc");
+  });
+
+  test("keeps only aria-label in action snapshots while middle-truncating href and src", () => {
+    const cleaned = cleanForAction(`
+      <html>
+        <body>
+          <os-shadow-root data-os-boundary="shadow">
+            <button
+              c="1"
+              data-opensteer-interactive="1"
+              aria-label="Search by voice"
+              aria-describedby="voice-help"
+              aria-expanded="false"
+              aria-haspopup="dialog"
+            >
+              Search
+            </button>
+            <button c="2" data-opensteer-interactive="1">
+              <img
+                c="3"
+                src="https://cdn.example.com/assets/icons/voice-search/button/large/2x/search-by-voice-asset-with-extra-path.png?token=abcdef1234567890&wid=640&fmt=webp"
+                alt="Voice search"
+              />
+            </button>
+          </os-shadow-root>
+          <os-iframe-root data-os-boundary="iframe">
+            <a
+              c="4"
+              data-opensteer-interactive="1"
+              href="https://shop.example.com/p/apple-airpods-max-2/-/A-1010453160?preselect=black&promo=weekly-sale&ref=homepage-hero"
+              aria-label="AirPods Max"
+              aria-controls="product-panel"
+              aria-describedby="product-desc"
+            >
+              View product
+            </a>
+          </os-iframe-root>
+        </body>
+      </html>
+    `);
+
+    expect(cleaned).toContain('aria-label="Search by voice"');
+    expect(cleaned).toContain('aria-label="AirPods Max"');
+    expect(cleaned).not.toContain("aria-describedby");
+    expect(cleaned).not.toContain("aria-expanded");
+    expect(cleaned).not.toContain("aria-haspopup");
+    expect(cleaned).not.toContain("aria-controls");
+    expect(cleaned).toContain("https://cdn.example.com/assets/icons/voi...");
+    expect(cleaned).toContain("640&amp;fmt=webp");
+    expect(cleaned).toContain("...");
+    expect(cleaned).not.toContain(
+      "https://cdn.example.com/assets/icons/voice-search/button/large/2x/search-by-voice-asset-with-extra-path.png?token=abcdef1234567890&wid=640&fmt=webp",
+    );
+    expect(cleaned).toContain("https://shop.example.com/p/apple-airpods");
+    expect(cleaned).toContain("age-hero");
+    expect(cleaned).toContain('data-os-boundary="shadow"');
+    expect(cleaned).toContain('data-os-boundary="iframe"');
+  });
+
+  test("removes all aria attributes in extraction snapshots while middle-truncating href and src", () => {
+    const cleaned = cleanForExtraction(`
+      <html>
+        <body>
+          <os-shadow-root data-os-boundary="shadow">
+            <a
+              c="1"
+              href="https://shop.example.com/p/apple-airpods-max-2/-/A-1010453160?preselect=black&promo=weekly-sale&ref=homepage-hero"
+              aria-label="AirPods Max"
+              aria-describedby="product-desc"
+            >
+              View product
+            </a>
+          </os-shadow-root>
+          <os-iframe-root data-os-boundary="iframe">
+            <img
+              c="2"
+              src="https://cdn.example.com/assets/catalog/products/hero/airpods-max/image-with-extra-long-name.png?token=abcdef1234567890&wid=1200&fmt=webp"
+              alt="Hero image"
+            />
+          </os-iframe-root>
+        </body>
+      </html>
+    `);
+
+    expect(cleaned).not.toContain("aria-label");
+    expect(cleaned).not.toContain("aria-describedby");
+    expect(cleaned).toContain("https://shop.example.com/p/apple-airpods");
+    expect(cleaned).toContain("age-hero");
+    expect(cleaned).toContain("https://cdn.example.com/assets/catalog/p...");
+    expect(cleaned).toContain("00&amp;fmt=webp");
+    expect(cleaned).toContain("...");
+    expect(cleaned).toContain('data-os-boundary="shadow"');
+    expect(cleaned).toContain('data-os-boundary="iframe"');
+  });
+
+  test("does not deduplicate counter-tagged images with the same truncated src", () => {
+    // After middle-truncation, images from the same CDN with the same dimensions share
+    // an identical truncated src (same 40-char head + same 20-char tail). Without the
+    // c-attribute guard, deduplicateImages would remove all but the first.
+    const cdnBase = "https://cdn.example.com/products/";
+    const suffix = "?qlt=65&fmt=webp&hei=350&wid=350";
+    const makeUrl = (uuid: string) => `${cdnBase}${uuid}${suffix}`;
+
+    const cleaned = cleanForExtraction(`
+      <html><body>
+        <a href="/p/product-1" c="1">
+          <img c="2" src="${makeUrl("AAAA1111-bbbb-cccc-dddd-eeee00000001")}" alt="Product 1" />
+        </a>
+        <a href="/p/product-2" c="3">
+          <img c="4" src="${makeUrl("AAAA1111-bbbb-cccc-dddd-eeee00000002")}" alt="Product 2" />
+        </a>
+        <a href="/p/product-3" c="5">
+          <img c="6" src="${makeUrl("AAAA1111-bbbb-cccc-dddd-eeee00000003")}" alt="Product 3" />
+        </a>
+      </body></html>
+    `);
+
+    // All three images must survive — they are distinct tracked elements
+    expect(cleaned).toContain('c="2"');
+    expect(cleaned).toContain('c="4"');
+    expect(cleaned).toContain('c="6"');
+    // All three srcs should appear (middle-truncated), not just the first
+    const imgMatches = [...cleaned.matchAll(/<img\b[^>]*c="[^"]*"[^>]*>/gi)];
+    expect(imgMatches).toHaveLength(3);
+  });
+
+  test("keeps srcset candidate boundaries intact when truncating data urls", () => {
+    const dataCandidate = `data:image/svg+xml;base64,${"PHN2Zz48L3N2Zz4=".repeat(18)}`;
+    const cleaned = cleanForExtraction(`
+      <html>
+        <body>
+          <img
+            c="1"
+            srcset="${dataCandidate} 1x, https://cdn.example.com/assets/catalog/hero-with-an-extra-long-name.png?token=${"abcdef123456".repeat(10)}&fmt=webp 2x"
+            alt="Hero"
+          />
+        </body>
+      </html>
+    `);
+
+    const srcsetMatch = cleaned.match(/srcset="([^"]*)"/);
+    expect(srcsetMatch).not.toBeNull();
+    expect(srcsetMatch?.[1].length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(160);
+    expect(srcsetMatch?.[1]).toContain("data:image/svg+xml;base64");
+    expect(srcsetMatch?.[1]).toContain("1x");
+    expect(srcsetMatch?.[1]).toContain("fmt=webp");
+    expect(srcsetMatch?.[1]).toContain("2x");
+    expect(srcsetMatch?.[1]).toContain("...");
   });
 });

--- a/tests/opensteer/snapshot-cleaner.test.ts
+++ b/tests/opensteer/snapshot-cleaner.test.ts
@@ -325,9 +325,6 @@ describe("action snapshot cleaner", () => {
   });
 
   test("does not deduplicate counter-tagged images with the same truncated src", () => {
-    // After middle-truncation, images from the same CDN with the same dimensions share
-    // an identical truncated src (same 40-char head + same 20-char tail). Without the
-    // c-attribute guard, deduplicateImages would remove all but the first.
     const cdnBase = "https://cdn.example.com/products/";
     const suffix = "?qlt=65&fmt=webp&hei=350&wid=350";
     const makeUrl = (uuid: string) => `${cdnBase}${uuid}${suffix}`;
@@ -346,11 +343,9 @@ describe("action snapshot cleaner", () => {
       </body></html>
     `);
 
-    // All three images must survive — they are distinct tracked elements
     expect(cleaned).toContain('c="2"');
     expect(cleaned).toContain('c="4"');
     expect(cleaned).toContain('c="6"');
-    // All three srcs should appear (middle-truncated), not just the first
     const imgMatches = [...cleaned.matchAll(/<img\b[^>]*c="[^"]*"[^>]*>/gi)];
     expect(imgMatches).toHaveLength(3);
   });

--- a/tests/protocol/public-contract.test.ts
+++ b/tests/protocol/public-contract.test.ts
@@ -237,13 +237,12 @@ describe("semantic protocol validation", () => {
     ).not.toThrow();
   });
 
-  test("accepts dom.extract with schema-only and named replay inputs", () => {
+  test("accepts dom.extract with named template and replay inputs", () => {
     expect(() =>
       assertValidSemanticOperationInput("dom.extract", {
-        schema: {
-          title: {
-            element: 3,
-          },
+        persist: "product cards",
+        template: {
+          title: 3,
         },
       }),
     ).not.toThrow();
@@ -251,12 +250,10 @@ describe("semantic protocol validation", () => {
     expect(() =>
       assertValidSemanticOperationInput("dom.extract", {
         persist: "product cards",
-        schema: {
+        template: {
           items: [
             {
-              name: {
-                element: 13,
-              },
+              name: 13,
             },
           ],
         },


### PR DESCRIPTION
**Summary**
- require `--persist` for CLI DOM actions and `extract`, and align help text, protocol types, and SDK surface with persist-first extraction
- switch extraction descriptors from inline `schema` usage to persisted `template` handling, including counter-based field references and replay updates
- improve snapshot cleaning around boundary preservation, URL/src/srcset truncation, indicator detection, and image deduplication behavior
- update README, skill docs, conformance coverage, and regression tests for the new extraction and snapshot behavior

**Testing**
- `pnpm vitest run --config vitest.config.ts tests/opensteer/snapshot-cleaner.test.ts tests/opensteer/extraction-descriptor.test.ts --passWithNoTests`
- `pnpm --filter @opensteer/runtime-core typecheck`
- `pnpm skills:check`