### PR TITLE
Improve hit-test error reporting across DOM runtime and CLI

### DIFF
--- a/packages/engine-abp/src/dom-action-bridge.ts
+++ b/packages/engine-abp/src/dom-action-bridge.ts
@@ -200,6 +200,20 @@ const POINTER_ACTION_HELPERS = String.raw`
     const rect = element.getBoundingClientRect();
     return rect.width > 0 && rect.height > 0;
   }
+
+  function describeBlockingElement(element) {
+    if (!(element instanceof Element)) return null;
+    const tag = "<" + element.tagName.toLowerCase() + ">";
+    const label = element.getAttribute("aria-label");
+    if (label) return tag + ' "' + label.slice(0, 80) + '"';
+    const text = (element.textContent || "").trim();
+    if (text) return tag + ' "' + text.slice(0, 80) + '"';
+    const role = element.getAttribute("role");
+    if (role) return tag + " role=" + JSON.stringify(role);
+    const id = element.getAttribute("id");
+    if (id) return tag + " id=" + JSON.stringify(id);
+    return tag;
+  }
 `;
 
 const RESOLVE_POINTER_OWNER_DECLARATION =
@@ -250,10 +264,13 @@ const CLASSIFY_POINTER_HIT_DECLARATION =
       ? pointInsideDocumentRect(point, targetRect)
       : false;
 
+  const blockingDescription = blocking ? describeBlockingElement(blockingCandidate) : null;
+
   return {
     relation,
     blocking,
     ambiguous,
+    ...(blockingDescription ? { blockingDescription } : {}),
   };
 }`;
 
@@ -995,11 +1012,15 @@ function normalizePointerHitAssessment(
   if (candidate.ambiguous !== undefined && typeof candidate.ambiguous !== "boolean") {
     throw new Error("DOM action bridge returned an invalid pointer hit payload");
   }
+  if (candidate.blockingDescription !== undefined && typeof candidate.blockingDescription !== "string") {
+    throw new Error("DOM action bridge returned an invalid pointer hit payload");
+  }
 
   return {
     relation: candidate.relation,
     blocking: candidate.blocking,
     ...(candidate.ambiguous === undefined ? {} : { ambiguous: candidate.ambiguous }),
+    ...(candidate.blockingDescription === undefined ? {} : { blockingDescription: candidate.blockingDescription }),
     canonicalTarget,
   };
 }

--- a/packages/engine-abp/src/dom-action-bridge.ts
+++ b/packages/engine-abp/src/dom-action-bridge.ts
@@ -44,31 +44,43 @@ interface AbpDomActionBridgeContext {
 }
 
 const POINTER_ACTION_HELPERS = String.raw`
+  function isElementNode(node) {
+    return node != null && node.nodeType === 1;
+  }
+
+  function isShadowRoot(node) {
+    return node != null && node.nodeType === 11 && "host" in node;
+  }
+
+  function isNodeLike(node) {
+    return node != null && typeof node.nodeType === "number";
+  }
+
   function parentInComposedTree(node) {
     if (!node) {
       return null;
     }
     const slot = "assignedSlot" in node ? node.assignedSlot : null;
-    if (slot instanceof Element) {
+    if (isElementNode(slot)) {
       return slot;
     }
     const parent = node.parentNode;
-    if (parent instanceof ShadowRoot) {
+    if (isShadowRoot(parent)) {
       return parent.host;
     }
-    return parent instanceof Element ? parent : null;
+    return isElementNode(parent) ? parent : null;
   }
 
   function closestElementInComposedTree(node) {
     if (!node) {
       return null;
     }
-    if (node instanceof Element) {
+    if (isElementNode(node)) {
       return node;
     }
     let current = parentInComposedTree(node);
     while (current) {
-      if (current instanceof Element) {
+      if (isElementNode(current)) {
         return current;
       }
       current = parentInComposedTree(current);
@@ -128,7 +140,7 @@ const POINTER_ACTION_HELPERS = String.raw`
     while (current) {
       if (current.localName === "label") {
         const control = "control" in current ? current.control : null;
-        if (control instanceof Element) {
+        if (isElementNode(control)) {
           return control;
         }
       }
@@ -142,7 +154,7 @@ const POINTER_ACTION_HELPERS = String.raw`
   }
 
   function composedContains(container, node) {
-    if (!(container instanceof Node) || !(node instanceof Node)) {
+    if (!isNodeLike(container) || !isNodeLike(node)) {
       return false;
     }
     let current = node;
@@ -202,7 +214,7 @@ const POINTER_ACTION_HELPERS = String.raw`
   }
 
   function describeBlockingElement(element) {
-    if (!(element instanceof Element)) return null;
+    if (!isElementNode(element)) return null;
     const tag = "<" + element.tagName.toLowerCase() + ">";
     const label = element.getAttribute("aria-label");
     if (label) return tag + ' "' + label.slice(0, 80) + '"';
@@ -322,6 +334,14 @@ const BUILD_LIVE_REPLAY_PATH_DECLARATION = String.raw`function(policy, source) {
 const BUILD_LIVE_REPLAY_PATH_SOURCE = String.raw`(target, policy) => {
   const MAX_ATTRIBUTE_VALUE_LENGTH = 300;
 
+  function isElementNode(node) {
+    return node != null && node.nodeType === 1;
+  }
+
+  function isShadowRoot(node) {
+    return node != null && node.nodeType === 11 && "host" in node;
+  }
+
   function isValidAttrKey(key) {
     const trimmed = String(key || "").trim();
     if (!trimmed) return false;
@@ -396,7 +416,7 @@ const BUILD_LIVE_REPLAY_PATH_SOURCE = String.raw`(target, policy) => {
   }
 
   function countMatches(root, tag, attrKey, attrValue, mode) {
-    const scope = root instanceof ShadowRoot ? root : root.ownerDocument;
+    const scope = isShadowRoot(root) ? root : root.ownerDocument;
     if (!scope || typeof scope.querySelectorAll !== "function") return 0;
     const escapedTag = String(tag || "*");
     let selector = escapedTag;
@@ -449,7 +469,7 @@ const BUILD_LIVE_REPLAY_PATH_SOURCE = String.raw`(target, policy) => {
   function buildChain(node) {
     const nodes = [];
     let current = node;
-    while (current && current instanceof Element) {
+    while (current && isElementNode(current)) {
       nodes.unshift(current);
       current = current.parentElement;
     }
@@ -491,17 +511,17 @@ const BUILD_LIVE_REPLAY_PATH_SOURCE = String.raw`(target, policy) => {
     };
   }
 
-  if (!(target instanceof Element)) return null;
+  if (!isElementNode(target)) return null;
 
   const context = [];
-  let currentRoot = target.getRootNode() instanceof ShadowRoot ? target.getRootNode() : document;
+  let currentRoot = isShadowRoot(target.getRootNode()) ? target.getRootNode() : document;
   const targetChain = buildChain(target);
   const finalizedTarget = finalizePath(targetChain, currentRoot);
   if (!finalizedTarget) return null;
 
-  while (currentRoot instanceof ShadowRoot) {
+  while (isShadowRoot(currentRoot)) {
     const host = currentRoot.host;
-    const hostRoot = host.getRootNode() instanceof ShadowRoot ? host.getRootNode() : document;
+    const hostRoot = isShadowRoot(host.getRootNode()) ? host.getRootNode() : document;
     const hostChain = buildChain(host);
     const finalizedHost = finalizePath(hostChain, hostRoot);
     if (!finalizedHost) return null;

--- a/packages/engine-abp/src/dom-action-bridge.ts
+++ b/packages/engine-abp/src/dom-action-bridge.ts
@@ -521,15 +521,18 @@ const BUILD_LIVE_REPLAY_PATH_SOURCE = String.raw`(target, policy) => {
 
 export function createAbpDomActionBridge(context: AbpDomActionBridgeContext): DomActionBridge {
   return {
-    async buildReplayPath(locator) {
+    async buildReplayPath(locator, options) {
       const { controller, document, backendNodeId } = await prepareLiveNodeContext(
         context,
         locator,
       );
       return withTemporaryExecutionResume(context, controller, async () => {
+        const policy = options?.enableTextMatch
+          ? { ...LIVE_REPLAY_PATH_POLICY, enableTextMatch: true }
+          : LIVE_REPLAY_PATH_POLICY;
         const raw = await callNodeValueFunction(controller, document, locator, backendNodeId, {
           functionDeclaration: BUILD_LIVE_REPLAY_PATH_DECLARATION,
-          arguments: [{ value: LIVE_REPLAY_PATH_POLICY }, { value: BUILD_LIVE_REPLAY_PATH_SOURCE }],
+          arguments: [{ value: policy }, { value: BUILD_LIVE_REPLAY_PATH_SOURCE }],
         });
         return requireReplayPath(raw, locator);
       });

--- a/packages/engine-abp/src/dom-action-bridge.ts
+++ b/packages/engine-abp/src/dom-action-bridge.ts
@@ -404,110 +404,302 @@ const BUILD_LIVE_REPLAY_PATH_SOURCE = String.raw`(target, policy) => {
     return Array.from(root.children || []);
   }
 
-  function cssEscape(value) {
-    return String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-  }
-
-  function stablePrimaryKey(attrs) {
-    for (const key of policy.stablePrimaryAttrKeys || []) {
-      if (attrs[key]) return key;
-    }
-    return null;
-  }
-
-  function countMatches(root, tag, attrKey, attrValue, mode) {
-    const scope = isShadowRoot(root) ? root : root.ownerDocument;
-    if (!scope || typeof scope.querySelectorAll !== "function") return 0;
-    const escapedTag = String(tag || "*");
-    let selector = escapedTag;
-    if (attrKey && attrValue) {
-      const operator = mode === "prefix" ? "^=" : "=";
-      selector += "[" + attrKey + operator + "\\"" + cssEscape(attrValue) + "\\"]";
-    }
-    try {
-      return scope.querySelectorAll(selector).length;
-    } catch {
-      return 0;
-    }
-  }
-
-  function chooseAttribute(tag, attrs, root) {
-    const stableKey = stablePrimaryKey(attrs);
-    if (stableKey) {
-      const exactCount = countMatches(root, tag, stableKey, attrs[stableKey], "exact");
-      if (exactCount === 1) {
-        return {
-          key: stableKey,
-          value: attrs[stableKey],
-          match: "exact",
-        };
-      }
-    }
-
-    const entries = Object.entries(attrs)
-      .filter(([key]) => !policy.deferredMatchAttrKeys.includes(key))
-      .concat(Object.entries(attrs).filter(([key]) => policy.deferredMatchAttrKeys.includes(key)));
-
-    for (const [key, value] of entries) {
-      const exactCount = countMatches(root, tag, key, value, "exact");
-      if (exactCount === 1) {
-        return { key, value, match: "exact" };
-      }
-      if (value.length >= 4) {
-        const prefixLength = Math.min(Math.max(4, Math.floor(value.length / 2)), value.length);
-        const prefix = value.slice(0, prefixLength);
-        const prefixCount = countMatches(root, tag, key, prefix, "prefix");
-        if (prefixCount === 1) {
-          return { key, value: prefix, match: "prefix" };
-        }
-      }
-    }
-
-    return null;
+  function toPosition(node, root) {
+    const siblings = getSiblings(node, root);
+    const tag = node.tagName.toLowerCase();
+    const sameTag = siblings.filter((candidate) => candidate.tagName.toLowerCase() === tag);
+    return {
+      nthChild: siblings.indexOf(node) + 1,
+      nthOfType: sameTag.indexOf(node) + 1,
+    };
   }
 
   function buildChain(node) {
-    const nodes = [];
+    const chain = [];
     let current = node;
-    while (current && isElementNode(current)) {
-      nodes.unshift(current);
-      current = current.parentElement;
+    while (current) {
+      chain.push(current);
+      if (current.parentElement) {
+        current = current.parentElement;
+        continue;
+      }
+      break;
     }
-    return nodes;
+    chain.reverse();
+    return chain;
   }
 
-  function finalizePath(chain, root) {
-    const result = [];
-    for (const node of chain) {
-      const tag = node.tagName.toLowerCase();
-      const attrs = collectAttrs(node);
-      const attribute = chooseAttribute(tag, attrs, root);
-      if (attribute) {
-        result.push({
-          tag,
-          attributes: [
-            {
-              name: attribute.key,
-              value: attribute.value,
-              match: attribute.match,
-            },
-          ],
-        });
+  function sortAttributeKeys(keys) {
+    const priority = Array.isArray(policy?.matchAttributePriority)
+      ? policy.matchAttributePriority.map((value) => String(value))
+      : [];
+    return [...keys].sort((left, right) => {
+      const leftIndex = priority.indexOf(left);
+      const rightIndex = priority.indexOf(right);
+      const leftRank = leftIndex === -1 ? Number.MAX_SAFE_INTEGER : leftIndex;
+      const rightRank = rightIndex === -1 ? Number.MAX_SAFE_INTEGER : rightIndex;
+      if (leftRank !== rightRank) {
+        return leftRank - rightRank;
+      }
+      return left.localeCompare(right);
+    });
+  }
+
+  function tokenizeClassValue(value) {
+    const seen = new Set();
+    const out = [];
+    for (const token of String(value || "").split(/\s+/)) {
+      const normalized = token.trim();
+      if (!normalized || seen.has(normalized)) continue;
+      seen.add(normalized);
+      out.push(normalized);
+    }
+    return out;
+  }
+
+  function clauseKey(clause) {
+    return JSON.stringify(clause);
+  }
+
+  function shouldDeferMatchAttribute(rawKey) {
+    const key = String(rawKey || "").trim().toLowerCase();
+    if (!key || key === "class") return false;
+    if (key === "id" || /(?:^|[-_:])id$/.test(key)) return true;
+    const deferred = new Set(
+      Array.isArray(policy?.deferredMatchAttrKeys)
+        ? policy.deferredMatchAttrKeys.map((value) => String(value))
+        : [],
+    );
+    if (deferred.has(key)) return true;
+    const stablePrimary = new Set(
+      Array.isArray(policy?.stablePrimaryAttrKeys)
+        ? policy.stablePrimaryAttrKeys.map((value) => String(value))
+        : [],
+    );
+    if (key.startsWith("data-") && !stablePrimary.has(key)) return true;
+    return !stablePrimary.has(key);
+  }
+
+  function buildSegmentSelector(data) {
+    let selector = String(data.tag || "*").toLowerCase();
+    for (const clause of data.match || []) {
+      if (clause.kind === "text") continue;
+      if (clause.kind === "position") {
+        if (clause.axis === "nthOfType") {
+          selector += ":nth-of-type(" + Math.max(1, Number(data.position?.nthOfType || 1)) + ")";
+        } else {
+          selector += ":nth-child(" + Math.max(1, Number(data.position?.nthChild || 1)) + ")";
+        }
         continue;
       }
 
-      const siblings = getSiblings(node, root).filter(
-        (candidate) => candidate.tagName.toLowerCase() === tag,
-      );
-      const index = siblings.indexOf(node);
-      result.push({
-        tag,
-        index: siblings.length <= 1 || index < 0 ? undefined : index,
-      });
+      const key = String(clause.key || "");
+      const value = typeof clause.value === "string" ? clause.value : data.attrs?.[key];
+      if (!key || !value) continue;
+      if (key === "class" && (clause.op || "exact") === "exact") {
+        for (const token of tokenizeClassValue(value)) {
+          const escapedToken = String(token).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+          selector += '[class~="' + escapedToken + '"]';
+        }
+        continue;
+      }
+      const escaped = String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+      const op = clause.op || "exact";
+      if (op === "startsWith") selector += "[" + key + '^="' + escaped + '"]';
+      else if (op === "contains") selector += "[" + key + '*="' + escaped + '"]';
+      else selector += "[" + key + '="' + escaped + '"]';
+    }
+    return selector;
+  }
+
+  function buildCandidates(nodes) {
+    const parts = nodes.map((node) => buildSegmentSelector(node));
+    const out = [];
+    const seen = new Set();
+    for (let start = 0; start < parts.length; start += 1) {
+      const selector = parts.slice(start).join(" ");
+      if (!selector || seen.has(selector)) continue;
+      seen.add(selector);
+      out.push(selector);
+    }
+    return out;
+  }
+
+  function selectReplayCandidate(nodes, root) {
+    const selectors = buildCandidates(nodes);
+    const targetNode = nodes[nodes.length - 1];
+    const textClauses = (targetNode?.match || []).filter((c) => c.kind === "text");
+    let fallback = null;
+    let fallbackSelector = null;
+    let fallbackCount = 0;
+    for (const selector of selectors) {
+      let matches = [];
+      try {
+        matches = Array.from(root.querySelectorAll(selector));
+      } catch {
+        matches = [];
+      }
+      if (textClauses.length > 0 && matches.length > 1) {
+        const filtered = matches.filter((el) => {
+          const text = (el.textContent || "").replace(/\s+/g, " ").trim();
+          return textClauses.every((tc) => text.includes(tc.value));
+        });
+        if (filtered.length > 0) matches = filtered;
+      }
+      if (!matches.length) continue;
+      if (matches.length === 1) {
+        return {
+          element: matches[0],
+          selector,
+          count: 1,
+          mode: "unique",
+        };
+      }
+      if (!fallback) {
+        fallback = matches[0];
+        fallbackSelector = selector;
+        fallbackCount = matches.length;
+      }
+    }
+    if (fallback && fallbackSelector) {
+      return {
+        element: fallback,
+        selector: fallbackSelector,
+        count: fallbackCount,
+        mode: "fallback",
+      };
+    }
+    return null;
+  }
+
+  function buildClausePool(data) {
+    const attrs = data.attrs || {};
+    const pool = [];
+    const deferred = [];
+    const used = new Set();
+
+    const classValue = String(attrs.class || "").trim();
+    if (classValue) {
+      const clause = { kind: "attr", key: "class", op: "exact", value: classValue };
+      used.add(clauseKey(clause));
+      pool.push(clause);
     }
 
+    for (const key of sortAttributeKeys(Object.keys(attrs))) {
+      if (key === "class") continue;
+      const value = attrs[key];
+      if (!value || !String(value).trim()) continue;
+      const clause = { kind: "attr", key, op: "exact" };
+      const keyId = clauseKey(clause);
+      if (used.has(keyId)) continue;
+      used.add(keyId);
+      if (shouldDeferMatchAttribute(key)) deferred.push(clause);
+      else pool.push(clause);
+    }
+
+    if (data.textContent) {
+      const clause = { kind: "text", value: data.textContent };
+      const keyId = clauseKey(clause);
+      if (!used.has(keyId)) {
+        used.add(keyId);
+        pool.push(clause);
+      }
+    }
+
+    for (const clause of [
+      { kind: "position", axis: "nthOfType" },
+      { kind: "position", axis: "nthChild" },
+    ]) {
+      const keyId = clauseKey(clause);
+      if (used.has(keyId)) continue;
+      used.add(keyId);
+      pool.push(clause);
+    }
+
+    if (!pool.some((clause) => clause.kind === "attr")) {
+      pool.push(...deferred);
+    }
+
+    return pool;
+  }
+
+  function finalizePath(elements, root) {
+    if (!elements.length) return null;
+    const nodes = elements.map((element) => ({
+      tag: element.tagName.toLowerCase(),
+      attrs: collectAttrs(element),
+      position: toPosition(element, root),
+      textContent: policy.enableTextMatch
+        ? (element.textContent || "").replace(/\s+/g, " ").trim().slice(0, 80)
+        : "",
+      match: [],
+    }));
+
+    const pools = nodes.map((node) => {
+      node.match = [];
+      return [...buildClausePool(node)];
+    });
+
+    for (let index = 0; index < pools.length; index += 1) {
+      const classIndex = pools[index].findIndex(
+        (clause) => clause.kind === "attr" && clause.key === "class",
+      );
+      if (classIndex < 0) continue;
+      const classClause = pools[index][classIndex];
+      if (!classClause) continue;
+      nodes[index].match.push(classClause);
+      pools[index].splice(classIndex, 1);
+    }
+
+    const expected = elements[elements.length - 1];
+    const totalRemaining = pools.reduce((count, pool) => count + pool.length, 0);
+    for (let iteration = 0; iteration <= totalRemaining; iteration += 1) {
+      const chosen = selectReplayCandidate(nodes, root);
+      if (chosen && chosen.mode === "unique" && chosen.element === expected) {
+        return {
+          nodes,
+          selector: chosen.selector,
+        };
+      }
+
+      let bestIndex = -1;
+      let bestClause = null;
+      let bestRank = Number.MAX_SAFE_INTEGER;
+      for (let index = 0; index < pools.length; index += 1) {
+        const clause = pools[index][0];
+        if (!clause) continue;
+        const rank =
+          clause.kind === "attr"
+            ? 0
+            : clause.kind === "text"
+              ? 1
+              : clause.axis === "nthOfType"
+                ? 2
+                : 3;
+        if (rank < bestRank) {
+          bestRank = rank;
+          bestIndex = index;
+          bestClause = clause;
+        }
+      }
+
+      if (bestIndex === -1 || !bestClause) {
+        break;
+      }
+
+      nodes[bestIndex].match.push(bestClause);
+      pools[bestIndex].shift();
+    }
+
+    const fallback = selectReplayCandidate(nodes, root);
+    if (!fallback || fallback.element !== expected) {
+      return {
+        nodes,
+      };
+    }
     return {
-      nodes: result,
+      nodes,
+      selector: fallback.selector,
     };
   }
 

--- a/packages/engine-playwright/src/dom-action-bridge.ts
+++ b/packages/engine-playwright/src/dom-action-bridge.ts
@@ -44,7 +44,7 @@ interface PlaywrightDomActionBridgeContext {
 
 const READ_ACTION_TARGET_STATE_DECLARATION = String.raw`function() {
   const node = this;
-  if (!(node instanceof Element)) {
+  if (!node || node.nodeType !== 1) {
     return {
       connected: false,
       cssVisible: false,
@@ -72,13 +72,13 @@ const READ_ACTION_TARGET_STATE_DECLARATION = String.raw`function() {
       ? !node.matches(":disabled") && node.getAttribute("aria-disabled") !== "true"
       : true;
 
+  const tag = node.localName;
   const editable =
-    (node instanceof ownerWindow.HTMLInputElement ||
-      node instanceof ownerWindow.HTMLTextAreaElement) &&
+    (tag === "input" || tag === "textarea") &&
     !node.readOnly &&
     enabled
       ? true
-      : node instanceof ownerWindow.HTMLSelectElement && enabled
+      : tag === "select" && enabled
         ? true
         : node.isContentEditable;
 
@@ -95,31 +95,43 @@ const READ_ACTION_TARGET_STATE_DECLARATION = String.raw`function() {
 }`;
 
 const POINTER_ACTION_HELPERS = String.raw`
+  function isElementNode(node) {
+    return node != null && node.nodeType === 1;
+  }
+
+  function isShadowRoot(node) {
+    return node != null && node.nodeType === 11 && "host" in node;
+  }
+
+  function isNodeLike(node) {
+    return node != null && typeof node.nodeType === "number";
+  }
+
   function parentInComposedTree(node) {
     if (!node) {
       return null;
     }
     const slot = "assignedSlot" in node ? node.assignedSlot : null;
-    if (slot instanceof Element) {
+    if (isElementNode(slot)) {
       return slot;
     }
     const parent = node.parentNode;
-    if (parent instanceof ShadowRoot) {
+    if (isShadowRoot(parent)) {
       return parent.host;
     }
-    return parent instanceof Element ? parent : null;
+    return isElementNode(parent) ? parent : null;
   }
 
   function closestElementInComposedTree(node) {
     if (!node) {
       return null;
     }
-    if (node instanceof Element) {
+    if (isElementNode(node)) {
       return node;
     }
     let current = parentInComposedTree(node);
     while (current) {
-      if (current instanceof Element) {
+      if (isElementNode(current)) {
         return current;
       }
       current = parentInComposedTree(current);
@@ -179,7 +191,7 @@ const POINTER_ACTION_HELPERS = String.raw`
     while (current) {
       if (current.localName === "label") {
         const control = "control" in current ? current.control : null;
-        if (control instanceof Element) {
+        if (isElementNode(control)) {
           return control;
         }
       }
@@ -193,7 +205,7 @@ const POINTER_ACTION_HELPERS = String.raw`
   }
 
   function composedContains(container, node) {
-    if (!(container instanceof Node) || !(node instanceof Node)) {
+    if (!isNodeLike(container) || !isNodeLike(node)) {
       return false;
     }
     let current = node;
@@ -253,7 +265,7 @@ const POINTER_ACTION_HELPERS = String.raw`
   }
 
   function describeBlockingElement(element) {
-    if (!(element instanceof Element)) return null;
+    if (!isElementNode(element)) return null;
     const tag = "<" + element.tagName.toLowerCase() + ">";
     const label = element.getAttribute("aria-label");
     if (label) return tag + ' "' + label.slice(0, 80) + '"';
@@ -390,6 +402,14 @@ const BUILD_LIVE_REPLAY_PATH_DECLARATION = String.raw`function(policy, source) {
 
 const BUILD_LIVE_REPLAY_PATH_SOURCE = String.raw`(target, policy) => {
   const MAX_ATTRIBUTE_VALUE_LENGTH = 300;
+
+  function isElementNode(node) {
+    return node != null && node.nodeType === 1;
+  }
+
+  function isShadowRoot(node) {
+    return node != null && node.nodeType === 11 && "host" in node;
+  }
 
   function isValidAttrKey(key) {
     const trimmed = String(key || "").trim();
@@ -726,18 +746,18 @@ const BUILD_LIVE_REPLAY_PATH_SOURCE = String.raw`(target, policy) => {
     return null;
   }
 
-  if (!(target instanceof Element)) return null;
+  if (!isElementNode(target)) return null;
 
   const context = [];
-  let currentRoot = target.getRootNode() instanceof ShadowRoot ? target.getRootNode() : document;
+  let currentRoot = isShadowRoot(target.getRootNode()) ? target.getRootNode() : document;
   const targetChain = buildChain(target);
   const finalizedTarget = finalizePath(targetChain, currentRoot);
   if (!finalizedTarget) return null;
 
-  while (currentRoot instanceof ShadowRoot) {
+  while (isShadowRoot(currentRoot)) {
     const host = currentRoot.host;
     const hostRoot =
-      host.getRootNode() instanceof ShadowRoot ? host.getRootNode() : document;
+      isShadowRoot(host.getRootNode()) ? host.getRootNode() : document;
     const hostChain = buildChain(host);
     const finalizedHost = finalizePath(hostChain, hostRoot);
     if (!finalizedHost) return null;

--- a/packages/engine-playwright/src/dom-action-bridge.ts
+++ b/packages/engine-playwright/src/dom-action-bridge.ts
@@ -251,6 +251,20 @@ const POINTER_ACTION_HELPERS = String.raw`
     const rect = element.getBoundingClientRect();
     return rect.width > 0 && rect.height > 0;
   }
+
+  function describeBlockingElement(element) {
+    if (!(element instanceof Element)) return null;
+    const tag = "<" + element.tagName.toLowerCase() + ">";
+    const label = element.getAttribute("aria-label");
+    if (label) return tag + ' "' + label.slice(0, 80) + '"';
+    const text = (element.textContent || "").trim();
+    if (text) return tag + ' "' + text.slice(0, 80) + '"';
+    const role = element.getAttribute("role");
+    if (role) return tag + " role=" + JSON.stringify(role);
+    const id = element.getAttribute("id");
+    if (id) return tag + " id=" + JSON.stringify(id);
+    return tag;
+  }
 `;
 
 const RESOLVE_POINTER_OWNER_DECLARATION =
@@ -301,10 +315,13 @@ const CLASSIFY_POINTER_HIT_DECLARATION =
       ? pointInsideDocumentRect(point, targetRect)
       : false;
 
+  const blockingDescription = blocking ? describeBlockingElement(blockingCandidate) : null;
+
   return {
     relation,
     blocking,
     ambiguous,
+    ...(blockingDescription ? { blockingDescription } : {}),
   };
 }`;
 
@@ -1174,11 +1191,15 @@ function normalizePointerHitAssessment(
   if (candidate.ambiguous !== undefined && typeof candidate.ambiguous !== "boolean") {
     throw new Error("DOM action bridge returned an invalid pointer hit payload");
   }
+  if (candidate.blockingDescription !== undefined && typeof candidate.blockingDescription !== "string") {
+    throw new Error("DOM action bridge returned an invalid pointer hit payload");
+  }
 
   return {
     relation: candidate.relation,
     blocking: candidate.blocking,
     ...(candidate.ambiguous === undefined ? {} : { ambiguous: candidate.ambiguous }),
+    ...(candidate.blockingDescription === undefined ? {} : { blockingDescription: candidate.blockingDescription }),
     canonicalTarget,
   };
 }

--- a/packages/engine-playwright/src/dom-action-bridge.ts
+++ b/packages/engine-playwright/src/dom-action-bridge.ts
@@ -532,6 +532,7 @@ const BUILD_LIVE_REPLAY_PATH_SOURCE = String.raw`(target, policy) => {
   function buildSegmentSelector(data) {
     let selector = String(data.tag || "*").toLowerCase();
     for (const clause of data.match || []) {
+      if (clause.kind === "text") continue;
       if (clause.kind === "position") {
         if (clause.axis === "nthOfType") {
           selector += ":nth-of-type(" + Math.max(1, Number(data.position?.nthOfType || 1)) + ")";
@@ -575,6 +576,8 @@ const BUILD_LIVE_REPLAY_PATH_SOURCE = String.raw`(target, policy) => {
 
   function selectReplayCandidate(nodes, root) {
     const selectors = buildCandidates(nodes);
+    const targetNode = nodes[nodes.length - 1];
+    const textClauses = (targetNode?.match || []).filter((c) => c.kind === "text");
     let fallback = null;
     let fallbackSelector = null;
     let fallbackCount = 0;
@@ -584,6 +587,13 @@ const BUILD_LIVE_REPLAY_PATH_SOURCE = String.raw`(target, policy) => {
         matches = Array.from(root.querySelectorAll(selector));
       } catch {
         matches = [];
+      }
+      if (textClauses.length > 0 && matches.length > 1) {
+        const filtered = matches.filter((el) => {
+          const text = (el.textContent || "").replace(/\s+/g, " ").trim();
+          return textClauses.every((tc) => text.includes(tc.value));
+        });
+        if (filtered.length > 0) matches = filtered;
       }
       if (!matches.length) continue;
       if (matches.length === 1) {
@@ -636,6 +646,15 @@ const BUILD_LIVE_REPLAY_PATH_SOURCE = String.raw`(target, policy) => {
       else pool.push(clause);
     }
 
+    if (data.textContent) {
+      const clause = { kind: "text", value: data.textContent };
+      const keyId = clauseKey(clause);
+      if (!used.has(keyId)) {
+        used.add(keyId);
+        pool.push(clause);
+      }
+    }
+
     for (const clause of [
       { kind: "position", axis: "nthOfType" },
       { kind: "position", axis: "nthChild" },
@@ -659,6 +678,9 @@ const BUILD_LIVE_REPLAY_PATH_SOURCE = String.raw`(target, policy) => {
       tag: element.tagName.toLowerCase(),
       attrs: collectAttrs(element),
       position: toPosition(element, root),
+      textContent: policy.enableTextMatch
+        ? (element.textContent || "").replace(/\s+/g, " ").trim().slice(0, 80)
+        : "",
       match: [],
     }));
 
@@ -737,13 +759,14 @@ export function createPlaywrightDomActionBridge(
   context: PlaywrightDomActionBridgeContext,
 ): DomActionBridge {
   return {
-    buildReplayPath(locator) {
+    buildReplayPath(locator, options) {
       return withLiveNode(context, locator, async ({ controller, document, backendNodeId }) => {
         const localPath = await buildLiveReplayPathForLocator(
           controller,
           document,
           locator,
           backendNodeId,
+          options,
         );
         return prefixIframeReplayPath(context, document.frameRef, localPath);
       });
@@ -1209,10 +1232,14 @@ async function buildLiveReplayPathForLocator(
   document: DocumentState,
   locator: NodeLocator,
   backendNodeId: number,
+  options?: { readonly enableTextMatch?: boolean },
 ): Promise<ReplayElementPath> {
+  const policy = options?.enableTextMatch
+    ? { ...LIVE_REPLAY_PATH_POLICY, enableTextMatch: true }
+    : LIVE_REPLAY_PATH_POLICY;
   const raw = await callNodeFunction(controller, document, locator, backendNodeId, {
     functionDeclaration: BUILD_LIVE_REPLAY_PATH_DECLARATION,
-    arguments: [{ value: LIVE_REPLAY_PATH_POLICY }, { value: BUILD_LIVE_REPLAY_PATH_SOURCE }],
+    arguments: [{ value: policy }, { value: BUILD_LIVE_REPLAY_PATH_SOURCE }],
     returnByValue: true,
   });
   return requireReplayPath(raw, locator);

--- a/packages/opensteer/src/cli/bin.ts
+++ b/packages/opensteer/src/cli/bin.ts
@@ -23,6 +23,7 @@ import {
 } from "../sdk/runtime-resolution.js";
 import { dispatchSemanticOperation } from "./dispatch.js";
 import { loadCliEnvironment } from "./env-loader.js";
+import { CliError, emitWarning, formatCliErrorOutput } from "./errors.js";
 import { getHelpText } from "./help.js";
 import { buildOperationInput } from "./operation-input.js";
 import { renderOperationOutput } from "./output.js";
@@ -108,11 +109,11 @@ async function main(): Promise<void> {
 
   const operation = resolveOperation(parsed.command);
   if (!operation) {
-    throw new Error(`Unknown command: ${parsed.command.join(" ")}`);
+    throw new CliError("unknown_command", `Unknown command: ${parsed.command.join(" ")}`);
   }
 
   if (parsed.options.workspace === undefined) {
-    throw new Error('Stateful commands require "--workspace <id>" or OPENSTEER_WORKSPACE.');
+    throw new CliError("missing_workspace", 'Stateful commands require "--workspace <id>" or OPENSTEER_WORKSPACE.');
   }
 
   const { engineName, provider, runtimeProvider } = resolveCliRuntimeSelection(parsed);
@@ -138,14 +139,29 @@ async function main(): Promise<void> {
   let renderOperation = operation;
   try {
     const input = await buildOperationInput(operation, parsed, runtime);
-    result = await dispatchSemanticOperation(runtime, operation, input);
+    const rawResult = await dispatchSemanticOperation(runtime, operation, input);
 
     if (parsed.command[0] === "tab" && operation !== "page.list") {
       renderOperation = "page.list";
       result = await runtime.listPages({});
+    } else {
+      result = rawResult;
+    }
+
+    let warning: string | undefined;
+    if (result !== null && typeof result === "object" && "warning" in (result as object)) {
+      const { warning: w, ...rest } = result as Record<string, unknown>;
+      if (typeof w === "string") {
+        warning = w;
+        result = rest;
+      }
     }
 
     process.stdout.write(renderOperationOutput(renderOperation, result, input));
+
+    if (warning !== undefined) {
+      emitWarning(warning);
+    }
   } finally {
     await runtime.disconnect().catch(() => undefined);
   }
@@ -153,12 +169,14 @@ async function main(): Promise<void> {
 
 async function handleExecCommand(parsed: ParsedCommandLine): Promise<void> {
   if (parsed.options.workspace === undefined) {
-    throw new Error('exec requires "--workspace <id>" or OPENSTEER_WORKSPACE.');
+    throw new CliError("missing_workspace", 'exec requires "--workspace <id>" or OPENSTEER_WORKSPACE.');
   }
   const expression = parsed.rest.join(" ");
   if (!expression) {
-    throw new Error(
-      "exec requires an expression. Example: exec \"await this.evaluate('document.title')\"",
+    throw new CliError(
+      "missing_arguments",
+      "exec requires an expression.",
+      'opensteer exec <expression>',
     );
   }
 
@@ -199,8 +217,10 @@ async function handleBrowserCommand(parsed: ParsedCommandLine): Promise<void> {
   if (subcommand === "inspect") {
     const endpoint = parsed.options.attachEndpoint ?? parsed.rest[0];
     if (!endpoint) {
-      throw new Error(
+      throw new CliError(
+        "missing_arguments",
         'browser inspect requires "--attach-endpoint <url>" or a positional endpoint.',
+        "opensteer browser inspect <endpoint>",
       );
     }
     const result = await inspectCdpEndpoint({
@@ -217,7 +237,8 @@ async function handleBrowserCommand(parsed: ParsedCommandLine): Promise<void> {
   }
 
   if (parsed.options.workspace === undefined) {
-    throw new Error(
+    throw new CliError(
+      "missing_workspace",
       'Browser workspace commands require "--workspace <id>" or OPENSTEER_WORKSPACE.',
     );
   }
@@ -241,7 +262,11 @@ async function handleBrowserCommand(parsed: ParsedCommandLine): Promise<void> {
     case "clone": {
       const sourceUserDataDir = parsed.options.sourceUserDataDir;
       if (!sourceUserDataDir) {
-        throw new Error('browser clone requires "--source-user-data-dir <path>".');
+        throw new CliError(
+          "missing_arguments",
+          'browser clone requires "--source-user-data-dir <path>".',
+          "opensteer browser clone --source-user-data-dir <path>",
+        );
       }
       const result = await manager.clonePersistentBrowser({
         sourceUserDataDir,
@@ -263,7 +288,7 @@ async function handleBrowserCommand(parsed: ParsedCommandLine): Promise<void> {
       return;
     }
     default:
-      throw new Error(`Unknown browser command: ${parsed.command.join(" ")}`);
+      throw new CliError("unknown_command", `Unknown browser command: ${parsed.command.join(" ")}`);
   }
 }
 
@@ -304,26 +329,30 @@ async function handleCloseCommand(
 
 async function handleRecordCommandEntry(parsed: ParsedCommandLine): Promise<void> {
   if (parsed.options.workspace === undefined) {
-    throw new Error('record requires "--workspace <id>" or OPENSTEER_WORKSPACE.');
+    throw new CliError("missing_workspace", 'record requires "--workspace <id>" or OPENSTEER_WORKSPACE.');
   }
 
   const url = parsed.options.url ?? parsed.rest[0];
   if (url === undefined) {
-    throw new Error('record requires "--url <value>" or a positional URL.');
+    throw new CliError(
+      "missing_arguments",
+      'record requires "--url <value>" or a positional URL.',
+      "opensteer record --url <url> --workspace <id>",
+    );
   }
 
   const provider = resolveCliProvider(parsed);
   assertCloudCliOptionsMatchProvider(parsed, provider.mode);
   const engineName = resolveCliEngineName(parsed);
   if (engineName !== "playwright") {
-    throw new Error("record requires engine=playwright.");
+    throw new CliError("config_conflict", "record requires engine=playwright.");
   }
   const rootDir = process.cwd();
   const recordBrowser = parsed.options.browser;
 
   if (provider.mode === "cloud") {
     if (typeof recordBrowser === "object") {
-      throw new Error('record does not support browser.mode="attach".');
+      throw new CliError("config_conflict", 'record does not support browser.mode="attach".');
     }
 
     const runtimeProvider = buildCliRuntimeProvider(parsed, provider.mode);
@@ -346,11 +375,11 @@ async function handleRecordCommandEntry(parsed: ParsedCommandLine): Promise<void
   }
 
   if (parsed.options.launch?.headless === true) {
-    throw new Error('record requires a headed browser. Remove "--headless true".');
+    throw new CliError("config_conflict", 'record requires a headed browser. Remove "--headless true".');
   }
 
   if (typeof recordBrowser === "object") {
-    throw new Error('record does not support browser.mode="attach".');
+    throw new CliError("config_conflict", 'record does not support browser.mode="attach".');
   }
 
   const launch = {
@@ -436,7 +465,7 @@ function buildCliBrowserProfile(
     parsed.options.cloudProfileReuseIfActive === true &&
     parsed.options.cloudProfileId === undefined
   ) {
-    throw new Error('"--cloud-profile-reuse-if-active" requires "--cloud-profile-id <id>".');
+    throw new CliError("invalid_option", '"--cloud-profile-reuse-if-active" requires "--cloud-profile-id <id>".');
   }
 
   return parsed.options.cloudProfileId === undefined
@@ -537,7 +566,8 @@ function assertCloudCliOptionsMatchProvider(
       parsed.options.cloudProfileId !== undefined ||
       parsed.options.cloudProfileReuseIfActive === true)
   ) {
-    throw new Error(
+    throw new CliError(
+      "config_conflict",
       'Cloud-specific options require provider=cloud. Set "--provider cloud" or OPENSTEER_PROVIDER=cloud.',
     );
   }
@@ -575,20 +605,7 @@ function printVersion(): void {
 }
 
 main().catch((error) => {
-  const payload =
-    error instanceof Error
-      ? {
-          error: {
-            name: error.name,
-            message: error.message,
-          },
-        }
-      : {
-          error: {
-            name: "Error",
-            message: String(error),
-          },
-        };
+  const payload = formatCliErrorOutput(error);
   process.stderr.write(`${JSON.stringify(payload)}\n`);
   process.exitCode = 1;
 });

--- a/packages/opensteer/src/cli/errors.ts
+++ b/packages/opensteer/src/cli/errors.ts
@@ -1,0 +1,122 @@
+import { isBrowserCoreError } from "@opensteer/browser-core";
+import { isOpensteerProtocolError, type OpensteerError } from "@opensteer/protocol";
+
+export type CliErrorType =
+  | "unknown_command"
+  | "unknown_option"
+  | "missing_arguments"
+  | "invalid_value"
+  | "invalid_option"
+  | "missing_workspace"
+  | "config_conflict"
+  | "unsupported_operation";
+
+export class CliError extends Error {
+  readonly type: CliErrorType;
+  readonly usage: string | undefined;
+
+  constructor(type: CliErrorType, message: string, usage?: string) {
+    super(message);
+    this.name = "CliError";
+    this.type = type;
+    this.usage = usage;
+  }
+
+  format(): string {
+    return this.usage === undefined ? this.message : `${this.message}\nUsage: ${this.usage}`;
+  }
+}
+
+export function isCliError(value: unknown): value is CliError {
+  return value instanceof CliError;
+}
+
+export function formatCliErrorOutput(error: unknown): Record<string, unknown> {
+  if (isCliError(error)) {
+    return {
+      success: false,
+      error: error.format(),
+      type: error.type,
+    };
+  }
+
+  if (isOpensteerProtocolError(error)) {
+    return {
+      success: false,
+      error: error.message,
+      code: error.code,
+      retriable: error.retriable,
+    };
+  }
+
+  if (isBrowserCoreError(error)) {
+    return {
+      success: false,
+      error: error.message,
+      code: error.code,
+      retriable: error.retriable,
+    };
+  }
+
+  if (error instanceof Error && "opensteerError" in error) {
+    const oe = (error as { opensteerError: OpensteerError }).opensteerError;
+    return {
+      success: false,
+      error: oe.message,
+      code: oe.code,
+      retriable: oe.retriable,
+    };
+  }
+
+  if (error instanceof SyntaxError) {
+    return {
+      success: false,
+      error: error.message,
+      type: "invalid_value" as CliErrorType,
+    };
+  }
+
+  return {
+    success: false,
+    error: error instanceof Error ? error.message : String(error),
+  };
+}
+
+export function emitWarning(warning: string): void {
+  process.stderr.write(`${JSON.stringify({ warning })}\n`);
+}
+
+export const CLI_USAGE_HINTS: Partial<Record<string, string>> = {
+  "session.open": "opensteer open <url> [--workspace <id>]",
+  "page.goto": "opensteer goto <url>",
+  "page.evaluate": "opensteer evaluate <script>",
+  "page.add-init-script": "opensteer init-script <script>",
+  "dom.click": "opensteer click <element> --persist <key>",
+  "dom.hover": "opensteer hover <element> --persist <key>",
+  "dom.input": "opensteer input <element> <text> --persist <key>",
+  "dom.scroll": "opensteer scroll <direction> <amount> --persist <key>",
+  "dom.extract": "opensteer extract <template> --persist <key>",
+  "network.detail": "opensteer network detail <recordId>",
+  "session.fetch": "opensteer fetch <url>",
+  "captcha.solve": "opensteer captcha solve --provider <name> --api-key <key>",
+  "scripts.capture": "opensteer scripts capture",
+  "scripts.beautify": "opensteer scripts beautify <artifactId>",
+  "scripts.deobfuscate": "opensteer scripts deobfuscate <artifactId>",
+  "scripts.sandbox": "opensteer scripts sandbox <artifactId>",
+  "interaction.capture": "opensteer interaction capture",
+  "interaction.get": "opensteer interaction get <traceId>",
+  "interaction.replay": "opensteer interaction replay <traceId>",
+  "interaction.diff": "opensteer interaction diff <leftTraceId> <rightTraceId>",
+  "artifact.read": "opensteer artifact read <artifactId>",
+  "computer.click": "opensteer computer click <x> <y>",
+  "computer.type": "opensteer computer type <text>",
+  "computer.key": "opensteer computer key <key>",
+  "computer.scroll": "opensteer computer scroll <x> <y> --dx <n> --dy <n>",
+  "computer.move": "opensteer computer move <x> <y>",
+  "computer.drag": "opensteer computer drag <x1> <y1> <x2> <y2>",
+  "computer.screenshot": "opensteer computer screenshot",
+  exec: 'opensteer exec <expression>',
+  record: "opensteer record --url <url> --workspace <id>",
+  "browser.inspect": "opensteer browser inspect <endpoint>",
+  "browser.clone": "opensteer browser clone --source-user-data-dir <path>",
+};

--- a/packages/opensteer/src/cli/operation-input.ts
+++ b/packages/opensteer/src/cli/operation-input.ts
@@ -1,6 +1,7 @@
 import type { OpensteerSemanticOperationName } from "@opensteer/protocol";
 import type { OpensteerSemanticRuntime } from "@opensteer/runtime-core";
 
+import { CliError, CLI_USAGE_HINTS } from "./errors.js";
 import {
   parseCommaSeparatedList,
   parseKeyValueList,
@@ -32,7 +33,7 @@ export async function buildOperationInput(
     case "session.open": {
       const url = parsed.rest[0];
       if (url === undefined) {
-        throw new Error("open requires a URL.");
+        throw new CliError("missing_arguments", "open requires a URL.", CLI_USAGE_HINTS[operation]);
       }
       return {
         url,
@@ -65,7 +66,7 @@ export async function buildOperationInput(
     }
     case "page.goto": {
       if (parsed.rest[0] === undefined) {
-        throw new Error("goto requires a URL.");
+        throw new CliError("missing_arguments", "goto requires a URL.", CLI_USAGE_HINTS[operation]);
       }
       const captureNetwork = readSingle(parsed.rawOptions, "capture-network");
       return {
@@ -77,14 +78,14 @@ export async function buildOperationInput(
       return parsed.rest[0] === undefined ? {} : { mode: parsed.rest[0] };
     case "page.evaluate":
       if (parsed.rest[0] === undefined) {
-        throw new Error("evaluate requires a script.");
+        throw new CliError("missing_arguments", "evaluate requires a script.", CLI_USAGE_HINTS[operation]);
       }
       return {
         script: joinRest(parsed.rest, 0),
       };
     case "page.add-init-script":
       if (parsed.rest[0] === undefined) {
-        throw new Error("init-script requires a script.");
+        throw new CliError("missing_arguments", "init-script requires a script.", CLI_USAGE_HINTS[operation]);
       }
       return {
         script: joinRest(parsed.rest, 0),
@@ -100,7 +101,7 @@ export async function buildOperationInput(
       return buildElementTargetInput(parsed, "hover");
     case "dom.input": {
       if (parsed.rest[1] === undefined) {
-        throw new Error("input requires an element number and text.");
+        throw new CliError("missing_arguments", "input requires an element number and text.", CLI_USAGE_HINTS[operation]);
       }
       const pressEnter = readOptionalBoolean(parsed.rawOptions, "press-enter");
       return {
@@ -134,7 +135,7 @@ export async function buildOperationInput(
     }
     case "dom.extract": {
       if (parsed.rest[0] === undefined) {
-        throw new Error("extract requires a template.");
+        throw new CliError("missing_arguments", "extract requires a template.", CLI_USAGE_HINTS[operation]);
       }
       const persist = readPersistKey(parsed, "extract");
       return {
@@ -170,7 +171,7 @@ export async function buildOperationInput(
     }
     case "network.detail": {
       if (parsed.rest[0] === undefined) {
-        throw new Error("network detail requires a record id.");
+        throw new CliError("missing_arguments", "network detail requires a record id.", CLI_USAGE_HINTS[operation]);
       }
       const probeFlag = readOptionalBoolean(parsed.rawOptions, "probe");
       return {
@@ -181,7 +182,7 @@ export async function buildOperationInput(
     case "session.fetch": {
       const url = parsed.rest[0];
       if (url === undefined) {
-        throw new Error("fetch requires a URL.");
+        throw new CliError("missing_arguments", "fetch requires a URL.", CLI_USAGE_HINTS[operation]);
       }
       const bodyJson = readJsonValue(parsed.rawOptions, "body");
       const bodyText = readSingle(parsed.rawOptions, "body-text");
@@ -189,7 +190,7 @@ export async function buildOperationInput(
       const query = parseKeyValueList(parsed.rawOptions.get("query"));
       const headers = parseKeyValueList(parsed.rawOptions.get("header"));
       if (bodyJson !== undefined && bodyText !== undefined) {
-        throw new Error('Use either "--body" or "--body-text", not both.');
+        throw new CliError("invalid_option", 'Use either "--body" or "--body-text", not both.');
       }
       const transport = readSingle(parsed.rawOptions, "transport");
       const cookies = readOptionalBoolean(parsed.rawOptions, "cookies");
@@ -222,7 +223,7 @@ export async function buildOperationInput(
       const siteKey = readSingle(parsed.rawOptions, "site-key");
       const pageUrl = readSingle(parsed.rawOptions, "page-url");
       if (provider === undefined || apiKey === undefined) {
-        throw new Error('captcha solve requires "--provider" and "--api-key".');
+        throw new CliError("missing_arguments", 'captcha solve requires "--provider" and "--api-key".', CLI_USAGE_HINTS[operation]);
       }
       return {
         provider: readCaptchaProvider(provider),
@@ -252,7 +253,7 @@ export async function buildOperationInput(
     case "scripts.beautify":
     case "scripts.deobfuscate": {
       if (parsed.rest[0] === undefined) {
-        throw new Error(`${parsed.command.join(" ")} requires an artifact id.`);
+        throw new CliError("missing_arguments", `${parsed.command.join(" ")} requires an artifact id.`, CLI_USAGE_HINTS[operation]);
       }
       const persist = readOptionalBoolean(parsed.rawOptions, "persist");
       return {
@@ -262,7 +263,7 @@ export async function buildOperationInput(
     }
     case "scripts.sandbox":
       if (parsed.rest[0] === undefined) {
-        throw new Error("scripts sandbox requires an artifact id.");
+        throw new CliError("missing_arguments", "scripts sandbox requires an artifact id.", CLI_USAGE_HINTS[operation]);
       }
       {
         const fidelity = readSingle(parsed.rawOptions, "fidelity");
@@ -313,14 +314,14 @@ export async function buildOperationInput(
     case "interaction.get":
     case "interaction.replay":
       if (parsed.rest[0] === undefined) {
-        throw new Error(`${parsed.command.join(" ")} requires a trace id.`);
+        throw new CliError("missing_arguments", `${parsed.command.join(" ")} requires a trace id.`, CLI_USAGE_HINTS[operation]);
       }
       return {
         traceId: parsed.rest[0],
       };
     case "interaction.diff":
       if (parsed.rest[0] === undefined || parsed.rest[1] === undefined) {
-        throw new Error("interaction diff requires two trace ids.");
+        throw new CliError("missing_arguments", "interaction diff requires two trace ids.", CLI_USAGE_HINTS[operation]);
       }
       return {
         leftTraceId: parsed.rest[0],
@@ -328,7 +329,7 @@ export async function buildOperationInput(
       };
     case "artifact.read":
       if (parsed.rest[0] === undefined) {
-        throw new Error("artifact read requires an artifact id.");
+        throw new CliError("missing_arguments", "artifact read requires an artifact id.", CLI_USAGE_HINTS[operation]);
       }
       return {
         artifactId: parsed.rest[0],
@@ -336,7 +337,8 @@ export async function buildOperationInput(
     case "session.close":
       return {};
     default:
-      throw new Error(
+      throw new CliError(
+        "unsupported_operation",
         `${operation} does not have a direct CLI input shape. Use a supported command or the SDK.`,
       );
   }
@@ -392,7 +394,7 @@ function buildComputerExecuteInput(parsed: ParsedCommandLine): Record<string, un
     }
     case "type":
       if (parsed.rest[0] === undefined) {
-        throw new Error("computer type requires text.");
+        throw new CliError("missing_arguments", "computer type requires text.");
       }
       return {
         action: {
@@ -403,7 +405,7 @@ function buildComputerExecuteInput(parsed: ParsedCommandLine): Record<string, un
       };
     case "key": {
       if (parsed.rest[0] === undefined) {
-        throw new Error("computer key requires a key.");
+        throw new CliError("missing_arguments", "computer key requires a key.");
       }
       const modifiers = readKeyModifiers(readSingle(parsed.rawOptions, "modifiers"));
       return {
@@ -419,7 +421,7 @@ function buildComputerExecuteInput(parsed: ParsedCommandLine): Record<string, un
       const dx = readOptionalNumber(parsed.rawOptions, "dx");
       const dy = readOptionalNumber(parsed.rawOptions, "dy");
       if (dx === undefined || dy === undefined) {
-        throw new Error('computer scroll requires "--dx" and "--dy".');
+        throw new CliError("missing_arguments", 'computer scroll requires "--dx" and "--dy".');
       }
       return {
         action: {
@@ -474,7 +476,7 @@ function buildComputerExecuteInput(parsed: ParsedCommandLine): Record<string, un
         },
       };
     default:
-      throw new Error(`Unknown computer command: ${parsed.command.join(" ")}`);
+      throw new CliError("unknown_command", `Unknown computer command: ${parsed.command.join(" ")}`);
   }
 }
 
@@ -485,7 +487,7 @@ async function resolvePageRefByIndex(
   const pages = (await runtime.listPages({})).pages;
   const page = pages[index - 1];
   if (page === undefined) {
-    throw new Error(`tab ${String(index)} does not exist.`);
+    throw new CliError("invalid_value", `tab ${String(index)} does not exist.`);
   }
   return page.pageRef;
 }
@@ -493,32 +495,32 @@ async function resolvePageRefByIndex(
 function readRequiredPositiveInteger(value: string | undefined, message: string): number {
   const parsed = readRequiredNumber(value, message);
   if (!Number.isInteger(parsed) || parsed < 1) {
-    throw new Error(message);
+    throw new CliError("missing_arguments", message);
   }
   return parsed;
 }
 
 function readRequiredNumber(value: string | undefined, message: string): number {
   if (value === undefined) {
-    throw new Error(message);
+    throw new CliError("missing_arguments", message);
   }
   const parsed = Number(value);
   if (!Number.isFinite(parsed)) {
-    throw new Error(message);
+    throw new CliError("missing_arguments", message);
   }
   return parsed;
 }
 
 function readSingleDirection(value: string | undefined): "up" | "down" | "left" | "right" {
   if (value === undefined || !SCROLL_DIRECTIONS.has(value)) {
-    throw new Error("scroll requires a direction: up, down, left, or right.");
+    throw new CliError("missing_arguments", "scroll requires a direction: up, down, left, or right.");
   }
   return value as "up" | "down" | "left" | "right";
 }
 
 function readClickButton(value: string | undefined): "left" | "middle" | "right" {
   if (value === undefined || !CLICK_BUTTONS.has(value)) {
-    throw new Error('Expected "--button" to be one of: left, middle, right.');
+    throw new CliError("invalid_value", 'Expected "--button" to be one of: left, middle, right.');
   }
   return value as "left" | "middle" | "right";
 }
@@ -527,7 +529,8 @@ function readFetchTransport(
   value: string | undefined,
 ): "auto" | "direct" | "matched-tls" | "context" | "page" {
   if (value === undefined || !FETCH_TRANSPORTS.has(value)) {
-    throw new Error(
+    throw new CliError(
+      "invalid_value",
       'Expected "--transport" to be one of: auto, direct, matched-tls, context, page.',
     );
   }
@@ -536,35 +539,35 @@ function readFetchTransport(
 
 function readCaptchaProvider(value: string | undefined): "2captcha" | "capsolver" {
   if (value === undefined || !CAPTCHA_PROVIDERS.has(value)) {
-    throw new Error('Expected "--provider" to be one of: 2captcha, capsolver.');
+    throw new CliError("invalid_value", 'Expected "--provider" to be one of: 2captcha, capsolver.');
   }
   return value as "2captcha" | "capsolver";
 }
 
 function readCaptchaType(value: string | undefined): "recaptcha-v2" | "hcaptcha" | "turnstile" {
   if (value === undefined || !CAPTCHA_TYPES.has(value)) {
-    throw new Error('Expected "--type" to be one of: recaptcha-v2, hcaptcha, turnstile.');
+    throw new CliError("invalid_value", 'Expected "--type" to be one of: recaptcha-v2, hcaptcha, turnstile.');
   }
   return value as "recaptcha-v2" | "hcaptcha" | "turnstile";
 }
 
 function readSandboxFidelity(value: string | undefined): "minimal" | "standard" | "full" {
   if (value === undefined || !SANDBOX_FIDELITIES.has(value)) {
-    throw new Error('Expected "--fidelity" to be one of: minimal, standard, full.');
+    throw new CliError("invalid_value", 'Expected "--fidelity" to be one of: minimal, standard, full.');
   }
   return value as "minimal" | "standard" | "full";
 }
 
 function readSandboxClockMode(value: string | undefined): "real" | "manual" {
   if (value === undefined || !SANDBOX_CLOCK_MODES.has(value)) {
-    throw new Error('Expected "--clock" to be one of: real, manual.');
+    throw new CliError("invalid_value", 'Expected "--clock" to be one of: real, manual.');
   }
   return value as "real" | "manual";
 }
 
 function readScreenshotFormat(value: string | undefined): "png" | "jpeg" | "webp" {
   if (value === undefined || !SCREENSHOT_FORMATS.has(value)) {
-    throw new Error('Expected "--format" to be one of: png, jpeg, webp.');
+    throw new CliError("invalid_value", 'Expected "--format" to be one of: png, jpeg, webp.');
   }
   return value as "png" | "jpeg" | "webp";
 }
@@ -578,7 +581,7 @@ function readKeyModifiers(
   }
   for (const modifier of modifiers) {
     if (!KEY_MODIFIERS.has(modifier)) {
-      throw new Error('Expected "--modifiers" to contain only: Shift, Control, Alt, Meta.');
+      throw new CliError("invalid_value", 'Expected "--modifiers" to contain only: Shift, Control, Alt, Meta.');
     }
   }
   return [...new Set(modifiers)] as readonly ("Shift" | "Control" | "Alt" | "Meta")[];
@@ -590,18 +593,23 @@ function readPersistKey(
 ): string {
   const value = readSingle(parsed.rawOptions, "persist");
   if (value === undefined) {
-    throw new Error(`${verb} requires "--persist <key>".`);
+    throw new CliError("missing_arguments", `${verb} requires "--persist <key>".`);
   }
   if (value === "true" || value === "false") {
-    throw new Error(`${verb} requires "--persist <key>".`);
+    throw new CliError("missing_arguments", `${verb} requires "--persist <key>".`);
   }
   return value;
 }
 
 function parseRequiredJsonObjectArgument(value: string, label: string): Record<string, unknown> {
-  const parsed = JSON.parse(value);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new CliError("invalid_value", `${label} contains invalid JSON.`);
+  }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(`${label} must be a JSON object.`);
+    throw new CliError("invalid_value", `${label} must be a JSON object.`);
   }
   return parsed as Record<string, unknown>;
 }

--- a/packages/opensteer/src/cli/parse.ts
+++ b/packages/opensteer/src/cli/parse.ts
@@ -4,6 +4,7 @@ import type { OpensteerBrowserOptions } from "@opensteer/protocol";
 
 import { normalizeOpensteerProviderMode, type OpensteerProviderMode } from "../provider/config.js";
 import { resolveCommandLength } from "./commands.js";
+import { CliError } from "./errors.js";
 
 export interface ParsedCliOptions {
   readonly workspace?: string;
@@ -163,7 +164,7 @@ export function parseCommandLine(argv: readonly string[]): ParsedCommandLine {
     const key = token.slice(2, separator === -1 ? undefined : separator);
     const spec = CLI_OPTION_SPECS[key as keyof typeof CLI_OPTION_SPECS];
     if (spec === undefined) {
-      throw new Error(`Unknown option: --${key}.`);
+      throw new CliError("unknown_option", `Unknown option: --${key}.`);
     }
 
     if (separator !== -1) {
@@ -197,7 +198,8 @@ export function parseCommandLine(argv: readonly string[]): ParsedCommandLine {
     }
 
     if (next === undefined || next.startsWith("--")) {
-      throw new Error(
+      throw new CliError(
+        "missing_arguments",
         `Option "--${key}" requires a value.${next?.startsWith("--") === true ? ` Use "--${key}=<value>" when the value begins with "--".` : ``}`,
       );
     }
@@ -256,10 +258,14 @@ export function parseCommandLine(argv: readonly string[]): ParsedCommandLine {
   const autoLocalView = readOptionalBoolean(rawOptions, "auto");
   const noAutoLocalView = readOptionalBoolean(rawOptions, "no-auto");
   if (autoLocalView === true && noAutoLocalView === true) {
-    throw new Error('Options "--auto" and "--no-auto" cannot be combined.');
+    throw new CliError("invalid_option", 'Options "--auto" and "--no-auto" cannot be combined.');
   }
   if (command[0] !== "view" && (autoLocalView !== undefined || noAutoLocalView !== undefined)) {
-    throw new Error('Options "--auto" and "--no-auto" are only supported with "view".');
+    throw new CliError(
+      "invalid_option",
+      'Options "--auto" and "--no-auto" are only supported with "view".',
+      "opensteer view --auto",
+    );
   }
   const global = readOptionalBoolean(rawOptions, "global");
   const yes = readOptionalBoolean(rawOptions, "yes");
@@ -325,7 +331,7 @@ export function parseKeyValueList(
     values.map((entry) => {
       const separator = entry.indexOf("=");
       if (separator <= 0) {
-        throw new Error(`Expected NAME=VALUE, received "${entry}".`);
+        throw new CliError("invalid_value", `Expected NAME=VALUE, received "${entry}".`);
       }
       return [entry.slice(0, separator), entry.slice(separator + 1)];
     }),
@@ -368,7 +374,7 @@ export function readOptionalBoolean(
   if (value === "false") {
     return false;
   }
-  throw new Error(`Option "--${name}" must be true or false.`);
+  throw new CliError("invalid_value", `Option "--${name}" must be true or false.`);
 }
 
 export function readOptionalNumber(
@@ -381,7 +387,7 @@ export function readOptionalNumber(
   }
   const parsed = Number(value);
   if (!Number.isFinite(parsed)) {
-    throw new Error(`Option "--${name}" must be a number.`);
+    throw new CliError("invalid_value", `Option "--${name}" must be a number.`);
   }
   return parsed;
 }
@@ -391,7 +397,14 @@ export function readJsonValue(
   name: string,
 ): unknown {
   const value = readSingle(options, name);
-  return value === undefined ? undefined : JSON.parse(value);
+  if (value === undefined) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    throw new CliError("invalid_value", `Option "--${name}" contains invalid JSON.`);
+  }
 }
 
 export function readJsonObject(
@@ -403,7 +416,7 @@ export function readJsonObject(
     return undefined;
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(`Option "--${name}" must be a JSON object.`);
+    throw new CliError("invalid_value", `Option "--${name}" must be a JSON object.`);
   }
   return parsed as Record<string, unknown>;
 }
@@ -417,7 +430,7 @@ export function readJsonArray(
     return undefined;
   }
   if (!Array.isArray(parsed)) {
-    throw new Error(`Option "--${name}" must be a JSON array.`);
+    throw new CliError("invalid_value", `Option "--${name}" must be a JSON array.`);
   }
   return parsed;
 }

--- a/packages/opensteer/src/cli/view.ts
+++ b/packages/opensteer/src/cli/view.ts
@@ -11,6 +11,7 @@ import {
 } from "../local-view/service.js";
 import { buildLocalViewSessionId } from "../local-view/session-manifest.js";
 import { resolveFilesystemWorkspacePath } from "../root.js";
+import { CliError } from "./errors.js";
 import type { ParsedCommandLine } from "./parse.js";
 import { openBrowserUrl, type BrowserUrlOpener } from "./open-browser.js";
 
@@ -36,7 +37,7 @@ export async function handleViewCommand(
   }
 
   if (subcommand !== undefined) {
-    throw new Error(`Unknown view command: view ${subcommand}`);
+    throw new CliError("unknown_command", `Unknown view command: view ${subcommand}`);
   }
 
   if (parsed.options.localViewMode !== undefined) {
@@ -96,7 +97,10 @@ async function resolveWorkspaceSessionId(input: {
 
 function assertNoViewPreferenceFlag(parsed: ParsedCommandLine): void {
   if (parsed.options.localViewMode !== undefined) {
-    throw new Error("View preference flags cannot be combined with this subcommand.");
+    throw new CliError(
+      "invalid_option",
+      "View preference flags cannot be combined with this subcommand.",
+    );
   }
 }
 

--- a/packages/opensteer/src/cloud/client.ts
+++ b/packages/opensteer/src/cloud/client.ts
@@ -400,18 +400,15 @@ async function createCloudRequestError(
     pathname: input.pathname,
     url: input.url,
     message:
-      payload?.error ??
-      `${input.method} ${input.pathname} failed with ${String(response.status)}.`,
+      payload?.error ?? `${input.method} ${input.pathname} failed with ${String(response.status)}.`,
     ...(payload?.code === undefined ? {} : { code: payload.code }),
     ...(payload?.details === undefined ? {} : { details: payload.details }),
   });
 }
 
-async function readCloudErrorPayload(response: Response): Promise<OpensteerCloudErrorPayload | undefined> {
-  if (typeof response.json !== "function") {
-    return undefined;
-  }
-
+async function readCloudErrorPayload(
+  response: Response,
+): Promise<OpensteerCloudErrorPayload | undefined> {
   try {
     return asCloudErrorPayload(await response.json());
   } catch {

--- a/packages/opensteer/src/cloud/client.ts
+++ b/packages/opensteer/src/cloud/client.ts
@@ -36,12 +36,24 @@ export interface OpensteerCloudSessionDescriptor {
   readonly initialGrantExpiresAt?: number;
 }
 
-interface OpensteerCloudSessionState {
+export interface OpensteerCloudSessionState {
   readonly status?: string;
+  readonly runtimeWorkerId?: string;
+  readonly registryDesiredRevision?: number;
+  readonly registryLoadedRevision?: number;
+  readonly idleTimeoutMs?: number;
+  readonly absoluteTtlMs?: number;
+  readonly expiresAt?: number;
 }
 
 interface OpensteerCloudSessionCloseDescriptor {
   readonly status?: string;
+}
+
+interface OpensteerCloudErrorPayload {
+  readonly error?: string;
+  readonly code?: string;
+  readonly details?: unknown;
 }
 
 interface CloudRequestOptions {
@@ -53,6 +65,34 @@ const CLOUD_CLOSE_TIMEOUT_MS = 60_000;
 const CLOUD_CLOSE_POLL_INTERVAL_MS = 250;
 
 export type { SyncBrowserProfileCookiesInput };
+
+export class OpensteerCloudRequestError extends Error {
+  readonly statusCode: number;
+  readonly code: string | undefined;
+  readonly details: unknown;
+  readonly method: string;
+  readonly pathname: string;
+  readonly url: string;
+
+  constructor(args: {
+    readonly statusCode: number;
+    readonly code?: string;
+    readonly details?: unknown;
+    readonly method: string;
+    readonly pathname: string;
+    readonly url: string;
+    readonly message: string;
+  }) {
+    super(args.message);
+    this.name = "OpensteerCloudRequestError";
+    this.statusCode = args.statusCode;
+    this.code = args.code;
+    this.details = args.details;
+    this.method = args.method;
+    this.pathname = args.pathname;
+    this.url = args.url;
+  }
+}
 
 export class OpensteerCloudClient {
   constructor(private readonly config: OpensteerCloudConfig) {}
@@ -279,7 +319,11 @@ export class OpensteerCloudClient {
       });
     }
     if (!response.ok) {
-      throw new Error(`${init.method} ${pathname} failed with ${String(response.status)}.`);
+      throw await createCloudRequestError(response, {
+        method: init.method,
+        pathname,
+        url,
+      });
     }
     return response;
   }
@@ -339,4 +383,51 @@ function wrapCloudFetchError(
   );
   wrapped.name = error.name;
   return wrapped;
+}
+
+async function createCloudRequestError(
+  response: Response,
+  input: {
+    readonly method: string;
+    readonly pathname: string;
+    readonly url: string;
+  },
+): Promise<OpensteerCloudRequestError> {
+  const payload = await readCloudErrorPayload(response);
+  return new OpensteerCloudRequestError({
+    statusCode: response.status,
+    method: input.method,
+    pathname: input.pathname,
+    url: input.url,
+    message:
+      payload?.error ??
+      `${input.method} ${input.pathname} failed with ${String(response.status)}.`,
+    ...(payload?.code === undefined ? {} : { code: payload.code }),
+    ...(payload?.details === undefined ? {} : { details: payload.details }),
+  });
+}
+
+async function readCloudErrorPayload(response: Response): Promise<OpensteerCloudErrorPayload | undefined> {
+  if (typeof response.json !== "function") {
+    return undefined;
+  }
+
+  try {
+    return asCloudErrorPayload(await response.json());
+  } catch {
+    return undefined;
+  }
+}
+
+function asCloudErrorPayload(value: unknown): OpensteerCloudErrorPayload | undefined {
+  if (value === null || typeof value !== "object") {
+    return undefined;
+  }
+
+  const payload = value as Record<string, unknown>;
+  return {
+    ...(typeof payload.error === "string" ? { error: payload.error } : {}),
+    ...(typeof payload.code === "string" ? { code: payload.code } : {}),
+    ...("details" in payload ? { details: payload.details } : {}),
+  };
 }

--- a/packages/opensteer/src/cloud/session-proxy.ts
+++ b/packages/opensteer/src/cloud/session-proxy.ts
@@ -104,14 +104,8 @@ import {
 } from "../sdk/semantic-rest-client.js";
 import type { OpensteerDisconnectableRuntime } from "../sdk/semantic-runtime.js";
 import { OpensteerCloudAutomationClient } from "./automation-client.js";
-import type {
-  OpensteerCloudSessionCreateInput,
-  OpensteerCloudSessionState,
-} from "./client.js";
-import {
-  OpensteerCloudClient,
-  OpensteerCloudRequestError,
-} from "./client.js";
+import type { OpensteerCloudSessionCreateInput, OpensteerCloudSessionState } from "./client.js";
+import { OpensteerCloudClient, OpensteerCloudRequestError } from "./client.js";
 import { syncLocalWorkspaceToCloud } from "./workspace-sync.js";
 
 const TEMPORARY_CLOUD_WORKSPACE_PREFIX = "opensteer-cloud-workspace-";
@@ -133,6 +127,21 @@ interface CloudSessionInitInput {
   readonly browserProfile?: CloudBrowserProfilePreference;
 }
 
+type CloudBootstrapRecoveryOperation =
+  | "session.open"
+  | "instrumentation.route"
+  | "instrumentation.intercept-script";
+
+type StoredCloudInstrumentation =
+  | {
+      readonly kind: "route";
+      readonly input: OpensteerRouteOptions;
+    }
+  | {
+      readonly kind: "intercept-script";
+      readonly input: OpensteerInterceptScriptOptions;
+    };
+
 export { readPersistedCloudSessionRecord, resolveCloudSessionRecordPath };
 export type { PersistedCloudSessionRecord };
 
@@ -150,6 +159,8 @@ export class CloudSessionProxy implements OpensteerDisconnectableRuntime {
   private automation: OpensteerCloudAutomationClient | undefined;
   private workspaceStore: FilesystemOpensteerWorkspace | undefined;
   private syncWorkspaceOnClose = false;
+  private liveSessionStateEstablished = false;
+  private readonly storedInstrumentation: StoredCloudInstrumentation[] = [];
 
   constructor(cloud: OpensteerCloudClient, options: CloudSessionProxyOptions = {}) {
     this.cloud = cloud;
@@ -196,16 +207,14 @@ export class CloudSessionProxy implements OpensteerDisconnectableRuntime {
       this.bindClient(persisted);
     }
 
-    if (this.automation) {
-      try {
-        const sessionInfo = await this.automation.getSessionInfo();
-        return {
-          ...sessionInfo,
-          ...(this.workspace === undefined ? {} : { workspace: this.workspace }),
-        };
-      } catch {
-        // Fall back to local proxy metadata when the automation channel is unavailable.
-      }
+    const sessionInfo = this.automation
+      ? await this.automation.getSessionInfo().catch(() => undefined)
+      : undefined;
+    if (sessionInfo !== undefined) {
+      return {
+        ...sessionInfo,
+        ...(this.workspace === undefined ? {} : { workspace: this.workspace }),
+      };
     }
 
     return {
@@ -364,15 +373,29 @@ export class CloudSessionProxy implements OpensteerDisconnectableRuntime {
   }
 
   async route(input: OpensteerRouteOptions): Promise<OpensteerRouteRegistration> {
-    await this.ensureSession();
-    return this.requireAutomation().route(input);
+    const registration = await this.invokeBootstrapInstrumentationOperation(
+      "instrumentation.route",
+      (automation) => automation.route(input),
+    );
+    this.storedInstrumentation.push({
+      kind: "route",
+      input,
+    });
+    return registration;
   }
 
   async interceptScript(
     input: OpensteerInterceptScriptOptions,
   ): Promise<OpensteerRouteRegistration> {
-    await this.ensureSession();
-    return this.requireAutomation().interceptScript(input);
+    const registration = await this.invokeBootstrapInstrumentationOperation(
+      "instrumentation.intercept-script",
+      (automation) => automation.interceptScript(input),
+    );
+    this.storedInstrumentation.push({
+      kind: "intercept-script",
+      input,
+    });
+    return registration;
   }
 
   async getStorageSnapshot(
@@ -435,6 +458,8 @@ export class CloudSessionProxy implements OpensteerDisconnectableRuntime {
       this.client = undefined;
       this.sessionId = undefined;
       this.semanticGrant = undefined;
+      this.liveSessionStateEstablished = false;
+      this.storedInstrumentation.length = 0;
       if (this.cleanupRootOnClose) {
         await rm(this.rootPath, { recursive: true, force: true }).catch(() => undefined);
       }
@@ -467,6 +492,8 @@ export class CloudSessionProxy implements OpensteerDisconnectableRuntime {
     this.automation = undefined;
     this.sessionId = undefined;
     this.semanticGrant = undefined;
+    this.liveSessionStateEstablished = false;
+    this.storedInstrumentation.length = 0;
 
     if (syncError !== undefined) {
       throw syncError;
@@ -529,6 +556,7 @@ export class CloudSessionProxy implements OpensteerDisconnectableRuntime {
     };
     await this.writePersistedSession(record);
     this.bindClient(record, session.initialGrants?.semantic);
+    await this.restoreStoredInstrumentation();
   }
 
   private async syncWorkspaceToCloud(): Promise<void> {
@@ -547,12 +575,28 @@ export class CloudSessionProxy implements OpensteerDisconnectableRuntime {
     this.sessionId = record.sessionId;
     this.semanticGrant =
       initialSemanticGrant?.kind === "semantic" ? initialSemanticGrant : undefined;
+    this.liveSessionStateEstablished = false;
     this.client = new OpensteerSemanticRestClient({
       getBaseUrl: async () => (await this.ensureSemanticGrant()).url,
       getAuthorizationHeader: async () => `Bearer ${(await this.ensureSemanticGrant()).token}`,
       handleError: (error) => this.handleSemanticClientError(error),
     });
     this.automation = new OpensteerCloudAutomationClient(this.cloud, record.sessionId);
+  }
+
+  private async restoreStoredInstrumentation(): Promise<void> {
+    if (this.storedInstrumentation.length === 0) {
+      return;
+    }
+
+    const automation = this.requireAutomation();
+    for (const registration of this.storedInstrumentation) {
+      if (registration.kind === "route") {
+        await automation.route(registration.input);
+      } else {
+        await automation.interceptScript(registration.input);
+      }
+    }
   }
 
   private async ensureWorkspaceStore(): Promise<FilesystemOpensteerWorkspace> {
@@ -588,6 +632,7 @@ export class CloudSessionProxy implements OpensteerDisconnectableRuntime {
     this.client = undefined;
     this.sessionId = undefined;
     this.semanticGrant = undefined;
+    this.liveSessionStateEstablished = false;
     await this.clearPersistedSession();
   }
 
@@ -666,8 +711,7 @@ export class CloudSessionProxy implements OpensteerDisconnectableRuntime {
       await this.ensureSemanticGrant(true);
       return true;
     } catch (refreshError) {
-      if (isRecoverableCloudSessionError(refreshError)) {
-        await this.invalidateSession();
+      if (await this.resetStaleSession(refreshError)) {
         throw refreshError;
       }
       return false;
@@ -679,13 +723,15 @@ export class CloudSessionProxy implements OpensteerDisconnectableRuntime {
     input: TInput,
     sessionInit: CloudSessionInitInput = {},
   ): Promise<TOutput> {
-    return this.runOperationWithSessionRecovery(operation, async (timeout) => {
+    return this.runOperationWithSessionRecovery<TOutput>(operation, async (timeout) => {
       await this.ensureSession(sessionInit, timeout);
       await this.ensureSemanticGrant(false, timeout);
-      return this.requireClient().invoke(operation, input, {
+      const output = await this.requireClient().invoke<TInput, TOutput>(operation, input, {
         signal: timeout.signal,
         timeoutMs: timeout.remainingMs(),
       });
+      this.noteSuccessfulLiveOperation(operation);
+      return output;
     });
   }
 
@@ -694,10 +740,31 @@ export class CloudSessionProxy implements OpensteerDisconnectableRuntime {
     invoke: (automation: OpensteerCloudAutomationClient) => Promise<TOutput>,
     sessionInit: CloudSessionInitInput = {},
   ): Promise<TOutput> {
-    return this.runOperationWithSessionRecovery(operation, async (timeout) => {
+    return this.runOperationWithSessionRecovery<TOutput>(operation, async (timeout) => {
       await this.ensureSession(sessionInit, timeout);
-      return invoke(this.requireAutomation());
+      const output = await invoke(this.requireAutomation());
+      this.noteSuccessfulLiveOperation(operation);
+      return output;
     });
+  }
+
+  private async invokeBootstrapInstrumentationOperation<TOutput>(
+    operation: Exclude<CloudBootstrapRecoveryOperation, "session.open">,
+    invoke: (automation: OpensteerCloudAutomationClient) => Promise<TOutput>,
+  ): Promise<TOutput> {
+    let recovered = false;
+    while (true) {
+      try {
+        await this.ensureSession();
+        return await invoke(this.requireAutomation());
+      } catch (error) {
+        const stale = await this.resetStaleSession(error);
+        if (!stale || recovered || !this.canRecoverWithFreshSession(operation)) {
+          throw error;
+        }
+        recovered = true;
+      }
+    }
   }
 
   private async runOperationWithSessionRecovery<T>(
@@ -710,7 +777,8 @@ export class CloudSessionProxy implements OpensteerDisconnectableRuntime {
         try {
           return await invoke(timeout);
         } catch (error) {
-          if (recovered || !(await this.tryRecoverStaleSession(error))) {
+          const stale = await this.resetStaleSession(error);
+          if (!stale || recovered || !this.canRecoverWithFreshSession(operation)) {
             throw error;
           }
           recovered = true;
@@ -719,12 +787,58 @@ export class CloudSessionProxy implements OpensteerDisconnectableRuntime {
     });
   }
 
-  private async tryRecoverStaleSession(error: unknown): Promise<boolean> {
+  private async resetStaleSession(error: unknown): Promise<boolean> {
     if (!isRecoverableCloudSessionError(error)) {
       return false;
     }
     await this.invalidateSession();
     return true;
+  }
+
+  private canRecoverWithFreshSession(
+    operation:
+      | OpensteerSemanticOperationName
+      | Exclude<CloudBootstrapRecoveryOperation, "session.open">,
+  ): boolean {
+    return !this.liveSessionStateEstablished && isBootstrapRecoveryOperation(operation);
+  }
+
+  private noteSuccessfulLiveOperation(operation: OpensteerSemanticOperationName): void {
+    if (
+      operation === "session.open" ||
+      operation === "page.list" ||
+      operation === "page.new" ||
+      operation === "page.activate" ||
+      operation === "page.close" ||
+      operation === "page.goto" ||
+      operation === "page.evaluate" ||
+      operation === "page.add-init-script" ||
+      operation === "page.snapshot" ||
+      operation === "dom.click" ||
+      operation === "dom.hover" ||
+      operation === "dom.input" ||
+      operation === "dom.scroll" ||
+      operation === "dom.extract" ||
+      operation === "network.query" ||
+      operation === "network.detail" ||
+      operation === "interaction.capture" ||
+      operation === "interaction.get" ||
+      operation === "interaction.diff" ||
+      operation === "interaction.replay" ||
+      operation === "scripts.capture" ||
+      operation === "artifact.read" ||
+      operation === "scripts.beautify" ||
+      operation === "scripts.deobfuscate" ||
+      operation === "scripts.sandbox" ||
+      operation === "captcha.solve" ||
+      operation === "session.cookies" ||
+      operation === "session.storage" ||
+      operation === "session.state" ||
+      operation === "session.fetch" ||
+      operation === "computer.execute"
+    ) {
+      this.liveSessionStateEstablished = true;
+    }
   }
 
   private async runOperationWithPolicy<T>(
@@ -763,7 +877,10 @@ function assertSupportedCloudBrowserMode(browser: OpensteerOpenInput["browser"] 
 
 function isMissingCloudSessionError(error: unknown): boolean {
   if (error instanceof OpensteerCloudRequestError) {
-    return error.statusCode === 404 && (error.code === undefined || error.code === "CLOUD_SESSION_NOT_FOUND");
+    return (
+      error.statusCode === 404 &&
+      (error.code === undefined || error.code === "CLOUD_SESSION_NOT_FOUND")
+    );
   }
   return error instanceof Error && /\b404\b/.test(error.message);
 }
@@ -780,12 +897,20 @@ function isRecoverableCloudSessionError(error: unknown): boolean {
   return error.statusCode === 409 && error.code === "CLOUD_SESSION_STALE";
 }
 
+function isBootstrapRecoveryOperation(
+  operation:
+    | OpensteerSemanticOperationName
+    | Exclude<CloudBootstrapRecoveryOperation, "session.open">,
+): operation is CloudBootstrapRecoveryOperation {
+  return (
+    operation === "session.open" ||
+    operation === "instrumentation.route" ||
+    operation === "instrumentation.intercept-script"
+  );
+}
+
 function isReusableCloudSessionState(session: OpensteerCloudSessionState): boolean {
-  if (
-    session.status === "closing" ||
-    session.status === "closed" ||
-    session.status === "failed"
-  ) {
+  if (session.status === "closing" || session.status === "closed" || session.status === "failed") {
     return false;
   }
 

--- a/packages/opensteer/src/cloud/session-proxy.ts
+++ b/packages/opensteer/src/cloud/session-proxy.ts
@@ -104,11 +104,18 @@ import {
 } from "../sdk/semantic-rest-client.js";
 import type { OpensteerDisconnectableRuntime } from "../sdk/semantic-runtime.js";
 import { OpensteerCloudAutomationClient } from "./automation-client.js";
-import type { OpensteerCloudSessionCreateInput } from "./client.js";
-import { OpensteerCloudClient } from "./client.js";
+import type {
+  OpensteerCloudSessionCreateInput,
+  OpensteerCloudSessionState,
+} from "./client.js";
+import {
+  OpensteerCloudClient,
+  OpensteerCloudRequestError,
+} from "./client.js";
 import { syncLocalWorkspaceToCloud } from "./workspace-sync.js";
 
 const TEMPORARY_CLOUD_WORKSPACE_PREFIX = "opensteer-cloud-workspace-";
+const CLOUD_SESSION_REUSE_EXPIRY_SKEW_MS = 10_000;
 
 export interface CloudSessionProxyOptions {
   readonly rootDir?: string;
@@ -575,6 +582,15 @@ export class CloudSessionProxy implements OpensteerDisconnectableRuntime {
     await clearPersistedSessionRecord(this.rootPath, "cloud").catch(() => undefined);
   }
 
+  private async invalidateSession(): Promise<void> {
+    await this.automation?.close().catch(() => undefined);
+    this.automation = undefined;
+    this.client = undefined;
+    this.sessionId = undefined;
+    this.semanticGrant = undefined;
+    await this.clearPersistedSession();
+  }
+
   private async isReusableCloudSession(
     sessionId: string,
     timeout?: TimeoutExecutionContext,
@@ -584,7 +600,7 @@ export class CloudSessionProxy implements OpensteerDisconnectableRuntime {
         signal: timeout?.signal,
         timeoutMs: timeout?.remainingMs(),
       });
-      return session.status !== "closed" && session.status !== "failed";
+      return isReusableCloudSessionState(session);
     } catch (error) {
       if (isMissingCloudSessionError(error)) {
         return false;
@@ -649,7 +665,11 @@ export class CloudSessionProxy implements OpensteerDisconnectableRuntime {
     try {
       await this.ensureSemanticGrant(true);
       return true;
-    } catch {
+    } catch (refreshError) {
+      if (isRecoverableCloudSessionError(refreshError)) {
+        await this.invalidateSession();
+        throw refreshError;
+      }
       return false;
     }
   }
@@ -659,7 +679,7 @@ export class CloudSessionProxy implements OpensteerDisconnectableRuntime {
     input: TInput,
     sessionInit: CloudSessionInitInput = {},
   ): Promise<TOutput> {
-    return this.runOperationWithPolicy(operation, async (timeout) => {
+    return this.runOperationWithSessionRecovery(operation, async (timeout) => {
       await this.ensureSession(sessionInit, timeout);
       await this.ensureSemanticGrant(false, timeout);
       return this.requireClient().invoke(operation, input, {
@@ -674,10 +694,37 @@ export class CloudSessionProxy implements OpensteerDisconnectableRuntime {
     invoke: (automation: OpensteerCloudAutomationClient) => Promise<TOutput>,
     sessionInit: CloudSessionInitInput = {},
   ): Promise<TOutput> {
-    return this.runOperationWithPolicy(operation, async (timeout) => {
+    return this.runOperationWithSessionRecovery(operation, async (timeout) => {
       await this.ensureSession(sessionInit, timeout);
       return invoke(this.requireAutomation());
     });
+  }
+
+  private async runOperationWithSessionRecovery<T>(
+    operation: OpensteerSemanticOperationName,
+    invoke: (timeout: TimeoutExecutionContext) => Promise<T>,
+  ): Promise<T> {
+    return this.runOperationWithPolicy(operation, async (timeout) => {
+      let recovered = false;
+      while (true) {
+        try {
+          return await invoke(timeout);
+        } catch (error) {
+          if (recovered || !(await this.tryRecoverStaleSession(error))) {
+            throw error;
+          }
+          recovered = true;
+        }
+      }
+    });
+  }
+
+  private async tryRecoverStaleSession(error: unknown): Promise<boolean> {
+    if (!isRecoverableCloudSessionError(error)) {
+      return false;
+    }
+    await this.invalidateSession();
+    return true;
   }
 
   private async runOperationWithPolicy<T>(
@@ -715,7 +762,37 @@ function assertSupportedCloudBrowserMode(browser: OpensteerOpenInput["browser"] 
 }
 
 function isMissingCloudSessionError(error: unknown): boolean {
+  if (error instanceof OpensteerCloudRequestError) {
+    return error.statusCode === 404 && (error.code === undefined || error.code === "CLOUD_SESSION_NOT_FOUND");
+  }
   return error instanceof Error && /\b404\b/.test(error.message);
+}
+
+function isRecoverableCloudSessionError(error: unknown): boolean {
+  if (!(error instanceof OpensteerCloudRequestError)) {
+    return false;
+  }
+
+  if (error.statusCode === 404) {
+    return error.code === undefined || error.code === "CLOUD_SESSION_NOT_FOUND";
+  }
+
+  return error.statusCode === 409 && error.code === "CLOUD_SESSION_STALE";
+}
+
+function isReusableCloudSessionState(session: OpensteerCloudSessionState): boolean {
+  if (
+    session.status === "closing" ||
+    session.status === "closed" ||
+    session.status === "failed"
+  ) {
+    return false;
+  }
+
+  return !(
+    typeof session.expiresAt === "number" &&
+    session.expiresAt <= Date.now() + CLOUD_SESSION_REUSE_EXPIRY_SKEW_MS
+  );
 }
 
 function isLoopbackBaseUrl(baseUrl: string): boolean {

--- a/packages/opensteer/src/index.ts
+++ b/packages/opensteer/src/index.ts
@@ -296,3 +296,10 @@ export {
   inspectCdpEndpoint,
   OpensteerAttachAmbiguousError,
 } from "./local-browser/cdp-discovery.js";
+export {
+  OpensteerProtocolError,
+  isOpensteerProtocolError,
+  opensteerErrorCodes,
+  type OpensteerError,
+  type OpensteerErrorCode,
+} from "@opensteer/protocol";

--- a/packages/opensteer/src/internal/errors.ts
+++ b/packages/opensteer/src/internal/errors.ts
@@ -32,6 +32,20 @@ export function normalizeThrownOpensteerError(
     });
   }
 
+  if (
+    error instanceof Error &&
+    "opensteerError" in error &&
+    typeof (error as { opensteerError: unknown }).opensteerError === "object" &&
+    (error as { opensteerError: unknown }).opensteerError !== null
+  ) {
+    const oe = (error as { opensteerError: OpensteerError }).opensteerError;
+    return createOpensteerError(oe.code, oe.message, {
+      retriable: oe.retriable,
+      ...(oe.capability === undefined ? {} : { capability: oe.capability }),
+      ...(oe.details === undefined ? {} : { details: oe.details }),
+    });
+  }
+
   if (error instanceof Error) {
     return createOpensteerError("operation-failed", error.message, {
       details: {

--- a/packages/opensteer/src/provider/config.ts
+++ b/packages/opensteer/src/provider/config.ts
@@ -1,4 +1,4 @@
-import type { CloudBrowserProfilePreference } from "@opensteer/protocol";
+import { OpensteerProtocolError, type CloudBrowserProfilePreference } from "@opensteer/protocol";
 
 export const OPENSTEER_PROVIDER_MODES = ["local", "cloud"] as const;
 
@@ -37,7 +37,8 @@ export function assertProviderSupportsEngine(
   }
 
   if (provider === "cloud") {
-    throw new Error(
+    throw new OpensteerProtocolError(
+      "invalid-argument",
       "ABP is not supported for provider=cloud. Cloud provider currently requires Playwright.",
     );
   }
@@ -52,7 +53,8 @@ export function normalizeOpensteerProviderMode(
     return normalized;
   }
 
-  throw new Error(
+  throw new OpensteerProtocolError(
+    "invalid-argument",
     `${source} must be one of ${OPENSTEER_PROVIDER_MODES.join(", ")}; received "${value}".`,
   );
 }

--- a/packages/opensteer/src/sdk/opensteer.ts
+++ b/packages/opensteer/src/sdk/opensteer.ts
@@ -1,39 +1,41 @@
-import type {
-  CookieRecord,
-  OpensteerCookieQueryOutput,
-  OpensteerActionResult,
-  OpensteerAddInitScriptInput,
-  OpensteerAddInitScriptOutput,
-  OpensteerComputerExecuteInput,
-  OpensteerComputerExecuteOutput,
-  OpensteerComputerKeyModifier,
-  OpensteerComputerMouseButton,
-  OpensteerNetworkDetailOutput,
-  OpensteerNetworkQueryInput,
-  OpensteerNetworkQueryOutput,
-  OpensteerOpenInput,
-  OpensteerOpenOutput,
-  OpensteerPageActivateInput,
-  OpensteerPageActivateOutput,
-  OpensteerPageCloseInput,
-  OpensteerPageCloseOutput,
-  OpensteerPageEvaluateInput,
-  OpensteerPageEvaluateOutput,
-  OpensteerPageGotoInput,
-  OpensteerPageGotoOutput,
-  OpensteerPageListInput,
-  OpensteerPageListOutput,
-  OpensteerPageNewInput,
-  OpensteerPageNewOutput,
-  OpensteerRequestBodyInput,
-  OpensteerRequestResponseResult,
-  OpensteerSessionCloseOutput,
-  OpensteerSessionFetchInput,
-  OpensteerSessionInfo,
-  OpensteerStateQueryOutput,
-  OpensteerStorageArea,
-  OpensteerStorageDomainSnapshot,
-  OpensteerTargetInput,
+import {
+  OpensteerProtocolError,
+  isOpensteerProtocolError,
+  type CookieRecord,
+  type OpensteerCookieQueryOutput,
+  type OpensteerActionResult,
+  type OpensteerAddInitScriptInput,
+  type OpensteerAddInitScriptOutput,
+  type OpensteerComputerExecuteInput,
+  type OpensteerComputerExecuteOutput,
+  type OpensteerComputerKeyModifier,
+  type OpensteerComputerMouseButton,
+  type OpensteerNetworkDetailOutput,
+  type OpensteerNetworkQueryInput,
+  type OpensteerNetworkQueryOutput,
+  type OpensteerOpenInput,
+  type OpensteerOpenOutput,
+  type OpensteerPageActivateInput,
+  type OpensteerPageActivateOutput,
+  type OpensteerPageCloseInput,
+  type OpensteerPageCloseOutput,
+  type OpensteerPageEvaluateInput,
+  type OpensteerPageEvaluateOutput,
+  type OpensteerPageGotoInput,
+  type OpensteerPageGotoOutput,
+  type OpensteerPageListInput,
+  type OpensteerPageListOutput,
+  type OpensteerPageNewInput,
+  type OpensteerPageNewOutput,
+  type OpensteerRequestBodyInput,
+  type OpensteerRequestResponseResult,
+  type OpensteerSessionCloseOutput,
+  type OpensteerSessionFetchInput,
+  type OpensteerSessionInfo,
+  type OpensteerStateQueryOutput,
+  type OpensteerStorageArea,
+  type OpensteerStorageDomainSnapshot,
+  type OpensteerTargetInput,
 } from "@opensteer/protocol";
 
 import {
@@ -42,6 +44,7 @@ import {
   type WorkspaceBrowserManifest,
 } from "../browser-manager.js";
 import { resolveOpensteerEnvironment } from "../env.js";
+import { normalizeThrownOpensteerError } from "../internal/errors.js";
 import type { OpensteerProviderOptions } from "../provider/config.js";
 import type {
   OpensteerInterceptScriptOptions,
@@ -169,6 +172,23 @@ class SessionCookieJar implements OpensteerCookieJar {
   }
 }
 
+async function wrapSdkError<T>(operation: string, fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    if (isOpensteerProtocolError(error)) {
+      throw error;
+    }
+    const normalized = normalizeThrownOpensteerError(error, `${operation} failed`);
+    throw new OpensteerProtocolError(normalized.code, normalized.message, {
+      cause: error,
+      retriable: normalized.retriable,
+      ...(normalized.capability === undefined ? {} : { capability: normalized.capability }),
+      ...(normalized.details === undefined ? {} : { details: normalized.details }),
+    });
+  }
+}
+
 export class Opensteer {
   private readonly runtime: OpensteerDisconnectableRuntime;
   private readonly browserManager: OpensteerBrowserManager | undefined;
@@ -177,186 +197,217 @@ export class Opensteer {
   readonly network: OpensteerNetworkController;
 
   constructor(options: OpensteerOptions = {}) {
-    const environment = resolveOpensteerEnvironment(options.rootDir);
-    const { provider, engineName, ...runtimeOptions } = options;
-    const runtimeConfig = resolveOpensteerRuntimeConfig({
-      ...(provider === undefined ? {} : { provider }),
-      environment,
-    });
+    try {
+      const environment = resolveOpensteerEnvironment(options.rootDir);
+      const { provider, engineName, ...runtimeOptions } = options;
+      const runtimeConfig = resolveOpensteerRuntimeConfig({
+        ...(provider === undefined ? {} : { provider }),
+        environment,
+      });
 
-    if (runtimeConfig.provider.mode === "cloud") {
-      this.browserManager = undefined;
-      this.runtime = createOpensteerSemanticRuntime({
-        ...(provider === undefined ? {} : { provider }),
-        ...(engineName === undefined ? {} : { engine: engineName }),
-        environment,
-        runtimeOptions,
-      });
-      this.browser = createUnsupportedBrowserController();
-    } else {
-      this.browserManager = new OpensteerBrowserManager({
-        ...(runtimeOptions.rootDir === undefined ? {} : { rootDir: runtimeOptions.rootDir }),
-        ...(runtimeOptions.rootPath === undefined ? {} : { rootPath: runtimeOptions.rootPath }),
-        ...(runtimeOptions.workspace === undefined ? {} : { workspace: runtimeOptions.workspace }),
-        ...(engineName === undefined ? {} : { engineName }),
-        environment,
-        ...(runtimeOptions.browser === undefined ? {} : { browser: runtimeOptions.browser }),
-        ...(runtimeOptions.launch === undefined ? {} : { launch: runtimeOptions.launch }),
-        ...(runtimeOptions.context === undefined ? {} : { context: runtimeOptions.context }),
-      });
-      this.runtime = createOpensteerSemanticRuntime({
-        ...(provider === undefined ? {} : { provider }),
-        ...(engineName === undefined ? {} : { engine: engineName }),
-        environment,
-        runtimeOptions: {
-          ...runtimeOptions,
-          rootPath: this.browserManager.rootPath,
-          cleanupRootOnClose: this.browserManager.cleanupRootOnDisconnect,
-        },
-      });
-      this.browser = {
-        status: () => this.browserManager!.status(),
-        clone: (input) => this.browserManager!.clonePersistentBrowser(input),
-        reset: () => this.browserManager!.reset(),
-        delete: () => this.browserManager!.delete(),
+      if (runtimeConfig.provider.mode === "cloud") {
+        this.browserManager = undefined;
+        this.runtime = createOpensteerSemanticRuntime({
+          ...(provider === undefined ? {} : { provider }),
+          ...(engineName === undefined ? {} : { engine: engineName }),
+          environment,
+          runtimeOptions,
+        });
+        this.browser = createUnsupportedBrowserController();
+      } else {
+        this.browserManager = new OpensteerBrowserManager({
+          ...(runtimeOptions.rootDir === undefined ? {} : { rootDir: runtimeOptions.rootDir }),
+          ...(runtimeOptions.rootPath === undefined ? {} : { rootPath: runtimeOptions.rootPath }),
+          ...(runtimeOptions.workspace === undefined ? {} : { workspace: runtimeOptions.workspace }),
+          ...(engineName === undefined ? {} : { engineName }),
+          environment,
+          ...(runtimeOptions.browser === undefined ? {} : { browser: runtimeOptions.browser }),
+          ...(runtimeOptions.launch === undefined ? {} : { launch: runtimeOptions.launch }),
+          ...(runtimeOptions.context === undefined ? {} : { context: runtimeOptions.context }),
+        });
+        this.runtime = createOpensteerSemanticRuntime({
+          ...(provider === undefined ? {} : { provider }),
+          ...(engineName === undefined ? {} : { engine: engineName }),
+          environment,
+          runtimeOptions: {
+            ...runtimeOptions,
+            rootPath: this.browserManager.rootPath,
+            cleanupRootOnClose: this.browserManager.cleanupRootOnDisconnect,
+          },
+        });
+        this.browser = {
+          status: () => wrapSdkError("browser.status", () => this.browserManager!.status()),
+          clone: (input) => wrapSdkError("browser.clone", () => this.browserManager!.clonePersistentBrowser(input)),
+          reset: () => wrapSdkError("browser.reset", () => this.browserManager!.reset()),
+          delete: () => wrapSdkError("browser.delete", () => this.browserManager!.delete()),
+        };
+      }
+
+      this.dom = {
+        click: (input) => wrapSdkError("dom.click", () => this.click(input)),
+        hover: (input) => wrapSdkError("dom.hover", () => this.hover(input)),
+        input: (input) => wrapSdkError("dom.input", () => this.input(input)),
+        scroll: (input) => wrapSdkError("dom.scroll", () => this.scroll(input)),
       };
+
+      this.network = {
+        query: (input = {}) => wrapSdkError("network.query", () => this.runtime.queryNetwork(input)),
+        detail: (recordId, options) => wrapSdkError("network.detail", () => this.runtime.getNetworkDetail({ recordId, ...options })),
+      };
+    } catch (error) {
+      if (isOpensteerProtocolError(error)) {
+        throw error;
+      }
+      const normalized = normalizeThrownOpensteerError(error, "Failed to initialize Opensteer");
+      throw new OpensteerProtocolError(normalized.code, normalized.message, {
+        cause: error,
+        retriable: normalized.retriable,
+        ...(normalized.capability === undefined ? {} : { capability: normalized.capability }),
+        ...(normalized.details === undefined ? {} : { details: normalized.details }),
+      });
     }
-
-    this.dom = {
-      click: (input) => this.click(input),
-      hover: (input) => this.hover(input),
-      input: (input) => this.input(input),
-      scroll: (input) => this.scroll(input),
-    };
-
-    this.network = {
-      query: (input = {}) => this.runtime.queryNetwork(input),
-      detail: (recordId, options) => this.runtime.getNetworkDetail({ recordId, ...options }),
-    };
   }
 
   async open(input: string | OpensteerOpenInput = {}): Promise<OpensteerOpenOutput> {
-    return this.runtime.open(typeof input === "string" ? { url: input } : input);
+    return wrapSdkError("session.open", () =>
+      this.runtime.open(typeof input === "string" ? { url: input } : input),
+    );
   }
 
   async info(): Promise<OpensteerSessionInfo> {
-    return this.runtime.info();
+    return wrapSdkError("session.info", () => this.runtime.info());
   }
 
   async listPages(input: OpensteerPageListInput = {}): Promise<OpensteerPageListOutput> {
-    return this.runtime.listPages(input);
+    return wrapSdkError("page.list", () => this.runtime.listPages(input));
   }
 
   async newPage(input: OpensteerPageNewInput = {}): Promise<OpensteerPageNewOutput> {
-    return this.runtime.newPage(input);
+    return wrapSdkError("page.new", () => this.runtime.newPage(input));
   }
 
   async activatePage(input: OpensteerPageActivateInput): Promise<OpensteerPageActivateOutput> {
-    return this.runtime.activatePage(input);
+    return wrapSdkError("page.activate", () => this.runtime.activatePage(input));
   }
 
   async closePage(input: OpensteerPageCloseInput = {}): Promise<OpensteerPageCloseOutput> {
-    return this.runtime.closePage(input);
+    return wrapSdkError("page.close", () => this.runtime.closePage(input));
   }
 
   async goto(url: string, options: OpensteerGotoOptions = {}): Promise<OpensteerPageGotoOutput> {
-    return this.runtime.goto({
-      url,
-      ...options,
-    });
+    return wrapSdkError("page.goto", () =>
+      this.runtime.goto({
+        url,
+        ...options,
+      }),
+    );
   }
 
   async evaluate(
     input: string | OpensteerPageEvaluateInput,
   ): Promise<OpensteerPageEvaluateOutput["value"]> {
-    const normalized =
-      typeof input === "string"
-        ? {
-            script: input,
-          }
-        : input;
-    return (await this.runtime.evaluate(normalized)).value;
+    return wrapSdkError("page.evaluate", async () => {
+      const normalized =
+        typeof input === "string"
+          ? {
+              script: input,
+            }
+          : input;
+      return (await this.runtime.evaluate(normalized)).value;
+    });
   }
 
   async addInitScript(
     input: string | OpensteerAddInitScriptInput,
   ): Promise<OpensteerAddInitScriptOutput> {
-    return this.runtime.addInitScript(
-      typeof input === "string"
-        ? {
-            script: input,
-          }
-        : input,
+    return wrapSdkError("page.addInitScript", () =>
+      this.runtime.addInitScript(
+        typeof input === "string"
+          ? {
+              script: input,
+            }
+          : input,
+      ),
     );
   }
 
   async click(input: OpensteerClickOptions): Promise<OpensteerActionResult> {
-    const { button, clickCount, modifiers, ...target } = input;
-    return this.runtime.click({
-      ...normalizeTargetOptions(target),
-      ...(button === undefined ? {} : { button }),
-      ...(clickCount === undefined ? {} : { clickCount }),
-      ...(modifiers === undefined ? {} : { modifiers }),
+    return wrapSdkError("dom.click", () => {
+      const { button, clickCount, modifiers, ...target } = input;
+      return this.runtime.click({
+        ...normalizeTargetOptions(target),
+        ...(button === undefined ? {} : { button }),
+        ...(clickCount === undefined ? {} : { clickCount }),
+        ...(modifiers === undefined ? {} : { modifiers }),
+      });
     });
   }
 
   async hover(input: OpensteerTargetOptions): Promise<OpensteerActionResult> {
-    return this.runtime.hover(normalizeTargetOptions(input));
+    return wrapSdkError("dom.hover", () => this.runtime.hover(normalizeTargetOptions(input)));
   }
 
   async input(input: OpensteerInputOptions): Promise<OpensteerActionResult> {
-    return this.runtime.input({
-      ...normalizeTargetOptions(input),
-      text: input.text,
-      ...(input.pressEnter === undefined ? {} : { pressEnter: input.pressEnter }),
-    });
+    return wrapSdkError("dom.input", () =>
+      this.runtime.input({
+        ...normalizeTargetOptions(input),
+        text: input.text,
+        ...(input.pressEnter === undefined ? {} : { pressEnter: input.pressEnter }),
+      }),
+    );
   }
 
   async scroll(input: OpensteerScrollOptions): Promise<OpensteerActionResult> {
-    return this.runtime.scroll({
-      ...normalizeTargetOptions(input),
-      direction: input.direction,
-      amount: input.amount,
-    });
+    return wrapSdkError("dom.scroll", () =>
+      this.runtime.scroll({
+        ...normalizeTargetOptions(input),
+        direction: input.direction,
+        amount: input.amount,
+      }),
+    );
   }
 
   async extract(input: OpensteerExtractOptions): Promise<unknown> {
-    return (await this.runtime.extract(input)).data;
+    return wrapSdkError("extract", async () => (await this.runtime.extract(input)).data);
   }
 
   async waitForPage(
     input: OpensteerWaitForPageOptions = {},
   ): Promise<OpensteerPageListOutput["pages"][number]> {
-    const baseline = new Set((await this.runtime.listPages()).pages.map((page) => page.pageRef));
-    const timeoutAt = Date.now() + (input.timeoutMs ?? 30_000);
-    const pollIntervalMs = input.pollIntervalMs ?? 100;
+    return wrapSdkError("page.waitForPage", async () => {
+      const baseline = new Set((await this.runtime.listPages()).pages.map((page) => page.pageRef));
+      const timeoutAt = Date.now() + (input.timeoutMs ?? 30_000);
+      const pollIntervalMs = input.pollIntervalMs ?? 100;
 
-    while (true) {
-      const match = (await this.runtime.listPages()).pages.find((page) => {
-        if (baseline.has(page.pageRef)) {
-          return false;
+      while (true) {
+        const match = (await this.runtime.listPages()).pages.find((page) => {
+          if (baseline.has(page.pageRef)) {
+            return false;
+          }
+          if (input.openerPageRef !== undefined && page.openerPageRef !== input.openerPageRef) {
+            return false;
+          }
+          if (input.urlIncludes !== undefined && !page.url.includes(input.urlIncludes)) {
+            return false;
+          }
+          return true;
+        });
+        if (match !== undefined) {
+          return match;
         }
-        if (input.openerPageRef !== undefined && page.openerPageRef !== input.openerPageRef) {
-          return false;
+        if (Date.now() >= timeoutAt) {
+          throw new OpensteerProtocolError("timeout", "waitForPage timed out");
         }
-        if (input.urlIncludes !== undefined && !page.url.includes(input.urlIncludes)) {
-          return false;
-        }
-        return true;
-      });
-      if (match !== undefined) {
-        return match;
+        await delay(pollIntervalMs);
       }
-      if (Date.now() >= timeoutAt) {
-        throw new Error("waitForPage timed out");
-      }
-      await delay(pollIntervalMs);
-    }
+    });
   }
 
   async cookies(domain?: string): Promise<OpensteerCookieJar> {
-    return new SessionCookieJar(
-      await this.runtime.getCookies(domain === undefined ? {} : { domain }),
+    return wrapSdkError("session.cookies", async () =>
+      new SessionCookieJar(
+        await this.runtime.getCookies(domain === undefined ? {} : { domain }),
+      ),
     );
   }
 
@@ -364,56 +415,68 @@ export class Opensteer {
     domain?: string,
     type: OpensteerStorageArea = "local",
   ): Promise<OpensteerStorageMap> {
-    const snapshot = await this.runtime.getStorageSnapshot(domain === undefined ? {} : { domain });
-    const domainSnapshot = pickStorageDomainSnapshot(snapshot, domain);
-    if (domainSnapshot === undefined) {
-      return {};
-    }
-    const entries = type === "local" ? domainSnapshot.localStorage : domainSnapshot.sessionStorage;
-    return Object.fromEntries(entries.map((entry) => [entry.key, entry.value]));
+    return wrapSdkError("session.storage", async () => {
+      const snapshot = await this.runtime.getStorageSnapshot(domain === undefined ? {} : { domain });
+      const domainSnapshot = pickStorageDomainSnapshot(snapshot, domain);
+      if (domainSnapshot === undefined) {
+        return {};
+      }
+      const entries = type === "local" ? domainSnapshot.localStorage : domainSnapshot.sessionStorage;
+      return Object.fromEntries(entries.map((entry) => [entry.key, entry.value]));
+    });
   }
 
   async state(domain?: string): Promise<OpensteerBrowserState> {
-    return this.runtime.getBrowserState(domain === undefined ? {} : { domain });
+    return wrapSdkError("session.state", () =>
+      this.runtime.getBrowserState(domain === undefined ? {} : { domain }),
+    );
   }
 
   async fetch(url: string, options: OpensteerFetchOptions = {}): Promise<Response> {
-    const input = buildFetchInput(url, options);
-    const result = await this.runtime.fetch(input);
-    if (result.response === undefined) {
-      throw new Error(result.note ?? `session.fetch did not produce a response for ${url}`);
-    }
-    return toResponse(result.response);
+    return wrapSdkError("session.fetch", async () => {
+      const input = buildFetchInput(url, options);
+      const result = await this.runtime.fetch(input);
+      if (result.response === undefined) {
+        throw new OpensteerProtocolError("operation-failed", result.note ?? `session.fetch did not produce a response for ${url}`);
+      }
+      return toResponse(result.response);
+    });
   }
 
   async computerExecute(
     input: OpensteerComputerExecuteOptions,
   ): Promise<OpensteerComputerExecuteOutput> {
-    return this.runtime.computerExecute(input);
+    return wrapSdkError("session.computerExecute", () => this.runtime.computerExecute(input));
   }
 
   async route(input: OpensteerRouteOptions): Promise<OpensteerRouteRegistration> {
-    return this.requireOwnedInstrumentationRuntime("route").route(input);
+    return wrapSdkError("session.route", () =>
+      this.requireOwnedInstrumentationRuntime("route").route(input),
+    );
   }
 
   async interceptScript(
     input: OpensteerInterceptScriptOptions,
   ): Promise<OpensteerRouteRegistration> {
-    return this.requireOwnedInstrumentationRuntime("interceptScript").interceptScript(input);
+    return wrapSdkError("session.interceptScript", () =>
+      this.requireOwnedInstrumentationRuntime("interceptScript").interceptScript(input),
+    );
   }
 
   async close(): Promise<OpensteerSessionCloseOutput> {
-    if (this.browserManager === undefined || this.browserManager.mode === "temporary") {
-      return this.runtime.close();
-    }
+    return wrapSdkError("session.close", async () => {
+      if (this.browserManager === undefined || this.browserManager.mode === "temporary") {
+        return this.runtime.close();
+      }
 
-    const output = await this.runtime.close();
-    await this.browserManager.close();
-    return output;
+      const output = await this.runtime.close();
+      await this.browserManager.close();
+      return output;
+    });
   }
 
   async disconnect(): Promise<void> {
-    await this.runtime.disconnect();
+    return wrapSdkError("session.disconnect", () => this.runtime.disconnect());
   }
 
   private requireOwnedInstrumentationRuntime(
@@ -426,13 +489,16 @@ export class Opensteer {
     ) {
       return this.runtime as OpensteerDisconnectableRuntime & OpensteerInstrumentableRuntime;
     }
-    throw new Error(`${method}() is not available for this session runtime.`);
+    throw new OpensteerProtocolError("unsupported-operation", `${method}() is not available for this session runtime.`);
   }
 }
 
 function createUnsupportedBrowserController(): OpensteerBrowserController {
   const fail = async (): Promise<never> => {
-    throw new Error("browser.* helpers are only available in local mode.");
+    throw new OpensteerProtocolError(
+      "unsupported-operation",
+      "browser.* helpers are only available in local mode.",
+    );
   };
 
   return {
@@ -451,7 +517,7 @@ function normalizeTargetOptions(input: OpensteerTargetOptions): {
   const hasElement = input.element !== undefined;
   const hasSelector = input.selector !== undefined;
   if (hasElement && hasSelector) {
-    throw new Error("Specify exactly one of element, selector, or persist.");
+    throw new OpensteerProtocolError("invalid-argument", "Specify exactly one of element, selector, or persist.");
   }
 
   if (hasElement) {
@@ -477,7 +543,7 @@ function normalizeTargetOptions(input: OpensteerTargetOptions): {
   }
 
   if (input.persist === undefined) {
-    throw new Error("Specify exactly one of element, selector, or persist.");
+    throw new OpensteerProtocolError("invalid-argument", "Specify exactly one of element, selector, or persist.");
   }
 
   return {

--- a/packages/opensteer/src/sdk/opensteer.ts
+++ b/packages/opensteer/src/sdk/opensteer.ts
@@ -172,6 +172,16 @@ class SessionCookieJar implements OpensteerCookieJar {
   }
 }
 
+function createSdkProtocolError(error: unknown, fallbackMessage: string): OpensteerProtocolError {
+  const normalized = normalizeThrownOpensteerError(error, fallbackMessage);
+  return new OpensteerProtocolError(normalized.code, normalized.message, {
+    cause: error,
+    retriable: normalized.retriable,
+    ...(normalized.capability === undefined ? {} : { capability: normalized.capability }),
+    ...(normalized.details === undefined ? {} : { details: normalized.details }),
+  });
+}
+
 async function wrapSdkError<T>(operation: string, fn: () => Promise<T>): Promise<T> {
   try {
     return await fn();
@@ -179,13 +189,7 @@ async function wrapSdkError<T>(operation: string, fn: () => Promise<T>): Promise
     if (isOpensteerProtocolError(error)) {
       throw error;
     }
-    const normalized = normalizeThrownOpensteerError(error, `${operation} failed`);
-    throw new OpensteerProtocolError(normalized.code, normalized.message, {
-      cause: error,
-      retriable: normalized.retriable,
-      ...(normalized.capability === undefined ? {} : { capability: normalized.capability }),
-      ...(normalized.details === undefined ? {} : { details: normalized.details }),
-    });
+    throw createSdkProtocolError(error, `${operation} failed`);
   }
 }
 
@@ -218,7 +222,9 @@ export class Opensteer {
         this.browserManager = new OpensteerBrowserManager({
           ...(runtimeOptions.rootDir === undefined ? {} : { rootDir: runtimeOptions.rootDir }),
           ...(runtimeOptions.rootPath === undefined ? {} : { rootPath: runtimeOptions.rootPath }),
-          ...(runtimeOptions.workspace === undefined ? {} : { workspace: runtimeOptions.workspace }),
+          ...(runtimeOptions.workspace === undefined
+            ? {}
+            : { workspace: runtimeOptions.workspace }),
           ...(engineName === undefined ? {} : { engineName }),
           environment,
           ...(runtimeOptions.browser === undefined ? {} : { browser: runtimeOptions.browser }),
@@ -237,34 +243,33 @@ export class Opensteer {
         });
         this.browser = {
           status: () => wrapSdkError("browser.status", () => this.browserManager!.status()),
-          clone: (input) => wrapSdkError("browser.clone", () => this.browserManager!.clonePersistentBrowser(input)),
+          clone: (input) =>
+            wrapSdkError("browser.clone", () => this.browserManager!.clonePersistentBrowser(input)),
           reset: () => wrapSdkError("browser.reset", () => this.browserManager!.reset()),
           delete: () => wrapSdkError("browser.delete", () => this.browserManager!.delete()),
         };
       }
 
       this.dom = {
-        click: (input) => wrapSdkError("dom.click", () => this.click(input)),
-        hover: (input) => wrapSdkError("dom.hover", () => this.hover(input)),
-        input: (input) => wrapSdkError("dom.input", () => this.input(input)),
-        scroll: (input) => wrapSdkError("dom.scroll", () => this.scroll(input)),
+        click: (input) => this.click(input),
+        hover: (input) => this.hover(input),
+        input: (input) => this.input(input),
+        scroll: (input) => this.scroll(input),
       };
 
       this.network = {
-        query: (input = {}) => wrapSdkError("network.query", () => this.runtime.queryNetwork(input)),
-        detail: (recordId, options) => wrapSdkError("network.detail", () => this.runtime.getNetworkDetail({ recordId, ...options })),
+        query: (input = {}) =>
+          wrapSdkError("network.query", () => this.runtime.queryNetwork(input)),
+        detail: (recordId, options) =>
+          wrapSdkError("network.detail", () =>
+            this.runtime.getNetworkDetail({ recordId, ...options }),
+          ),
       };
     } catch (error) {
       if (isOpensteerProtocolError(error)) {
         throw error;
       }
-      const normalized = normalizeThrownOpensteerError(error, "Failed to initialize Opensteer");
-      throw new OpensteerProtocolError(normalized.code, normalized.message, {
-        cause: error,
-        retriable: normalized.retriable,
-        ...(normalized.capability === undefined ? {} : { capability: normalized.capability }),
-        ...(normalized.details === undefined ? {} : { details: normalized.details }),
-      });
+      throw createSdkProtocolError(error, "Failed to initialize Opensteer");
     }
   }
 
@@ -404,10 +409,10 @@ export class Opensteer {
   }
 
   async cookies(domain?: string): Promise<OpensteerCookieJar> {
-    return wrapSdkError("session.cookies", async () =>
-      new SessionCookieJar(
-        await this.runtime.getCookies(domain === undefined ? {} : { domain }),
-      ),
+    return wrapSdkError(
+      "session.cookies",
+      async () =>
+        new SessionCookieJar(await this.runtime.getCookies(domain === undefined ? {} : { domain })),
     );
   }
 
@@ -416,12 +421,15 @@ export class Opensteer {
     type: OpensteerStorageArea = "local",
   ): Promise<OpensteerStorageMap> {
     return wrapSdkError("session.storage", async () => {
-      const snapshot = await this.runtime.getStorageSnapshot(domain === undefined ? {} : { domain });
+      const snapshot = await this.runtime.getStorageSnapshot(
+        domain === undefined ? {} : { domain },
+      );
       const domainSnapshot = pickStorageDomainSnapshot(snapshot, domain);
       if (domainSnapshot === undefined) {
         return {};
       }
-      const entries = type === "local" ? domainSnapshot.localStorage : domainSnapshot.sessionStorage;
+      const entries =
+        type === "local" ? domainSnapshot.localStorage : domainSnapshot.sessionStorage;
       return Object.fromEntries(entries.map((entry) => [entry.key, entry.value]));
     });
   }
@@ -437,7 +445,10 @@ export class Opensteer {
       const input = buildFetchInput(url, options);
       const result = await this.runtime.fetch(input);
       if (result.response === undefined) {
-        throw new OpensteerProtocolError("operation-failed", result.note ?? `session.fetch did not produce a response for ${url}`);
+        throw new OpensteerProtocolError(
+          "operation-failed",
+          result.note ?? `session.fetch did not produce a response for ${url}`,
+        );
       }
       return toResponse(result.response);
     });
@@ -489,7 +500,10 @@ export class Opensteer {
     ) {
       return this.runtime as OpensteerDisconnectableRuntime & OpensteerInstrumentableRuntime;
     }
-    throw new OpensteerProtocolError("unsupported-operation", `${method}() is not available for this session runtime.`);
+    throw new OpensteerProtocolError(
+      "unsupported-operation",
+      `${method}() is not available for this session runtime.`,
+    );
   }
 }
 
@@ -517,7 +531,10 @@ function normalizeTargetOptions(input: OpensteerTargetOptions): {
   const hasElement = input.element !== undefined;
   const hasSelector = input.selector !== undefined;
   if (hasElement && hasSelector) {
-    throw new OpensteerProtocolError("invalid-argument", "Specify exactly one of element, selector, or persist.");
+    throw new OpensteerProtocolError(
+      "invalid-argument",
+      "Specify exactly one of element, selector, or persist.",
+    );
   }
 
   if (hasElement) {
@@ -543,7 +560,10 @@ function normalizeTargetOptions(input: OpensteerTargetOptions): {
   }
 
   if (input.persist === undefined) {
-    throw new OpensteerProtocolError("invalid-argument", "Specify exactly one of element, selector, or persist.");
+    throw new OpensteerProtocolError(
+      "invalid-argument",
+      "Specify exactly one of element, selector, or persist.",
+    );
   }
 
   return {

--- a/packages/protocol/src/dom-action-bridge.ts
+++ b/packages/protocol/src/dom-action-bridge.ts
@@ -61,8 +61,12 @@ export interface DomPointerHitAssessment {
   readonly hitOwner?: NodeLocator;
 }
 
+export interface BuildReplayPathOptions {
+  readonly enableTextMatch?: boolean;
+}
+
 export interface DomActionBridge {
-  buildReplayPath(locator: NodeLocator): Promise<ReplayElementPath>;
+  buildReplayPath(locator: NodeLocator, options?: BuildReplayPathOptions): Promise<ReplayElementPath>;
   inspectActionTarget(locator: NodeLocator): Promise<DomActionTargetInspection>;
   canonicalizePointerTarget(locator: NodeLocator): Promise<NodeLocator>;
   classifyPointerHit(input: {

--- a/packages/protocol/src/dom-action-bridge.ts
+++ b/packages/protocol/src/dom-action-bridge.ts
@@ -56,6 +56,7 @@ export interface DomPointerHitAssessment {
   readonly relation: DomPointerHitRelation;
   readonly blocking: boolean;
   readonly ambiguous?: boolean;
+  readonly blockingDescription?: string;
   readonly canonicalTarget?: NodeLocator;
   readonly hitOwner?: NodeLocator;
 }

--- a/packages/protocol/src/dom-path-types.ts
+++ b/packages/protocol/src/dom-path-types.ts
@@ -12,7 +12,12 @@ export interface PositionMatchClause {
   readonly axis: "nthOfType" | "nthChild";
 }
 
-export type MatchClause = AttributeMatchClause | PositionMatchClause;
+export interface TextMatchClause {
+  readonly kind: "text";
+  readonly value: string;
+}
+
+export type MatchClause = AttributeMatchClause | PositionMatchClause | TextMatchClause;
 
 export interface PathNodePosition {
   readonly nthChild: number;

--- a/packages/runtime-core/src/internal/engine-selection.ts
+++ b/packages/runtime-core/src/internal/engine-selection.ts
@@ -1,7 +1,8 @@
-import type {
-  OpensteerBrowserContextOptions,
-  OpensteerBrowserLaunchOptions,
-  OpensteerBrowserOptions,
+import {
+  OpensteerProtocolError,
+  type OpensteerBrowserContextOptions,
+  type OpensteerBrowserLaunchOptions,
+  type OpensteerBrowserOptions,
 } from "@opensteer/protocol";
 
 export const OPENSTEER_ENGINE_NAMES = ["playwright", "abp"] as const;
@@ -43,7 +44,8 @@ export function normalizeOpensteerEngineName(
     return normalized;
   }
 
-  throw new Error(
+  throw new OpensteerProtocolError(
+    "invalid-argument",
     `${source} must be one of ${OPENSTEER_ENGINE_NAMES.join(", ")}; received "${value}".`,
   );
 }
@@ -62,7 +64,8 @@ export function assertSupportedEngineOptions(input: {
     input.browser !== null &&
     input.browser.mode === "attach"
   ) {
-    throw new Error(
+    throw new OpensteerProtocolError(
+      "invalid-argument",
       'ABP engine does not support browser.mode="attach". Use the Playwright engine for attach flows.',
     );
   }
@@ -72,7 +75,8 @@ export function assertSupportedEngineOptions(input: {
     return;
   }
 
-  throw new Error(
+  throw new OpensteerProtocolError(
+    "invalid-argument",
     `ABP engine does not support ${unsupportedContextOptionNames.join(", ")}. Supported ABP context options: context.viewport.`,
   );
 }

--- a/packages/runtime-core/src/policy/defaults.ts
+++ b/packages/runtime-core/src/policy/defaults.ts
@@ -1,5 +1,4 @@
 import {
-  DEFAULT_VISUAL_STABILITY_SETTLE_MS,
   DEFAULT_POST_LOAD_TRACKER_QUIET_WINDOW_MS,
   type VisualStabilityScope,
 } from "@opensteer/browser-core";
@@ -41,23 +40,6 @@ const DEFAULT_SETTLE_DELAYS: Readonly<Record<string, number>> = {
   "dom-action": 100,
   snapshot: 0,
 };
-
-const defaultSnapshotSettleObserver: SettleObserver = {
-  async settle(input) {
-    if (input.trigger !== "snapshot") {
-      return false;
-    }
-
-    await input.engine.waitForVisualStability({
-      pageRef: input.pageRef,
-      ...(input.remainingMs === undefined ? {} : { timeoutMs: input.remainingMs }),
-      settleMs: DEFAULT_VISUAL_STABILITY_SETTLE_MS,
-      scope: "visible-frames",
-    });
-    return true;
-  },
-};
-Object.freeze(defaultSnapshotSettleObserver);
 
 interface VisualStabilityProfile {
   readonly settleMs: number;
@@ -165,7 +147,6 @@ const defaultNavigationSettleObserver: SettleObserver = {
 Object.freeze(defaultNavigationSettleObserver);
 
 const DEFAULT_SETTLE_OBSERVERS: NonNullable<SettlePolicy["observers"]> = Object.freeze([
-  defaultSnapshotSettleObserver,
   defaultDomActionSettleObserver,
   defaultNavigationSettleObserver,
 ]);

--- a/packages/runtime-core/src/runtimes/dom/executor.ts
+++ b/packages/runtime-core/src/runtimes/dom/executor.ts
@@ -70,7 +70,7 @@ interface ActionablePointerTarget {
   readonly original: ResolvedDomTarget;
 }
 
-const MAX_DOM_ACTION_ATTEMPTS = 3;
+const MAX_DOM_ACTION_ATTEMPTS = 2;
 const DEFAULT_SCROLL_OPTIONS = {
   block: "center",
   inline: "center",
@@ -673,11 +673,14 @@ export class DomActionExecutor {
     throw this.createActionabilityError(
       operation,
       "obscured",
-      `hit test resolved ${hit.nodeRef} outside the target subtree rooted at ${resolved.nodeRef}`,
+      `target is obscured by ${assessment.blockingDescription ?? "another element"} at the click point`,
       {
         ...details,
         hitRelation: assessment.relation,
         ...(assessment.ambiguous === undefined ? {} : { hitAmbiguous: assessment.ambiguous }),
+        ...(assessment.blockingDescription === undefined
+          ? {}
+          : { blockingDescription: assessment.blockingDescription }),
         ...(assessment.canonicalTarget === undefined
           ? {}
           : {
@@ -696,7 +699,6 @@ export class DomActionExecutor {
           (node) => node.nodeRef === hit.nodeRef,
         ),
       },
-      true,
     );
   }
 

--- a/packages/runtime-core/src/runtimes/dom/extraction.ts
+++ b/packages/runtime-core/src/runtimes/dom/extraction.ts
@@ -91,7 +91,7 @@ export function resolveExtractedValueInContext(
 function stripPositionClauses(nodes: ElementPath["nodes"]): ElementPath["nodes"] {
   return (nodes || []).map((node) => ({
     ...node,
-    match: (node.match || []).filter((clause) => clause.kind !== "position"),
+    match: (node.match || []).filter((clause) => clause.kind !== "position" && clause.kind !== "text"),
   }));
 }
 

--- a/packages/runtime-core/src/runtimes/dom/match-selectors.ts
+++ b/packages/runtime-core/src/runtimes/dom/match-selectors.ts
@@ -32,6 +32,10 @@ function buildClauseSelector(node: PathNode, clause: MatchClause): string {
     return "";
   }
 
+  if (clause.kind === "text") {
+    return "";
+  }
+
   if (clause.kind === "position") {
     if (clause.axis === "nthOfType") {
       return `:nth-of-type(${Math.max(1, Number(node.position?.nthOfType || 1))})`;

--- a/packages/runtime-core/src/runtimes/dom/path.ts
+++ b/packages/runtime-core/src/runtimes/dom/path.ts
@@ -27,6 +27,7 @@ import type {
   PathNodePosition,
   ReplayElementPath,
   StructuralElementAnchor,
+  TextMatchClause,
 } from "./types.js";
 
 const MAX_ATTRIBUTE_VALUE_LENGTH = 300;
@@ -180,9 +181,18 @@ export function resolveDomPathInScope(
     return null;
   }
 
+  const lastNode = domPath[domPath.length - 1];
+  const textClauses = lastNode?.match.filter((c): c is TextMatchClause => c.kind === "text") ?? [];
+
   let fallback: ResolveMatch | null = null;
   for (const selector of candidates) {
-    const matches = querySelectorAllInScope(index, selector, scope);
+    let matches = querySelectorAllInScope(index, selector, scope);
+    if (textClauses.length > 0 && matches.length > 1) {
+      const filtered = matches.filter((node) => matchesTextClauses(node, textClauses));
+      if (filtered.length > 0) {
+        matches = filtered;
+      }
+    }
     if (matches.length === 1) {
       return {
         node: matches[0]!,
@@ -202,6 +212,14 @@ export function resolveDomPathInScope(
   }
 
   return fallback;
+}
+
+function matchesTextClauses(
+  node: DomSnapshotNode,
+  clauses: readonly TextMatchClause[],
+): boolean {
+  const text = (node.textContent ?? "").replace(/\s+/g, " ").trim();
+  return clauses.every((clause) => text.includes(clause.value));
 }
 
 export function queryAllDomPathInScope(
@@ -485,14 +503,18 @@ function clonePathNode(node: PathNode): PathNode {
 }
 
 function cloneMatchClause(clause: MatchClause): MatchClause {
-  return clause.kind === "position"
-    ? { kind: "position", axis: clause.axis }
-    : {
-        kind: "attr",
-        key: clause.key,
-        ...(clause.op === undefined ? {} : { op: clause.op }),
-        ...(clause.value === undefined ? {} : { value: clause.value }),
-      };
+  if (clause.kind === "position") {
+    return { kind: "position", axis: clause.axis };
+  }
+  if (clause.kind === "text") {
+    return { kind: "text", value: clause.value };
+  }
+  return {
+    kind: "attr",
+    key: clause.key,
+    ...(clause.op === undefined ? {} : { op: clause.op }),
+    ...(clause.value === undefined ? {} : { value: clause.value }),
+  };
 }
 
 function normalizeMatch(
@@ -550,6 +572,13 @@ function normalizeMatch(
           op,
           ...(value === undefined ? {} : { value }),
         });
+        continue;
+      }
+      if (record.kind === "text") {
+        const textValue = typeof record.value === "string" ? record.value.trim() : "";
+        if (textValue) {
+          push({ kind: "text", value: textValue.slice(0, 80) });
+        }
       }
     }
   }

--- a/packages/runtime-core/src/runtimes/dom/runtime.ts
+++ b/packages/runtime-core/src/runtimes/dom/runtime.ts
@@ -178,7 +178,12 @@ class DefaultDomRuntime implements DomRuntime {
   }
 
   async buildPath(input: DomBuildPathInput): Promise<ReplayElementPath> {
-    return sanitizeReplayElementPath(await this.requireBridge().buildReplayPath(input.locator));
+    return sanitizeReplayElementPath(
+      await this.requireBridge().buildReplayPath(
+        input.locator,
+        input.enableTextMatch ? { enableTextMatch: true } : undefined,
+      ),
+    );
   }
 
   async resolveTarget(input: DomResolveTargetInput): Promise<ResolvedDomTarget> {
@@ -470,7 +475,7 @@ class DefaultDomRuntime implements DomRuntime {
     if (resolvedByLocator) {
       const { snapshot, node } = resolvedByLocator;
       const anchor = await this.buildAnchorFromSnapshotNode(session, snapshot, node);
-      const replayPath = await this.tryBuildPathFromNode(snapshot, node);
+      const replayPath = await this.tryBuildPathFromNode(snapshot, node, { enableTextMatch: true });
       return this.createResolvedTarget("live", snapshot, node, anchor, {
         ...(target.persist === undefined ? {} : { persist: target.persist }),
         ...(replayPath === undefined ? {} : { replayPath }),
@@ -500,14 +505,15 @@ class DefaultDomRuntime implements DomRuntime {
     const anchor = await this.buildAnchorFromSnapshotNode(session, snapshot, node);
     const writeDescriptor =
       descriptorWriter ?? ((input: DomWriteDescriptorInput) => this.descriptors.write(input));
-    const replayPath = await this.tryBuildPathFromNode(snapshot, node);
+    const enableTextMatch = method !== "extract";
+    const replayPath = await this.tryBuildPathFromNode(snapshot, node, { enableTextMatch });
     const descriptor =
       target.persist === undefined
         ? undefined
         : await writeDescriptor({
             method,
             persist: target.persist,
-            path: replayPath ?? (await this.buildPathForNode(snapshot, node)),
+            path: replayPath ?? (await this.buildPathForNode(snapshot, node, { enableTextMatch })),
             sourceUrl: snapshot.url,
           });
     return this.createResolvedTarget("selector", snapshot, node, anchor, {
@@ -668,7 +674,7 @@ class DefaultDomRuntime implements DomRuntime {
       );
     }
 
-    const replayPath = await this.tryBuildPathFromNode(context.snapshot, target.node);
+    const replayPath = await this.tryBuildPathFromNode(context.snapshot, target.node, { enableTextMatch: true });
     return this.createResolvedTarget(source, context.snapshot, target.node, anchor, {
       ...(persist === undefined ? {} : { persist }),
       ...(replayPath === undefined ? {} : { replayPath }),
@@ -928,6 +934,7 @@ class DefaultDomRuntime implements DomRuntime {
   private async buildPathForNode(
     snapshot: DomSnapshot,
     node: DomSnapshotNode,
+    options?: { readonly enableTextMatch?: boolean },
   ): Promise<ReplayElementPath> {
     if (node.nodeRef === undefined) {
       throw new Error(
@@ -937,15 +944,17 @@ class DefaultDomRuntime implements DomRuntime {
 
     return this.buildPath({
       locator: createNodeLocator(snapshot.documentRef, snapshot.documentEpoch, node.nodeRef),
+      ...(options?.enableTextMatch ? { enableTextMatch: true } : {}),
     });
   }
 
   private async tryBuildPathFromNode(
     snapshot: DomSnapshot,
     node: DomSnapshotNode,
+    options?: { readonly enableTextMatch?: boolean },
   ): Promise<ReplayElementPath | undefined> {
     try {
-      return await this.buildPathForNode(snapshot, node);
+      return await this.buildPathForNode(snapshot, node, options);
     } catch {
       return undefined;
     }

--- a/packages/runtime-core/src/runtimes/dom/types.ts
+++ b/packages/runtime-core/src/runtimes/dom/types.ts
@@ -22,6 +22,7 @@ import type {
   PathNodePosition,
   ReplayElementPath,
   StructuralElementAnchor,
+  TextMatchClause,
 } from "@opensteer/protocol";
 
 import type { TimeoutExecutionContext } from "../../policy/index.js";
@@ -35,6 +36,7 @@ export type {
   PathNodePosition,
   ReplayElementPath,
   StructuralElementAnchor,
+  TextMatchClause,
 } from "@opensteer/protocol";
 
 export type DomPath = readonly PathNode[];
@@ -116,6 +118,7 @@ export interface ResolvedDomTarget {
 
 export interface DomBuildPathInput {
   readonly locator: NodeLocator;
+  readonly enableTextMatch?: boolean;
 }
 
 export interface DomResolveTargetInput {

--- a/packages/runtime-core/src/sdk/extraction-consolidation.ts
+++ b/packages/runtime-core/src/sdk/extraction-consolidation.ts
@@ -568,6 +568,10 @@ function relaxPathForSingleSample(path: ElementPath, mode: "item-root" | "field"
           return !isLast;
         }
 
+        if (clause.kind === "text") {
+          return false;
+        }
+
         const key = String(clause.key || "")
           .trim()
           .toLowerCase();
@@ -696,13 +700,11 @@ function buildNodeStructure(node: PathNode): Record<string, unknown> {
   }
 
   const matchClauses = (node.match || [])
-    .map((clause) =>
-      clause.kind === "position"
-        ? `position:${clause.axis}`
-        : `attr:${String(clause.key || "")
-            .trim()
-            .toLowerCase()}`,
-    )
+    .map((clause) => {
+      if (clause.kind === "position") return `position:${clause.axis}`;
+      if (clause.kind === "text") return `text:${clause.value}`;
+      return `attr:${String(clause.key || "").trim().toLowerCase()}`;
+    })
     .sort();
 
   return {
@@ -1217,6 +1219,10 @@ function mergeMatchByMajority(
         op: clause.op === "startsWith" || clause.op === "contains" ? clause.op : "exact",
         ...(clause.value === undefined ? {} : { value: clause.value }),
       });
+      continue;
+    }
+
+    if (clause.kind === "text") {
       continue;
     }
 

--- a/tests/engine-abp/abp-unit.test.ts
+++ b/tests/engine-abp/abp-unit.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import {
+  createNodeLocator,
   createDocumentEpoch,
   createDocumentRef,
   createFrameRef,
@@ -14,6 +15,7 @@ import {
   PAGE_CDP_METHOD_ALLOWLIST,
 } from "../../packages/engine-abp/src/cdp-transport.js";
 import { createAbpComputerUseBridge } from "../../packages/engine-abp/src/computer-use.js";
+import { createAbpDomActionBridge } from "../../packages/engine-abp/src/dom-action-bridge.js";
 import { AbpApiError, normalizeAbpError } from "../../packages/engine-abp/src/errors.js";
 import { buildAbpLaunchCommand } from "../../packages/engine-abp/src/launcher.js";
 import {
@@ -252,6 +254,105 @@ describe("engine-abp internals", () => {
     expect(chooseNextActivePageRef([first, second], second)).toBe(second);
     expect(chooseNextActivePageRef([first, second], createPageRef("third"))).toBe(first);
     expect(chooseNextActivePageRef([])).toBeUndefined();
+  });
+
+  test("ships a text-aware replay path source when ABP text matching is enabled", async () => {
+    const pageRef = createPageRef("abp-page");
+    const documentRef = createDocumentRef("abp-document");
+    const documentEpoch = createDocumentEpoch(1);
+    const locator = createNodeLocator(documentRef, documentEpoch, "node:abp-1");
+    const runtimeCalls: Array<readonly { readonly value: unknown }[]> = [];
+
+    const controller: PageController = {
+      sessionRef: createSessionRef("abp-session"),
+      pageRef,
+      tabId: "tab:abp",
+      cdp: {
+        send: vi.fn(async (method: string, params?: Record<string, unknown>) => {
+          if (method === "DOM.resolveNode") {
+            return {
+              object: {
+                objectId: "object:abp-node",
+              },
+            };
+          }
+
+          if (method === "Runtime.callFunctionOn") {
+            runtimeCalls.push(
+              Array.isArray(params?.arguments)
+                ? (params.arguments as readonly { readonly value: unknown }[])
+                : [],
+            );
+            return {
+              result: {
+                value: {
+                  resolution: "deterministic",
+                  context: [],
+                  nodes: [],
+                },
+              },
+            };
+          }
+
+          if (method === "Runtime.releaseObject") {
+            return {};
+          }
+
+          throw new Error(`Unexpected CDP method: ${method}`);
+        }),
+      },
+      queuedEvents: [],
+      framesByCdpId: new Map(),
+      documentsByRef: new Map(),
+      lifecycleState: "active",
+      openerPageRef: undefined,
+      mainFrameRef: undefined,
+      lastKnownTitle: "",
+      explicitCloseInFlight: false,
+      domUpdateTask: undefined,
+      backgroundError: undefined,
+      executionPaused: false,
+      settleTrackerRegistered: false,
+    };
+
+    const bridge = createAbpDomActionBridge({
+      resolveController: () => controller,
+      resolveSession: () => {
+        throw new Error("resolveSession should not be called");
+      },
+      flushDomUpdateTask: async () => undefined,
+      settleActionBoundary: async () => {
+        throw new Error("settleActionBoundary should not be called");
+      },
+      syncExecutionPaused: async () => false,
+      setExecutionPaused: async () => undefined,
+      isPageClosedError: () => false,
+      locateBackendNode: () => locator,
+      requireLiveNode: () => ({
+        document: {
+          documentRef,
+          pageRef,
+        },
+        backendNodeId: 1,
+      }),
+      getDomSnapshot: async () => {
+        throw new Error("getDomSnapshot should not be called");
+      },
+      getViewportMetrics: async () => {
+        throw new Error("getViewportMetrics should not be called");
+      },
+    });
+
+    await bridge.buildReplayPath(locator, {
+      enableTextMatch: true,
+    });
+
+    const buildReplayCall = runtimeCalls.find((args) => args.length >= 2);
+    expect(buildReplayCall?.[0]?.value).toMatchObject({
+      enableTextMatch: true,
+    });
+    expect(String(buildReplayCall?.[1]?.value)).toContain('clause.kind === "text"');
+    expect(String(buildReplayCall?.[1]?.value)).toContain("textContent: policy.enableTextMatch");
   });
 
   test("resolves opener relationships after adopted pages are registered", () => {

--- a/tests/opensteer/cloud-browser-profile.test.ts
+++ b/tests/opensteer/cloud-browser-profile.test.ts
@@ -11,7 +11,10 @@ import {
   type OpensteerRequestEnvelope,
 } from "@opensteer/protocol";
 import { defaultPolicy } from "../../packages/opensteer/src/index.js";
-import { OpensteerCloudClient } from "../../packages/opensteer/src/cloud/client.js";
+import {
+  OpensteerCloudClient,
+  OpensteerCloudRequestError,
+} from "../../packages/opensteer/src/cloud/client.js";
 const syncLocalWorkspaceToCloudMock = vi.fn();
 vi.mock("../../packages/opensteer/src/cloud/workspace-sync.js", () => ({
   syncLocalWorkspaceToCloud: (...args: unknown[]) => syncLocalWorkspaceToCloudMock(...args),
@@ -198,6 +201,41 @@ describe("cloud browser-profile integration", () => {
         method: "POST",
       }),
     );
+  });
+
+  test("OpensteerCloudClient preserves structured cloud request errors", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 409,
+      json: async () => ({
+        error: "Session has expired.",
+        code: "CLOUD_SESSION_STALE",
+        details: {
+          reason: "expired",
+        },
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new OpensteerCloudClient({
+      apiKey: "osk_test",
+      baseUrl: "https://api.opensteer.dev",
+    });
+
+    try {
+      await client.issueAccess("session_123", ["semantic"]);
+      throw new Error("expected issueAccess to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(OpensteerCloudRequestError);
+      expect(error).toMatchObject({
+        message: "Session has expired.",
+        statusCode: 409,
+        code: "CLOUD_SESSION_STALE",
+        details: {
+          reason: "expired",
+        },
+      });
+    }
   });
 
   test("OpensteerCloudClient syncs cookies into a cloud browser profile", async () => {
@@ -435,6 +473,566 @@ describe("cloud browser-profile integration", () => {
     } finally {
       await rm(rootDir, { recursive: true, force: true });
     }
+  });
+
+  test("CloudSessionProxy does not reuse persisted workspace sessions that are already expired", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "opensteer-cloud-session-"));
+    const workspace = "cloud-workspace";
+    const workspaceRoot = path.join(rootDir, ".opensteer", "workspaces", workspace);
+    const firstSemanticBaseUrl = "https://cloud.example/runtime/session_123";
+    const secondSemanticBaseUrl = "https://cloud.example/runtime/session_456";
+    const firstSemanticGrant = {
+      kind: "semantic" as const,
+      transport: "http" as const,
+      url: firstSemanticBaseUrl,
+      token: "semantic-token-1",
+      expiresAt: 4_102_444_800_000,
+    };
+    const secondSemanticGrant = {
+      kind: "semantic" as const,
+      transport: "http" as const,
+      url: secondSemanticBaseUrl,
+      token: "semantic-token-2",
+      expiresAt: 4_102_444_800_000,
+    };
+    let createSessionCalls = 0;
+    let getSessionCalls = 0;
+    let staleAccessCalls = 0;
+    let closeSessionCalls = 0;
+    const events: string[] = [];
+
+    syncLocalWorkspaceToCloudMock.mockResolvedValue(undefined);
+
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "https://api.opensteer.dev/v1/sessions" && init?.method === "POST") {
+        createSessionCalls += 1;
+        events.push(`create-session-${createSessionCalls}`);
+        if (createSessionCalls === 1) {
+          return {
+            ok: true,
+            json: async () => ({
+              sessionId: "session_123",
+              status: "active",
+              initialGrants: {
+                semantic: firstSemanticGrant,
+              },
+              initialGrantExpiresAt: firstSemanticGrant.expiresAt,
+            }),
+          };
+        }
+
+        return {
+          ok: true,
+          json: async () => ({
+            sessionId: "session_456",
+            status: "active",
+            initialGrants: {
+              semantic: secondSemanticGrant,
+            },
+            initialGrantExpiresAt: secondSemanticGrant.expiresAt,
+          }),
+        };
+      }
+
+      if (url === "https://api.opensteer.dev/v1/sessions/session_123" && init?.method === "GET") {
+        getSessionCalls += 1;
+        events.push("get-session");
+        return {
+          ok: true,
+          json: async () => ({
+            status: "active",
+            expiresAt: Date.now() - 1,
+          }),
+        };
+      }
+
+      if (
+        url === "https://api.opensteer.dev/v1/sessions/session_123/access" &&
+        init?.method === "POST"
+      ) {
+        staleAccessCalls += 1;
+        events.push("stale-access");
+        return {
+          ok: false,
+          status: 409,
+          json: async () => ({
+            error: "Session has expired.",
+            code: "CLOUD_SESSION_STALE",
+          }),
+        };
+      }
+
+      if (
+        url === "https://api.opensteer.dev/v1/sessions/session_456" &&
+        init?.method === "DELETE"
+      ) {
+        closeSessionCalls += 1;
+        return {
+          ok: true,
+          json: async () => ({
+            status: "closed",
+          }),
+        };
+      }
+
+      if (
+        url === `${firstSemanticBaseUrl}/api/v2/semantic/operations/session/open` &&
+        init?.method === "POST"
+      ) {
+        const request = JSON.parse(String(init.body)) as OpensteerRequestEnvelope<unknown>;
+        events.push("semantic-open-1");
+        return {
+          ok: true,
+          json: async () =>
+            createSuccessEnvelope(request, {
+              sessionRef: "session:cloud-1",
+              pageRef: "page:cloud-1",
+              url: "https://example.com",
+              title: "Cloud Workspace",
+            }),
+        };
+      }
+
+      if (
+        url === `${secondSemanticBaseUrl}/api/v2/semantic/operations/session/open` &&
+        init?.method === "POST"
+      ) {
+        const request = JSON.parse(String(init.body)) as OpensteerRequestEnvelope<unknown>;
+        events.push("semantic-open-2");
+        return {
+          ok: true,
+          json: async () =>
+            createSuccessEnvelope(request, {
+              sessionRef: "session:cloud-2",
+              pageRef: "page:cloud-2",
+              url: "https://example.com",
+              title: "Recovered Cloud Workspace",
+            }),
+        };
+      }
+
+      throw new Error(`Unexpected fetch ${init?.method ?? "GET"} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const client = new OpensteerCloudClient({
+        apiKey: "osk_test",
+        baseUrl: "https://api.opensteer.dev",
+      });
+
+      const first = new CloudSessionProxy(client, {
+        rootDir,
+        workspace,
+      });
+      await first.open({
+        url: "https://example.com",
+      });
+      await first.disconnect();
+
+      expect(await readPersistedCloudSessionRecord(workspaceRoot)).toMatchObject({
+        sessionId: "session_123",
+      });
+
+      const second = new CloudSessionProxy(client, {
+        rootDir,
+        workspace,
+      });
+      const reopened = await second.open({
+        url: "https://example.com",
+      });
+
+      expect(reopened).toMatchObject({
+        title: "Recovered Cloud Workspace",
+      });
+      expect(events).toEqual([
+        "create-session-1",
+        "semantic-open-1",
+        "get-session",
+        "create-session-2",
+        "semantic-open-2",
+      ]);
+      expect(createSessionCalls).toBe(2);
+      expect(getSessionCalls).toBe(1);
+      expect(staleAccessCalls).toBe(0);
+      expect(await readPersistedCloudSessionRecord(workspaceRoot)).toMatchObject({
+        sessionId: "session_456",
+      });
+
+      await second.close();
+
+      expect(closeSessionCalls).toBe(1);
+      expect(await readPersistedCloudSessionRecord(workspaceRoot)).toBeUndefined();
+    } finally {
+      await rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  test("CloudSessionProxy recreates a persisted workspace session when access is stale", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "opensteer-cloud-session-"));
+    const workspace = "cloud-workspace";
+    const workspaceRoot = path.join(rootDir, ".opensteer", "workspaces", workspace);
+    const firstSemanticBaseUrl = "https://cloud.example/runtime/session_123";
+    const secondSemanticBaseUrl = "https://cloud.example/runtime/session_456";
+    const firstSemanticGrant = {
+      kind: "semantic" as const,
+      transport: "http" as const,
+      url: firstSemanticBaseUrl,
+      token: "semantic-token-1",
+      expiresAt: 4_102_444_800_000,
+    };
+    const secondSemanticGrant = {
+      kind: "semantic" as const,
+      transport: "http" as const,
+      url: secondSemanticBaseUrl,
+      token: "semantic-token-2",
+      expiresAt: 4_102_444_800_000,
+    };
+    let createSessionCalls = 0;
+    let getSessionCalls = 0;
+    let staleAccessCalls = 0;
+    let closeSessionCalls = 0;
+    const events: string[] = [];
+
+    syncLocalWorkspaceToCloudMock.mockResolvedValue(undefined);
+
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "https://api.opensteer.dev/v1/sessions" && init?.method === "POST") {
+        createSessionCalls += 1;
+        events.push(`create-session-${createSessionCalls}`);
+        if (createSessionCalls === 1) {
+          return {
+            ok: true,
+            json: async () => ({
+              sessionId: "session_123",
+              status: "active",
+              initialGrants: {
+                semantic: firstSemanticGrant,
+              },
+              initialGrantExpiresAt: firstSemanticGrant.expiresAt,
+            }),
+          };
+        }
+
+        return {
+          ok: true,
+          json: async () => ({
+            sessionId: "session_456",
+            status: "active",
+            initialGrants: {
+              semantic: secondSemanticGrant,
+            },
+            initialGrantExpiresAt: secondSemanticGrant.expiresAt,
+          }),
+        };
+      }
+
+      if (url === "https://api.opensteer.dev/v1/sessions/session_123" && init?.method === "GET") {
+        getSessionCalls += 1;
+        events.push("get-session");
+        return {
+          ok: true,
+          json: async () => ({
+            status: "active",
+            expiresAt: Date.now() + 60_000,
+          }),
+        };
+      }
+
+      if (
+        url === "https://api.opensteer.dev/v1/sessions/session_123/access" &&
+        init?.method === "POST"
+      ) {
+        staleAccessCalls += 1;
+        events.push("stale-access");
+        return {
+          ok: false,
+          status: 409,
+          json: async () => ({
+            error: "Session has expired.",
+            code: "CLOUD_SESSION_STALE",
+          }),
+        };
+      }
+
+      if (
+        url === "https://api.opensteer.dev/v1/sessions/session_456" &&
+        init?.method === "DELETE"
+      ) {
+        closeSessionCalls += 1;
+        return {
+          ok: true,
+          json: async () => ({
+            status: "closed",
+          }),
+        };
+      }
+
+      if (
+        url === `${firstSemanticBaseUrl}/api/v2/semantic/operations/session/open` &&
+        init?.method === "POST"
+      ) {
+        const request = JSON.parse(String(init.body)) as OpensteerRequestEnvelope<unknown>;
+        events.push("semantic-open-1");
+        return {
+          ok: true,
+          json: async () =>
+            createSuccessEnvelope(request, {
+              sessionRef: "session:cloud-1",
+              pageRef: "page:cloud-1",
+              url: "https://example.com",
+              title: "Cloud Workspace",
+            }),
+        };
+      }
+
+      if (
+        url === `${secondSemanticBaseUrl}/api/v2/semantic/operations/session/open` &&
+        init?.method === "POST"
+      ) {
+        const request = JSON.parse(String(init.body)) as OpensteerRequestEnvelope<unknown>;
+        events.push("semantic-open-2");
+        return {
+          ok: true,
+          json: async () =>
+            createSuccessEnvelope(request, {
+              sessionRef: "session:cloud-2",
+              pageRef: "page:cloud-2",
+              url: "https://example.com",
+              title: "Recovered Cloud Workspace",
+            }),
+        };
+      }
+
+      throw new Error(`Unexpected fetch ${init?.method ?? "GET"} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const client = new OpensteerCloudClient({
+        apiKey: "osk_test",
+        baseUrl: "https://api.opensteer.dev",
+      });
+
+      const first = new CloudSessionProxy(client, {
+        rootDir,
+        workspace,
+      });
+      await first.open({
+        url: "https://example.com",
+      });
+      await first.disconnect();
+
+      expect(await readPersistedCloudSessionRecord(workspaceRoot)).toMatchObject({
+        sessionId: "session_123",
+      });
+
+      const second = new CloudSessionProxy(client, {
+        rootDir,
+        workspace,
+      });
+      const reopened = await second.open({
+        url: "https://example.com",
+      });
+
+      expect(reopened).toMatchObject({
+        title: "Recovered Cloud Workspace",
+      });
+      expect(events).toEqual([
+        "create-session-1",
+        "semantic-open-1",
+        "get-session",
+        "stale-access",
+        "create-session-2",
+        "semantic-open-2",
+      ]);
+      expect(createSessionCalls).toBe(2);
+      expect(getSessionCalls).toBe(1);
+      expect(staleAccessCalls).toBe(1);
+      expect(await readPersistedCloudSessionRecord(workspaceRoot)).toMatchObject({
+        sessionId: "session_456",
+      });
+
+      await second.close();
+
+      expect(closeSessionCalls).toBe(1);
+      expect(await readPersistedCloudSessionRecord(workspaceRoot)).toBeUndefined();
+    } finally {
+      await rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  test("CloudSessionProxy recreates a bound session when grant refresh reports a stale session", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    const firstSemanticBaseUrl = "https://cloud.example/runtime/session_123";
+    const secondSemanticBaseUrl = "https://cloud.example/runtime/session_456";
+    const firstSemanticGrant = {
+      kind: "semantic" as const,
+      transport: "http" as const,
+      url: firstSemanticBaseUrl,
+      token: "semantic-token-1",
+      expiresAt: Date.now() + 60_000,
+    };
+    const secondSemanticGrant = {
+      kind: "semantic" as const,
+      transport: "http" as const,
+      url: secondSemanticBaseUrl,
+      token: "semantic-token-2",
+      expiresAt: Date.now() + 120_000,
+    };
+    let createSessionCalls = 0;
+    let staleAccessCalls = 0;
+    let closeSessionCalls = 0;
+    const events: string[] = [];
+
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "https://api.opensteer.dev/v1/sessions" && init?.method === "POST") {
+        createSessionCalls += 1;
+        events.push(`create-session-${createSessionCalls}`);
+        if (createSessionCalls === 1) {
+          return {
+            ok: true,
+            json: async () => ({
+              sessionId: "session_123",
+              status: "active",
+              initialGrants: {
+                semantic: firstSemanticGrant,
+              },
+              initialGrantExpiresAt: firstSemanticGrant.expiresAt,
+            }),
+          };
+        }
+
+        return {
+          ok: true,
+          json: async () => ({
+            sessionId: "session_456",
+            status: "active",
+            initialGrants: {
+              semantic: secondSemanticGrant,
+            },
+            initialGrantExpiresAt: secondSemanticGrant.expiresAt,
+          }),
+        };
+      }
+
+      if (
+        url === "https://api.opensteer.dev/v1/sessions/session_123/access" &&
+        init?.method === "POST"
+      ) {
+        staleAccessCalls += 1;
+        events.push("stale-access");
+        return {
+          ok: false,
+          status: 409,
+          json: async () => ({
+            error: "Session has expired.",
+            code: "CLOUD_SESSION_STALE",
+          }),
+        };
+      }
+
+      if (
+        url === "https://api.opensteer.dev/v1/sessions/session_456" &&
+        init?.method === "DELETE"
+      ) {
+        closeSessionCalls += 1;
+        return {
+          ok: true,
+          json: async () => ({
+            status: "closed",
+          }),
+        };
+      }
+
+      if (
+        url === `${firstSemanticBaseUrl}/api/v2/semantic/operations/session/open` &&
+        init?.method === "POST"
+      ) {
+        const request = JSON.parse(String(init.body)) as OpensteerRequestEnvelope<unknown>;
+        events.push("semantic-open-1");
+        return {
+          ok: true,
+          json: async () =>
+            createSuccessEnvelope(request, {
+              sessionRef: "session:cloud-1",
+              pageRef: "page:cloud-1",
+              url: "https://example.com",
+              title: "Cloud Workspace",
+            }),
+        };
+      }
+
+      if (
+        url === `${secondSemanticBaseUrl}/api/v2/semantic/operations/page/list` &&
+        init?.method === "POST"
+      ) {
+        const request = JSON.parse(String(init.body)) as OpensteerRequestEnvelope<unknown>;
+        events.push("page-list-2");
+        return {
+          ok: true,
+          json: async () =>
+            createSuccessEnvelope(request, {
+              activePageRef: "page:cloud-2",
+              pages: [
+                {
+                  pageRef: "page:cloud-2",
+                  url: "https://example.com",
+                  title: "Recovered Cloud Workspace",
+                },
+              ],
+            }),
+        };
+      }
+
+      throw new Error(`Unexpected fetch ${init?.method ?? "GET"} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const proxy = new CloudSessionProxy(
+      new OpensteerCloudClient({
+        apiKey: "osk_test",
+        baseUrl: "https://api.opensteer.dev",
+      }),
+    );
+
+    const opened = await proxy.open({
+      url: "https://example.com",
+    });
+
+    expect(opened).toMatchObject({
+      title: "Cloud Workspace",
+    });
+
+    vi.setSystemTime(new Date("2026-01-01T00:00:55.000Z"));
+
+    const pages = await proxy.listPages();
+
+    expect(pages).toMatchObject({
+      activePageRef: "page:cloud-2",
+      pages: [
+        {
+          pageRef: "page:cloud-2",
+          url: "https://example.com",
+          title: "Recovered Cloud Workspace",
+        },
+      ],
+    });
+    expect(events).toEqual([
+      "create-session-1",
+      "semantic-open-1",
+      "stale-access",
+      "create-session-2",
+      "page-list-2",
+    ]);
+    expect(createSessionCalls).toBe(2);
+    expect(staleAccessCalls).toBe(1);
+
+    await proxy.close();
+
+    expect(closeSessionCalls).toBe(1);
   });
 
   test("CloudSessionProxy fails creating a new session when workspace sync fails", async () => {

--- a/tests/opensteer/cloud-browser-profile.test.ts
+++ b/tests/opensteer/cloud-browser-profile.test.ts
@@ -23,6 +23,7 @@ import {
   CloudSessionProxy,
   readPersistedCloudSessionRecord,
 } from "../../packages/opensteer/src/cloud/session-proxy.js";
+import { OpensteerCloudAutomationClient } from "../../packages/opensteer/src/cloud/automation-client.js";
 import { resolveOpensteerRuntimeConfig } from "../../packages/opensteer/src/sdk/runtime-resolution.js";
 
 const readBrowserCookiesMock = vi.fn();
@@ -36,7 +37,106 @@ afterEach(() => {
   vi.unstubAllEnvs();
   vi.unstubAllGlobals();
   vi.clearAllMocks();
+  vi.restoreAllMocks();
 });
+
+const CLOUD_API_KEY = "osk_test";
+const CLOUD_BASE_URL = "https://api.opensteer.dev";
+const CLOUD_WORKSPACE = "cloud-workspace";
+const EXAMPLE_URL = "https://example.com";
+
+type TemporaryCloudWorkspace = {
+  readonly rootDir: string;
+  readonly workspace: string;
+  readonly workspaceRoot: string;
+};
+
+function createCloudClient(
+  overrides: Partial<ConstructorParameters<typeof OpensteerCloudClient>[0]> = {},
+): OpensteerCloudClient {
+  return new OpensteerCloudClient({
+    apiKey: CLOUD_API_KEY,
+    baseUrl: CLOUD_BASE_URL,
+    ...overrides,
+  });
+}
+
+function createSemanticGrant(input: {
+  readonly url: string;
+  readonly token: string;
+  readonly expiresAt: number;
+}) {
+  return {
+    kind: "semantic" as const,
+    transport: "http" as const,
+    url: input.url,
+    token: input.token,
+    expiresAt: input.expiresAt,
+  };
+}
+
+function createActiveSessionDescriptor(
+  sessionId: string,
+  semanticGrant?: ReturnType<typeof createSemanticGrant>,
+) {
+  return {
+    sessionId,
+    status: "active" as const,
+    initialGrants: semanticGrant === undefined ? {} : { semantic: semanticGrant },
+    ...(semanticGrant === undefined ? {} : { initialGrantExpiresAt: semanticGrant.expiresAt }),
+  };
+}
+
+function createClosedSessionDescriptor() {
+  return {
+    status: "closed" as const,
+  };
+}
+
+function createStaleSessionPayload(details?: unknown) {
+  return {
+    error: "Session has expired.",
+    code: "CLOUD_SESSION_STALE",
+    ...(details === undefined ? {} : { details }),
+  };
+}
+
+function createStaleSessionResponse(details?: unknown) {
+  return {
+    ok: false,
+    status: 409,
+    json: async () => createStaleSessionPayload(details),
+  };
+}
+
+function createStaleSessionError(sessionId: string): OpensteerCloudRequestError {
+  return new OpensteerCloudRequestError({
+    statusCode: 409,
+    code: "CLOUD_SESSION_STALE",
+    method: "POST",
+    pathname: `/v1/sessions/${sessionId}/access`,
+    url: `${CLOUD_BASE_URL}/v1/sessions/${sessionId}/access`,
+    message: "Session has expired.",
+  });
+}
+
+function parseRequestEnvelope(init?: RequestInit): OpensteerRequestEnvelope<unknown> {
+  return JSON.parse(String(init?.body)) as OpensteerRequestEnvelope<unknown>;
+}
+
+async function withTemporaryCloudWorkspace(
+  run: (workspace: TemporaryCloudWorkspace) => Promise<void>,
+): Promise<void> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "opensteer-cloud-session-"));
+  const workspace = CLOUD_WORKSPACE;
+  const workspaceRoot = path.join(rootDir, ".opensteer", "workspaces", workspace);
+
+  try {
+    await run({ rootDir, workspace, workspaceRoot });
+  } finally {
+    await rm(rootDir, { recursive: true, force: true });
+  }
+}
 
 describe("cloud browser-profile integration", () => {
   test("resolves cloud runtime config with a default browser profile preference", () => {
@@ -204,23 +304,14 @@ describe("cloud browser-profile integration", () => {
   });
 
   test("OpensteerCloudClient preserves structured cloud request errors", async () => {
-    const fetchMock = vi.fn(async () => ({
-      ok: false,
-      status: 409,
-      json: async () => ({
-        error: "Session has expired.",
-        code: "CLOUD_SESSION_STALE",
-        details: {
-          reason: "expired",
-        },
+    const fetchMock = vi.fn(async () =>
+      createStaleSessionResponse({
+        reason: "expired",
       }),
-    }));
+    );
     vi.stubGlobal("fetch", fetchMock);
 
-    const client = new OpensteerCloudClient({
-      apiKey: "osk_test",
-      baseUrl: "https://api.opensteer.dev",
-    });
+    const client = createCloudClient();
 
     try {
       await client.issueAccess("session_123", ["semantic"]);
@@ -314,122 +405,97 @@ describe("cloud browser-profile integration", () => {
   });
 
   test("CloudSessionProxy reuses persisted workspace cloud sessions", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "opensteer-cloud-session-"));
-    const workspace = "cloud-workspace";
-    const workspaceRoot = path.join(rootDir, ".opensteer", "workspaces", workspace);
-    const semanticBaseUrl = "https://cloud.example/runtime/session_123";
-    const semanticGrant = {
-      kind: "semantic" as const,
-      transport: "http" as const,
-      url: semanticBaseUrl,
-      token: "semantic-token",
-      expiresAt: 4_102_444_800_000,
-    };
-    let createSessionCalls = 0;
-    let accessCalls = 0;
-    let getSessionCalls = 0;
-    let closeSessionCalls = 0;
-    let semanticOpenCalls = 0;
-    const events: string[] = [];
+    await withTemporaryCloudWorkspace(async ({ rootDir, workspace, workspaceRoot }) => {
+      const semanticBaseUrl = "https://cloud.example/runtime/session_123";
+      const semanticGrant = createSemanticGrant({
+        url: semanticBaseUrl,
+        token: "semantic-token",
+        expiresAt: 4_102_444_800_000,
+      });
+      let createSessionCalls = 0;
+      let accessCalls = 0;
+      let getSessionCalls = 0;
+      let closeSessionCalls = 0;
+      let semanticOpenCalls = 0;
+      const events: string[] = [];
 
-    syncLocalWorkspaceToCloudMock.mockImplementation(async () => {
-      events.push("sync");
-    });
-
-    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
-      if (url === "https://api.opensteer.dev/v1/sessions" && init?.method === "POST") {
-        createSessionCalls += 1;
-        events.push("create-session");
-        return {
-          ok: true,
-          json: async () => ({
-            sessionId: "session_123",
-            status: "active",
-            initialGrants: {
-              semantic: semanticGrant,
-            },
-            initialGrantExpiresAt: semanticGrant.expiresAt,
-          }),
-        };
-      }
-
-      if (
-        url === "https://api.opensteer.dev/v1/sessions/session_123/access" &&
-        init?.method === "POST"
-      ) {
-        accessCalls += 1;
-        events.push("access");
-        return {
-          ok: true,
-          json: async () => ({
-            sessionId: "session_123",
-            expiresAt: semanticGrant.expiresAt,
-            grants: {
-              semantic: semanticGrant,
-            },
-          }),
-        };
-      }
-
-      if (url === "https://api.opensteer.dev/v1/sessions/session_123" && init?.method === "GET") {
-        getSessionCalls += 1;
-        events.push("get-session");
-        return {
-          ok: true,
-          json: async () => ({
-            status: "active",
-          }),
-        };
-      }
-
-      if (
-        url === "https://api.opensteer.dev/v1/sessions/session_123" &&
-        init?.method === "DELETE"
-      ) {
-        closeSessionCalls += 1;
-        return {
-          ok: true,
-          json: async () => ({
-            status: "closed",
-          }),
-        };
-      }
-
-      if (
-        url === `${semanticBaseUrl}/api/v2/semantic/operations/session/open` &&
-        init?.method === "POST"
-      ) {
-        semanticOpenCalls += 1;
-        events.push("semantic-open");
-        const request = JSON.parse(String(init.body)) as OpensteerRequestEnvelope<unknown>;
-        return {
-          ok: true,
-          json: async () =>
-            createSuccessEnvelope(request, {
-              sessionRef: "session:cloud",
-              pageRef: "page:cloud",
-              url: "https://example.com",
-              title: "Cloud Workspace",
-            }),
-        };
-      }
-
-      throw new Error(`Unexpected fetch ${init?.method ?? "GET"} ${url}`);
-    });
-    vi.stubGlobal("fetch", fetchMock);
-
-    try {
-      const client = new OpensteerCloudClient({
-        apiKey: "osk_test",
-        baseUrl: "https://api.opensteer.dev",
+      syncLocalWorkspaceToCloudMock.mockImplementation(async () => {
+        events.push("sync");
       });
 
+      const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+        if (url === `${CLOUD_BASE_URL}/v1/sessions` && init?.method === "POST") {
+          createSessionCalls += 1;
+          events.push("create-session");
+          return {
+            ok: true,
+            json: async () => createActiveSessionDescriptor("session_123", semanticGrant),
+          };
+        }
+
+        if (url === `${CLOUD_BASE_URL}/v1/sessions/session_123/access` && init?.method === "POST") {
+          accessCalls += 1;
+          events.push("access");
+          return {
+            ok: true,
+            json: async () => ({
+              sessionId: "session_123",
+              expiresAt: semanticGrant.expiresAt,
+              grants: {
+                semantic: semanticGrant,
+              },
+            }),
+          };
+        }
+
+        if (url === `${CLOUD_BASE_URL}/v1/sessions/session_123` && init?.method === "GET") {
+          getSessionCalls += 1;
+          events.push("get-session");
+          return {
+            ok: true,
+            json: async () => ({
+              status: "active",
+            }),
+          };
+        }
+
+        if (url === `${CLOUD_BASE_URL}/v1/sessions/session_123` && init?.method === "DELETE") {
+          closeSessionCalls += 1;
+          return {
+            ok: true,
+            json: async () => createClosedSessionDescriptor(),
+          };
+        }
+
+        if (
+          url === `${semanticBaseUrl}/api/v2/semantic/operations/session/open` &&
+          init?.method === "POST"
+        ) {
+          semanticOpenCalls += 1;
+          events.push("semantic-open");
+          return {
+            ok: true,
+            json: async () =>
+              createSuccessEnvelope(parseRequestEnvelope(init), {
+                sessionRef: "session:cloud",
+                pageRef: "page:cloud",
+                url: EXAMPLE_URL,
+                title: "Cloud Workspace",
+              }),
+          };
+        }
+
+        throw new Error(`Unexpected fetch ${init?.method ?? "GET"} ${url}`);
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = createCloudClient();
       const first = new CloudSessionProxy(client, {
         rootDir,
         workspace,
       });
       const openedFirst = await first.open({
-        url: "https://example.com",
+        url: EXAMPLE_URL,
         browser: "persistent",
         launch: {
           headless: true,
@@ -437,7 +503,7 @@ describe("cloud browser-profile integration", () => {
       });
 
       expect(openedFirst).toMatchObject({
-        url: "https://example.com",
+        url: EXAMPLE_URL,
         title: "Cloud Workspace",
       });
       expect(events.slice(0, 3)).toEqual(["sync", "create-session", "semantic-open"]);
@@ -457,7 +523,7 @@ describe("cloud browser-profile integration", () => {
         workspace,
       });
       await second.open({
-        url: "https://example.com",
+        url: EXAMPLE_URL,
       });
 
       expect(events.slice(3)).toEqual(["get-session", "sync", "access", "semantic-open"]);
@@ -470,163 +536,116 @@ describe("cloud browser-profile integration", () => {
 
       expect(closeSessionCalls).toBe(1);
       expect(await readPersistedCloudSessionRecord(workspaceRoot)).toBeUndefined();
-    } finally {
-      await rm(rootDir, { recursive: true, force: true });
-    }
+    });
   });
 
   test("CloudSessionProxy does not reuse persisted workspace sessions that are already expired", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "opensteer-cloud-session-"));
-    const workspace = "cloud-workspace";
-    const workspaceRoot = path.join(rootDir, ".opensteer", "workspaces", workspace);
-    const firstSemanticBaseUrl = "https://cloud.example/runtime/session_123";
-    const secondSemanticBaseUrl = "https://cloud.example/runtime/session_456";
-    const firstSemanticGrant = {
-      kind: "semantic" as const,
-      transport: "http" as const,
-      url: firstSemanticBaseUrl,
-      token: "semantic-token-1",
-      expiresAt: 4_102_444_800_000,
-    };
-    const secondSemanticGrant = {
-      kind: "semantic" as const,
-      transport: "http" as const,
-      url: secondSemanticBaseUrl,
-      token: "semantic-token-2",
-      expiresAt: 4_102_444_800_000,
-    };
-    let createSessionCalls = 0;
-    let getSessionCalls = 0;
-    let staleAccessCalls = 0;
-    let closeSessionCalls = 0;
-    const events: string[] = [];
+    await withTemporaryCloudWorkspace(async ({ rootDir, workspace, workspaceRoot }) => {
+      const firstSemanticBaseUrl = "https://cloud.example/runtime/session_123";
+      const secondSemanticBaseUrl = "https://cloud.example/runtime/session_456";
+      const firstSemanticGrant = createSemanticGrant({
+        url: firstSemanticBaseUrl,
+        token: "semantic-token-1",
+        expiresAt: 4_102_444_800_000,
+      });
+      const secondSemanticGrant = createSemanticGrant({
+        url: secondSemanticBaseUrl,
+        token: "semantic-token-2",
+        expiresAt: 4_102_444_800_000,
+      });
+      let createSessionCalls = 0;
+      let getSessionCalls = 0;
+      let staleAccessCalls = 0;
+      let closeSessionCalls = 0;
+      const events: string[] = [];
 
-    syncLocalWorkspaceToCloudMock.mockResolvedValue(undefined);
+      syncLocalWorkspaceToCloudMock.mockResolvedValue(undefined);
 
-    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
-      if (url === "https://api.opensteer.dev/v1/sessions" && init?.method === "POST") {
-        createSessionCalls += 1;
-        events.push(`create-session-${createSessionCalls}`);
-        if (createSessionCalls === 1) {
+      const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+        if (url === `${CLOUD_BASE_URL}/v1/sessions` && init?.method === "POST") {
+          createSessionCalls += 1;
+          events.push(`create-session-${createSessionCalls}`);
+          return {
+            ok: true,
+            json: async () =>
+              createActiveSessionDescriptor(
+                createSessionCalls === 1 ? "session_123" : "session_456",
+                createSessionCalls === 1 ? firstSemanticGrant : secondSemanticGrant,
+              ),
+          };
+        }
+
+        if (url === `${CLOUD_BASE_URL}/v1/sessions/session_123` && init?.method === "GET") {
+          getSessionCalls += 1;
+          events.push("get-session");
           return {
             ok: true,
             json: async () => ({
-              sessionId: "session_123",
               status: "active",
-              initialGrants: {
-                semantic: firstSemanticGrant,
-              },
-              initialGrantExpiresAt: firstSemanticGrant.expiresAt,
+              expiresAt: Date.now() - 1,
             }),
           };
         }
 
-        return {
-          ok: true,
-          json: async () => ({
-            sessionId: "session_456",
-            status: "active",
-            initialGrants: {
-              semantic: secondSemanticGrant,
-            },
-            initialGrantExpiresAt: secondSemanticGrant.expiresAt,
-          }),
-        };
-      }
+        if (url === `${CLOUD_BASE_URL}/v1/sessions/session_123/access` && init?.method === "POST") {
+          staleAccessCalls += 1;
+          events.push("stale-access");
+          return createStaleSessionResponse();
+        }
 
-      if (url === "https://api.opensteer.dev/v1/sessions/session_123" && init?.method === "GET") {
-        getSessionCalls += 1;
-        events.push("get-session");
-        return {
-          ok: true,
-          json: async () => ({
-            status: "active",
-            expiresAt: Date.now() - 1,
-          }),
-        };
-      }
+        if (url === `${CLOUD_BASE_URL}/v1/sessions/session_456` && init?.method === "DELETE") {
+          closeSessionCalls += 1;
+          return {
+            ok: true,
+            json: async () => createClosedSessionDescriptor(),
+          };
+        }
 
-      if (
-        url === "https://api.opensteer.dev/v1/sessions/session_123/access" &&
-        init?.method === "POST"
-      ) {
-        staleAccessCalls += 1;
-        events.push("stale-access");
-        return {
-          ok: false,
-          status: 409,
-          json: async () => ({
-            error: "Session has expired.",
-            code: "CLOUD_SESSION_STALE",
-          }),
-        };
-      }
+        if (
+          url === `${firstSemanticBaseUrl}/api/v2/semantic/operations/session/open` &&
+          init?.method === "POST"
+        ) {
+          events.push("semantic-open-1");
+          return {
+            ok: true,
+            json: async () =>
+              createSuccessEnvelope(parseRequestEnvelope(init), {
+                sessionRef: "session:cloud-1",
+                pageRef: "page:cloud-1",
+                url: EXAMPLE_URL,
+                title: "Cloud Workspace",
+              }),
+          };
+        }
 
-      if (
-        url === "https://api.opensteer.dev/v1/sessions/session_456" &&
-        init?.method === "DELETE"
-      ) {
-        closeSessionCalls += 1;
-        return {
-          ok: true,
-          json: async () => ({
-            status: "closed",
-          }),
-        };
-      }
+        if (
+          url === `${secondSemanticBaseUrl}/api/v2/semantic/operations/session/open` &&
+          init?.method === "POST"
+        ) {
+          events.push("semantic-open-2");
+          return {
+            ok: true,
+            json: async () =>
+              createSuccessEnvelope(parseRequestEnvelope(init), {
+                sessionRef: "session:cloud-2",
+                pageRef: "page:cloud-2",
+                url: EXAMPLE_URL,
+                title: "Recovered Cloud Workspace",
+              }),
+          };
+        }
 
-      if (
-        url === `${firstSemanticBaseUrl}/api/v2/semantic/operations/session/open` &&
-        init?.method === "POST"
-      ) {
-        const request = JSON.parse(String(init.body)) as OpensteerRequestEnvelope<unknown>;
-        events.push("semantic-open-1");
-        return {
-          ok: true,
-          json: async () =>
-            createSuccessEnvelope(request, {
-              sessionRef: "session:cloud-1",
-              pageRef: "page:cloud-1",
-              url: "https://example.com",
-              title: "Cloud Workspace",
-            }),
-        };
-      }
-
-      if (
-        url === `${secondSemanticBaseUrl}/api/v2/semantic/operations/session/open` &&
-        init?.method === "POST"
-      ) {
-        const request = JSON.parse(String(init.body)) as OpensteerRequestEnvelope<unknown>;
-        events.push("semantic-open-2");
-        return {
-          ok: true,
-          json: async () =>
-            createSuccessEnvelope(request, {
-              sessionRef: "session:cloud-2",
-              pageRef: "page:cloud-2",
-              url: "https://example.com",
-              title: "Recovered Cloud Workspace",
-            }),
-        };
-      }
-
-      throw new Error(`Unexpected fetch ${init?.method ?? "GET"} ${url}`);
-    });
-    vi.stubGlobal("fetch", fetchMock);
-
-    try {
-      const client = new OpensteerCloudClient({
-        apiKey: "osk_test",
-        baseUrl: "https://api.opensteer.dev",
+        throw new Error(`Unexpected fetch ${init?.method ?? "GET"} ${url}`);
       });
+      vi.stubGlobal("fetch", fetchMock);
 
+      const client = createCloudClient();
       const first = new CloudSessionProxy(client, {
         rootDir,
         workspace,
       });
       await first.open({
-        url: "https://example.com",
+        url: EXAMPLE_URL,
       });
       await first.disconnect();
 
@@ -639,7 +658,7 @@ describe("cloud browser-profile integration", () => {
         workspace,
       });
       const reopened = await second.open({
-        url: "https://example.com",
+        url: EXAMPLE_URL,
       });
 
       expect(reopened).toMatchObject({
@@ -663,163 +682,116 @@ describe("cloud browser-profile integration", () => {
 
       expect(closeSessionCalls).toBe(1);
       expect(await readPersistedCloudSessionRecord(workspaceRoot)).toBeUndefined();
-    } finally {
-      await rm(rootDir, { recursive: true, force: true });
-    }
+    });
   });
 
   test("CloudSessionProxy recreates a persisted workspace session when access is stale", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "opensteer-cloud-session-"));
-    const workspace = "cloud-workspace";
-    const workspaceRoot = path.join(rootDir, ".opensteer", "workspaces", workspace);
-    const firstSemanticBaseUrl = "https://cloud.example/runtime/session_123";
-    const secondSemanticBaseUrl = "https://cloud.example/runtime/session_456";
-    const firstSemanticGrant = {
-      kind: "semantic" as const,
-      transport: "http" as const,
-      url: firstSemanticBaseUrl,
-      token: "semantic-token-1",
-      expiresAt: 4_102_444_800_000,
-    };
-    const secondSemanticGrant = {
-      kind: "semantic" as const,
-      transport: "http" as const,
-      url: secondSemanticBaseUrl,
-      token: "semantic-token-2",
-      expiresAt: 4_102_444_800_000,
-    };
-    let createSessionCalls = 0;
-    let getSessionCalls = 0;
-    let staleAccessCalls = 0;
-    let closeSessionCalls = 0;
-    const events: string[] = [];
+    await withTemporaryCloudWorkspace(async ({ rootDir, workspace, workspaceRoot }) => {
+      const firstSemanticBaseUrl = "https://cloud.example/runtime/session_123";
+      const secondSemanticBaseUrl = "https://cloud.example/runtime/session_456";
+      const firstSemanticGrant = createSemanticGrant({
+        url: firstSemanticBaseUrl,
+        token: "semantic-token-1",
+        expiresAt: 4_102_444_800_000,
+      });
+      const secondSemanticGrant = createSemanticGrant({
+        url: secondSemanticBaseUrl,
+        token: "semantic-token-2",
+        expiresAt: 4_102_444_800_000,
+      });
+      let createSessionCalls = 0;
+      let getSessionCalls = 0;
+      let staleAccessCalls = 0;
+      let closeSessionCalls = 0;
+      const events: string[] = [];
 
-    syncLocalWorkspaceToCloudMock.mockResolvedValue(undefined);
+      syncLocalWorkspaceToCloudMock.mockResolvedValue(undefined);
 
-    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
-      if (url === "https://api.opensteer.dev/v1/sessions" && init?.method === "POST") {
-        createSessionCalls += 1;
-        events.push(`create-session-${createSessionCalls}`);
-        if (createSessionCalls === 1) {
+      const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+        if (url === `${CLOUD_BASE_URL}/v1/sessions` && init?.method === "POST") {
+          createSessionCalls += 1;
+          events.push(`create-session-${createSessionCalls}`);
+          return {
+            ok: true,
+            json: async () =>
+              createActiveSessionDescriptor(
+                createSessionCalls === 1 ? "session_123" : "session_456",
+                createSessionCalls === 1 ? firstSemanticGrant : secondSemanticGrant,
+              ),
+          };
+        }
+
+        if (url === `${CLOUD_BASE_URL}/v1/sessions/session_123` && init?.method === "GET") {
+          getSessionCalls += 1;
+          events.push("get-session");
           return {
             ok: true,
             json: async () => ({
-              sessionId: "session_123",
               status: "active",
-              initialGrants: {
-                semantic: firstSemanticGrant,
-              },
-              initialGrantExpiresAt: firstSemanticGrant.expiresAt,
+              expiresAt: Date.now() + 60_000,
             }),
           };
         }
 
-        return {
-          ok: true,
-          json: async () => ({
-            sessionId: "session_456",
-            status: "active",
-            initialGrants: {
-              semantic: secondSemanticGrant,
-            },
-            initialGrantExpiresAt: secondSemanticGrant.expiresAt,
-          }),
-        };
-      }
+        if (url === `${CLOUD_BASE_URL}/v1/sessions/session_123/access` && init?.method === "POST") {
+          staleAccessCalls += 1;
+          events.push("stale-access");
+          return createStaleSessionResponse();
+        }
 
-      if (url === "https://api.opensteer.dev/v1/sessions/session_123" && init?.method === "GET") {
-        getSessionCalls += 1;
-        events.push("get-session");
-        return {
-          ok: true,
-          json: async () => ({
-            status: "active",
-            expiresAt: Date.now() + 60_000,
-          }),
-        };
-      }
+        if (url === `${CLOUD_BASE_URL}/v1/sessions/session_456` && init?.method === "DELETE") {
+          closeSessionCalls += 1;
+          return {
+            ok: true,
+            json: async () => createClosedSessionDescriptor(),
+          };
+        }
 
-      if (
-        url === "https://api.opensteer.dev/v1/sessions/session_123/access" &&
-        init?.method === "POST"
-      ) {
-        staleAccessCalls += 1;
-        events.push("stale-access");
-        return {
-          ok: false,
-          status: 409,
-          json: async () => ({
-            error: "Session has expired.",
-            code: "CLOUD_SESSION_STALE",
-          }),
-        };
-      }
+        if (
+          url === `${firstSemanticBaseUrl}/api/v2/semantic/operations/session/open` &&
+          init?.method === "POST"
+        ) {
+          events.push("semantic-open-1");
+          return {
+            ok: true,
+            json: async () =>
+              createSuccessEnvelope(parseRequestEnvelope(init), {
+                sessionRef: "session:cloud-1",
+                pageRef: "page:cloud-1",
+                url: EXAMPLE_URL,
+                title: "Cloud Workspace",
+              }),
+          };
+        }
 
-      if (
-        url === "https://api.opensteer.dev/v1/sessions/session_456" &&
-        init?.method === "DELETE"
-      ) {
-        closeSessionCalls += 1;
-        return {
-          ok: true,
-          json: async () => ({
-            status: "closed",
-          }),
-        };
-      }
+        if (
+          url === `${secondSemanticBaseUrl}/api/v2/semantic/operations/session/open` &&
+          init?.method === "POST"
+        ) {
+          events.push("semantic-open-2");
+          return {
+            ok: true,
+            json: async () =>
+              createSuccessEnvelope(parseRequestEnvelope(init), {
+                sessionRef: "session:cloud-2",
+                pageRef: "page:cloud-2",
+                url: EXAMPLE_URL,
+                title: "Recovered Cloud Workspace",
+              }),
+          };
+        }
 
-      if (
-        url === `${firstSemanticBaseUrl}/api/v2/semantic/operations/session/open` &&
-        init?.method === "POST"
-      ) {
-        const request = JSON.parse(String(init.body)) as OpensteerRequestEnvelope<unknown>;
-        events.push("semantic-open-1");
-        return {
-          ok: true,
-          json: async () =>
-            createSuccessEnvelope(request, {
-              sessionRef: "session:cloud-1",
-              pageRef: "page:cloud-1",
-              url: "https://example.com",
-              title: "Cloud Workspace",
-            }),
-        };
-      }
-
-      if (
-        url === `${secondSemanticBaseUrl}/api/v2/semantic/operations/session/open` &&
-        init?.method === "POST"
-      ) {
-        const request = JSON.parse(String(init.body)) as OpensteerRequestEnvelope<unknown>;
-        events.push("semantic-open-2");
-        return {
-          ok: true,
-          json: async () =>
-            createSuccessEnvelope(request, {
-              sessionRef: "session:cloud-2",
-              pageRef: "page:cloud-2",
-              url: "https://example.com",
-              title: "Recovered Cloud Workspace",
-            }),
-        };
-      }
-
-      throw new Error(`Unexpected fetch ${init?.method ?? "GET"} ${url}`);
-    });
-    vi.stubGlobal("fetch", fetchMock);
-
-    try {
-      const client = new OpensteerCloudClient({
-        apiKey: "osk_test",
-        baseUrl: "https://api.opensteer.dev",
+        throw new Error(`Unexpected fetch ${init?.method ?? "GET"} ${url}`);
       });
+      vi.stubGlobal("fetch", fetchMock);
 
+      const client = createCloudClient();
       const first = new CloudSessionProxy(client, {
         rootDir,
         workspace,
       });
       await first.open({
-        url: "https://example.com",
+        url: EXAMPLE_URL,
       });
       await first.disconnect();
 
@@ -832,7 +804,7 @@ describe("cloud browser-profile integration", () => {
         workspace,
       });
       const reopened = await second.open({
-        url: "https://example.com",
+        url: EXAMPLE_URL,
       });
 
       expect(reopened).toMatchObject({
@@ -857,15 +829,214 @@ describe("cloud browser-profile integration", () => {
 
       expect(closeSessionCalls).toBe(1);
       expect(await readPersistedCloudSessionRecord(workspaceRoot)).toBeUndefined();
-    } finally {
-      await rm(rootDir, { recursive: true, force: true });
-    }
+    });
   });
 
-  test("CloudSessionProxy recreates a bound session when grant refresh reports a stale session", async () => {
+  test("CloudSessionProxy invalidates a live bound session instead of recreating it on stale grant refresh", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
 
+    const firstSemanticBaseUrl = "https://cloud.example/runtime/session_123";
+    const firstSemanticGrant = createSemanticGrant({
+      url: firstSemanticBaseUrl,
+      token: "semantic-token-1",
+      expiresAt: Date.now() + 60_000,
+    });
+    let createSessionCalls = 0;
+    let staleAccessCalls = 0;
+    const events: string[] = [];
+
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === `${CLOUD_BASE_URL}/v1/sessions` && init?.method === "POST") {
+        createSessionCalls += 1;
+        events.push(`create-session-${createSessionCalls}`);
+        return {
+          ok: true,
+          json: async () => createActiveSessionDescriptor("session_123", firstSemanticGrant),
+        };
+      }
+
+      if (url === `${CLOUD_BASE_URL}/v1/sessions/session_123/access` && init?.method === "POST") {
+        staleAccessCalls += 1;
+        events.push("stale-access");
+        return createStaleSessionResponse();
+      }
+
+      if (
+        url === `${firstSemanticBaseUrl}/api/v2/semantic/operations/session/open` &&
+        init?.method === "POST"
+      ) {
+        events.push("semantic-open-1");
+        return {
+          ok: true,
+          json: async () =>
+            createSuccessEnvelope(parseRequestEnvelope(init), {
+              sessionRef: "session:cloud-1",
+              pageRef: "page:cloud-1",
+              url: EXAMPLE_URL,
+              title: "Cloud Workspace",
+            }),
+        };
+      }
+
+      throw new Error(`Unexpected fetch ${init?.method ?? "GET"} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const proxy = new CloudSessionProxy(createCloudClient());
+
+    const opened = await proxy.open({
+      url: EXAMPLE_URL,
+    });
+
+    expect(opened).toMatchObject({
+      title: "Cloud Workspace",
+    });
+
+    vi.setSystemTime(new Date("2026-01-01T00:00:55.000Z"));
+
+    await expect(proxy.listPages()).rejects.toMatchObject({
+      statusCode: 409,
+      code: "CLOUD_SESSION_STALE",
+    });
+    expect(events).toEqual(["create-session-1", "semantic-open-1", "stale-access"]);
+    expect(createSessionCalls).toBe(1);
+    expect(staleAccessCalls).toBe(1);
+
+    await expect(proxy.close()).resolves.toMatchObject({
+      closed: true,
+    });
+  });
+
+  test("CloudSessionProxy recovers bootstrap route registration when the automation session is stale", async () => {
+    const events: string[] = [];
+    let createSessionCalls = 0;
+
+    const routeSpy = vi
+      .spyOn(OpensteerCloudAutomationClient.prototype, "route")
+      .mockImplementation(async function (input) {
+        const sessionId = (this as { sessionId: string }).sessionId;
+        events.push(`route:${sessionId}`);
+        if (sessionId === "session_123") {
+          throw createStaleSessionError(sessionId);
+        }
+        return {
+          routeId: `route:${sessionId}`,
+          sessionRef: `session:${sessionId}`,
+          urlPattern: input.urlPattern,
+        };
+      });
+
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "https://api.opensteer.dev/v1/sessions" && init?.method === "POST") {
+        createSessionCalls += 1;
+        events.push(`create-session-${createSessionCalls}`);
+        return {
+          ok: true,
+          json: async () => ({
+            sessionId: createSessionCalls === 1 ? "session_123" : "session_456",
+            status: "active",
+            initialGrants: {},
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected fetch ${init?.method ?? "GET"} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const proxy = new CloudSessionProxy(
+      new OpensteerCloudClient({
+        apiKey: "osk_test",
+        baseUrl: "https://api.opensteer.dev",
+      }),
+    );
+
+    const registration = await proxy.route({
+      urlPattern: "**/*",
+      handler: async () => ({ kind: "continue" }),
+    });
+
+    expect(registration).toMatchObject({
+      routeId: "route:session_456",
+      sessionRef: "session:session_456",
+      urlPattern: "**/*",
+    });
+    expect(events).toEqual([
+      "create-session-1",
+      "route:session_123",
+      "create-session-2",
+      "route:session_456",
+    ]);
+    expect(createSessionCalls).toBe(2);
+    expect(routeSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("CloudSessionProxy recovers bootstrap script interception when the automation session is stale", async () => {
+    const events: string[] = [];
+    let createSessionCalls = 0;
+
+    const interceptSpy = vi
+      .spyOn(OpensteerCloudAutomationClient.prototype, "interceptScript")
+      .mockImplementation(async function (input) {
+        const sessionId = (this as { sessionId: string }).sessionId;
+        events.push(`intercept:${sessionId}`);
+        if (sessionId === "session_123") {
+          throw createStaleSessionError(sessionId);
+        }
+        return {
+          routeId: `route:${sessionId}`,
+          sessionRef: `session:${sessionId}`,
+          urlPattern: input.urlPattern,
+        };
+      });
+
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "https://api.opensteer.dev/v1/sessions" && init?.method === "POST") {
+        createSessionCalls += 1;
+        events.push(`create-session-${createSessionCalls}`);
+        return {
+          ok: true,
+          json: async () => ({
+            sessionId: createSessionCalls === 1 ? "session_123" : "session_456",
+            status: "active",
+            initialGrants: {},
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected fetch ${init?.method ?? "GET"} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const proxy = new CloudSessionProxy(
+      new OpensteerCloudClient({
+        apiKey: "osk_test",
+        baseUrl: "https://api.opensteer.dev",
+      }),
+    );
+
+    const registration = await proxy.interceptScript({
+      urlPattern: "**/*.js",
+      handler: async ({ content }) => content,
+    });
+
+    expect(registration).toMatchObject({
+      routeId: "route:session_456",
+      sessionRef: "session:session_456",
+      urlPattern: "**/*.js",
+    });
+    expect(events).toEqual([
+      "create-session-1",
+      "intercept:session_123",
+      "create-session-2",
+      "intercept:session_456",
+    ]);
+    expect(createSessionCalls).toBe(2);
+    expect(interceptSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("CloudSessionProxy reapplies stored route registrations before retrying session.open on a fresh session", async () => {
     const firstSemanticBaseUrl = "https://cloud.example/runtime/session_123";
     const secondSemanticBaseUrl = "https://cloud.example/runtime/session_456";
     const firstSemanticGrant = {
@@ -873,19 +1044,30 @@ describe("cloud browser-profile integration", () => {
       transport: "http" as const,
       url: firstSemanticBaseUrl,
       token: "semantic-token-1",
-      expiresAt: Date.now() + 60_000,
+      expiresAt: Date.now() + 1_000,
     };
     const secondSemanticGrant = {
       kind: "semantic" as const,
       transport: "http" as const,
       url: secondSemanticBaseUrl,
       token: "semantic-token-2",
-      expiresAt: Date.now() + 120_000,
+      expiresAt: Date.now() + 60_000,
     };
     let createSessionCalls = 0;
     let staleAccessCalls = 0;
-    let closeSessionCalls = 0;
     const events: string[] = [];
+
+    const routeSpy = vi
+      .spyOn(OpensteerCloudAutomationClient.prototype, "route")
+      .mockImplementation(async function (input) {
+        const sessionId = (this as { sessionId: string }).sessionId;
+        events.push(`route:${sessionId}`);
+        return {
+          routeId: `route:${sessionId}`,
+          sessionRef: `session:${sessionId}`,
+          urlPattern: input.urlPattern,
+        };
+      });
 
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
       if (url === "https://api.opensteer.dev/v1/sessions" && init?.method === "POST") {
@@ -935,54 +1117,19 @@ describe("cloud browser-profile integration", () => {
       }
 
       if (
-        url === "https://api.opensteer.dev/v1/sessions/session_456" &&
-        init?.method === "DELETE"
-      ) {
-        closeSessionCalls += 1;
-        return {
-          ok: true,
-          json: async () => ({
-            status: "closed",
-          }),
-        };
-      }
-
-      if (
-        url === `${firstSemanticBaseUrl}/api/v2/semantic/operations/session/open` &&
+        url === `${secondSemanticBaseUrl}/api/v2/semantic/operations/session/open` &&
         init?.method === "POST"
       ) {
         const request = JSON.parse(String(init.body)) as OpensteerRequestEnvelope<unknown>;
-        events.push("semantic-open-1");
+        events.push("semantic-open-2");
         return {
           ok: true,
           json: async () =>
             createSuccessEnvelope(request, {
-              sessionRef: "session:cloud-1",
-              pageRef: "page:cloud-1",
+              sessionRef: "session:cloud-2",
+              pageRef: "page:cloud-2",
               url: "https://example.com",
-              title: "Cloud Workspace",
-            }),
-        };
-      }
-
-      if (
-        url === `${secondSemanticBaseUrl}/api/v2/semantic/operations/page/list` &&
-        init?.method === "POST"
-      ) {
-        const request = JSON.parse(String(init.body)) as OpensteerRequestEnvelope<unknown>;
-        events.push("page-list-2");
-        return {
-          ok: true,
-          json: async () =>
-            createSuccessEnvelope(request, {
-              activePageRef: "page:cloud-2",
-              pages: [
-                {
-                  pageRef: "page:cloud-2",
-                  url: "https://example.com",
-                  title: "Recovered Cloud Workspace",
-                },
-              ],
+              title: "Recovered Cloud Workspace",
             }),
         };
       }
@@ -998,41 +1145,29 @@ describe("cloud browser-profile integration", () => {
       }),
     );
 
+    await proxy.route({
+      urlPattern: "**/*",
+      handler: async () => ({ kind: "continue" }),
+    });
+
     const opened = await proxy.open({
       url: "https://example.com",
     });
 
     expect(opened).toMatchObject({
-      title: "Cloud Workspace",
-    });
-
-    vi.setSystemTime(new Date("2026-01-01T00:00:55.000Z"));
-
-    const pages = await proxy.listPages();
-
-    expect(pages).toMatchObject({
-      activePageRef: "page:cloud-2",
-      pages: [
-        {
-          pageRef: "page:cloud-2",
-          url: "https://example.com",
-          title: "Recovered Cloud Workspace",
-        },
-      ],
+      title: "Recovered Cloud Workspace",
     });
     expect(events).toEqual([
       "create-session-1",
-      "semantic-open-1",
+      "route:session_123",
       "stale-access",
       "create-session-2",
-      "page-list-2",
+      "route:session_456",
+      "semantic-open-2",
     ]);
     expect(createSessionCalls).toBe(2);
     expect(staleAccessCalls).toBe(1);
-
-    await proxy.close();
-
-    expect(closeSessionCalls).toBe(1);
+    expect(routeSpy).toHaveBeenCalledTimes(2);
   });
 
   test("CloudSessionProxy fails creating a new session when workspace sync fails", async () => {

--- a/tests/opensteer/dom-runtime.test.ts
+++ b/tests/opensteer/dom-runtime.test.ts
@@ -917,10 +917,12 @@ describe("Phase 5 DOM runtime integration", () => {
           }),
         ).rejects.toMatchObject({
           code: "operation-failed",
+          message: expect.stringContaining("obscured by"),
           details: {
             policy: "actionability",
             reason: "obscured",
             hitRelation: "outside",
+            blockingDescription: expect.stringContaining("<button>"),
           },
         });
       } finally {

--- a/tests/opensteer/policy.test.ts
+++ b/tests/opensteer/policy.test.ts
@@ -103,7 +103,7 @@ describe("Phase 7 policy settle", () => {
         settle: async () => true,
       }),
     ).toThrow(TypeError);
-    expect(defaultPolicy().settle.observers).toHaveLength(3);
+    expect(defaultPolicy().settle.observers).toHaveLength(2);
   });
 
   test("skips fixed delays when configured as zero", async () => {
@@ -370,7 +370,7 @@ describe("Phase 7 visual stability settle observers", () => {
     await promise;
   });
 
-  test("snapshot observer is unaffected by new observers", async () => {
+  test("snapshot trigger settles immediately without visual stability wait", async () => {
     const engine = createMockEngine();
     const policy = defaultPolicy().settle;
     const context = {
@@ -384,11 +384,7 @@ describe("Phase 7 visual stability settle observers", () => {
 
     await settleWithPolicy(policy, context);
 
-    expect(engine.waitForVisualStability).toHaveBeenCalledWith({
-      pageRef: context.pageRef,
-      settleMs: 750,
-      scope: "visible-frames",
-    });
+    expect(engine.waitForVisualStability).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/opensteer/shadow-dom-counter-sync.test.ts
+++ b/tests/opensteer/shadow-dom-counter-sync.test.ts
@@ -1,0 +1,288 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { once } from "node:events";
+
+import { createPlaywrightBrowserCoreEngine } from "../../packages/engine-playwright/src/index.js";
+import { compileOpensteerSnapshot } from "../../packages/runtime-core/src/sdk/snapshot/compiler.js";
+
+let baseUrl = "";
+let closeServer: (() => Promise<void>) | undefined;
+
+function html(body: string, title: string): string {
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>${title}</title></head><body>${body}</body></html>`;
+}
+
+/**
+ * Control: shadow DOM content present from initial page load, no dynamic changes.
+ */
+function staticShadow(): string {
+  return html(
+    `
+      <div id="host"></div>
+      <script>
+        const host = document.getElementById("host");
+        const shadow = host.attachShadow({ mode: "open" });
+        shadow.innerHTML =
+          '<div id="messaging"><button class="msg-btn" type="button">Messaging</button></div>' +
+          '<div id="dialog">' +
+          '<button class="dialog-btn" type="button">Add a note</button>' +
+          '<button class="dialog-btn" type="button">Send without a note</button>' +
+          '</div>';
+      </script>
+    `,
+    "counter-sync: static shadow",
+  );
+}
+
+/**
+ * Simulates LinkedIn's connect dialog: shadow DOM host starts with only
+ * a messaging overlay. Clicking a trigger dynamically injects dialog
+ * buttons into the shadow root.
+ */
+function dynamicShadowDialog(): string {
+  return html(
+    `
+      <button id="trigger" type="button" style="margin:10px;padding:8px 16px">Open Dialog</button>
+      <div id="host"></div>
+      <script>
+        const host = document.getElementById("host");
+        const shadow = host.attachShadow({ mode: "open" });
+        shadow.innerHTML =
+          '<div id="messaging"><button class="msg-btn" type="button">Messaging</button></div>';
+
+        document.getElementById("trigger").addEventListener("click", () => {
+          const dialog = document.createElement("div");
+          dialog.id = "dialog";
+          dialog.innerHTML =
+            '<button class="dialog-btn" type="button">Add a note</button>' +
+            '<button class="dialog-btn" type="button">Send without a note</button>';
+          shadow.insertBefore(dialog, shadow.firstChild);
+        });
+      </script>
+    `,
+    "counter-sync: dynamic shadow dialog",
+  );
+}
+
+/**
+ * Simulates Ember-like framework re-rendering: shadow DOM content is
+ * periodically replaced via innerHTML, stripping any data-os-* attributes.
+ */
+function frameworkRerender(): string {
+  return html(
+    `
+      <div id="host"></div>
+      <script>
+        const host = document.getElementById("host");
+        const shadow = host.attachShadow({ mode: "open" });
+        const render = () => {
+          shadow.innerHTML =
+            '<div class="dialog">' +
+            '<button class="action" type="button">Add a note</button>' +
+            '<button class="action" type="button">Send without a note</button>' +
+            '</div>';
+        };
+        render();
+        setInterval(render, 200);
+      </script>
+    `,
+    "counter-sync: framework rerender",
+  );
+}
+
+async function handleRequest(_request: IncomingMessage, response: ServerResponse): Promise<void> {
+  const url = new URL(_request.url ?? "/", "http://127.0.0.1");
+  const pages: Record<string, () => string> = {
+    "/counter-sync/static-shadow": staticShadow,
+    "/counter-sync/dynamic-shadow-dialog": dynamicShadowDialog,
+    "/counter-sync/framework-rerender": frameworkRerender,
+  };
+
+  const factory = pages[url.pathname];
+  if (factory) {
+    response.setHeader("content-type", "text/html; charset=utf-8");
+    response.end(factory());
+    return;
+  }
+
+  response.statusCode = 404;
+  response.end("not found");
+}
+
+async function startServer(): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = createServer((request, response) => {
+    void handleRequest(request, response);
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("failed to start test server");
+  }
+  return {
+    url: `http://127.0.0.1:${String(address.port)}`,
+    close: async () => {
+      server.close();
+      await once(server, "close");
+    },
+  };
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Filter counter records for shadow DOM buttons by their text content.
+ * Counter records are the authoritative source — they come directly from
+ * the snapshot and include nodeRef, shadowDepth, and text.
+ */
+function findButtonCounters(
+  counters: readonly { element: number; text?: string; tagName: string; shadowDepth: number; nodeRef?: string }[],
+  texts: readonly string[],
+) {
+  return counters.filter(
+    (c) => c.tagName === "BUTTON" && c.shadowDepth > 0 && texts.some((t) => c.text?.includes(t)),
+  );
+}
+
+beforeAll(async () => {
+  const started = await startServer();
+  baseUrl = started.url;
+  closeServer = started.close;
+}, 30_000);
+
+afterAll(async () => {
+  if (closeServer) {
+    await closeServer();
+  }
+});
+
+describe.sequential("Shadow DOM counter sync", () => {
+  test(
+    "assigns counters to static shadow DOM elements in snapshot HTML",
+    { timeout: 60_000 },
+    async () => {
+      const engine = await createPlaywrightBrowserCoreEngine({
+        launch: { headless: true },
+      });
+
+      try {
+        const sessionRef = await engine.createSession();
+        const created = await engine.createPage({
+          sessionRef,
+          url: `${baseUrl}/counter-sync/static-shadow`,
+        });
+        await wait(300);
+
+        const snapshot = await compileOpensteerSnapshot({
+          engine,
+          pageRef: created.data.pageRef,
+          mode: "action",
+        });
+
+        // Snapshot HTML should contain shadow DOM button text
+        expect(snapshot.html).toContain("Add a note");
+        expect(snapshot.html).toContain("Send without a note");
+
+        // Counter records should include nodeRefs for shadow DOM buttons
+        const dialogButtons = findButtonCounters(snapshot.counters, ["Add a note", "Send without a note"]);
+        expect(dialogButtons.length).toBe(2);
+        for (const record of dialogButtons) {
+          expect(record.nodeRef).toBeDefined();
+          expect(record.shadowDepth).toBeGreaterThan(0);
+        }
+      } finally {
+        await engine.dispose();
+      }
+    },
+  );
+
+  test(
+    "assigns counters to dynamically injected shadow DOM elements",
+    { timeout: 60_000 },
+    async () => {
+      const engine = await createPlaywrightBrowserCoreEngine({
+        launch: { headless: true },
+      });
+
+      try {
+        const sessionRef = await engine.createSession();
+        const created = await engine.createPage({
+          sessionRef,
+          url: `${baseUrl}/counter-sync/dynamic-shadow-dialog`,
+        });
+        await wait(300);
+
+        // Click the trigger to inject dialog into shadow DOM
+        const frames = await engine.listFrames({ pageRef: created.data.pageRef });
+        const mainFrame = (frames as { frameRef: string; parentFrameRef?: string }[]).find(
+          (f) => f.parentFrameRef === undefined,
+        )!;
+        await engine.evaluateFrame({
+          frameRef: mainFrame.frameRef,
+          script: `(() => { document.getElementById("trigger").click(); })`,
+          args: [],
+        });
+        await wait(200);
+
+        // Snapshot should capture the dynamically injected dialog buttons
+        const snapshot = await compileOpensteerSnapshot({
+          engine,
+          pageRef: created.data.pageRef,
+          mode: "action",
+        });
+
+        // Snapshot HTML should contain dynamic dialog button text
+        expect(snapshot.html).toContain("Add a note");
+        expect(snapshot.html).toContain("Send without a note");
+
+        // Counter records should have nodeRefs for dynamically injected buttons
+        const dialogButtons = findButtonCounters(snapshot.counters, ["Add a note", "Send without a note"]);
+        expect(dialogButtons.length).toBe(2);
+        for (const record of dialogButtons) {
+          expect(record.nodeRef).toBeDefined();
+        }
+      } finally {
+        await engine.dispose();
+      }
+    },
+  );
+
+  test(
+    "assigns counters under framework re-rendering",
+    { timeout: 60_000 },
+    async () => {
+      const engine = await createPlaywrightBrowserCoreEngine({
+        launch: { headless: true },
+      });
+
+      try {
+        const sessionRef = await engine.createSession();
+        const created = await engine.createPage({
+          sessionRef,
+          url: `${baseUrl}/counter-sync/framework-rerender`,
+        });
+        await wait(500);
+
+        // Snapshot should capture buttons even under constant re-renders.
+        // Since counter resolution uses the snapshot (not live DOM c= attrs),
+        // re-rendering doesn't affect counter usability.
+        const snapshot = await compileOpensteerSnapshot({
+          engine,
+          pageRef: created.data.pageRef,
+          mode: "action",
+        });
+
+        expect(snapshot.html).toContain("Add a note");
+        expect(snapshot.html).toContain("Send without a note");
+
+        // Counter records should exist for buttons even under re-rendering
+        const dialogButtons = findButtonCounters(snapshot.counters, ["Add a note", "Send without a note"]);
+        expect(dialogButtons.length).toBe(2);
+      } finally {
+        await engine.dispose();
+      }
+    },
+  );
+});

--- a/tests/opensteer/shadow-dom-counter-sync.test.ts
+++ b/tests/opensteer/shadow-dom-counter-sync.test.ts
@@ -5,16 +5,21 @@ import { once } from "node:events";
 import { createPlaywrightBrowserCoreEngine } from "../../packages/engine-playwright/src/index.js";
 import { compileOpensteerSnapshot } from "../../packages/runtime-core/src/sdk/snapshot/compiler.js";
 
+type SnapshotResult = Awaited<ReturnType<typeof compileOpensteerSnapshot>>;
+type PlaywrightEngine = Awaited<ReturnType<typeof createPlaywrightBrowserCoreEngine>>;
+type SnapshotSetup = {
+  readonly engine: PlaywrightEngine;
+  readonly pageRef: string;
+};
+
 let baseUrl = "";
 let closeServer: (() => Promise<void>) | undefined;
+const SHADOW_BUTTON_TEXTS = ["Add a note", "Send without a note"] as const;
 
 function html(body: string, title: string): string {
   return `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>${title}</title></head><body>${body}</body></html>`;
 }
 
-/**
- * Control: shadow DOM content present from initial page load, no dynamic changes.
- */
 function staticShadow(): string {
   return html(
     `
@@ -34,11 +39,6 @@ function staticShadow(): string {
   );
 }
 
-/**
- * Simulates LinkedIn's connect dialog: shadow DOM host starts with only
- * a messaging overlay. Clicking a trigger dynamically injects dialog
- * buttons into the shadow root.
- */
 function dynamicShadowDialog(): string {
   return html(
     `
@@ -64,10 +64,6 @@ function dynamicShadowDialog(): string {
   );
 }
 
-/**
- * Simulates Ember-like framework re-rendering: shadow DOM content is
- * periodically replaced via innerHTML, stripping any data-os-* attributes.
- */
 function frameworkRerender(): string {
   return html(
     `
@@ -132,18 +128,86 @@ function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/**
- * Filter counter records for shadow DOM buttons by their text content.
- * Counter records are the authoritative source — they come directly from
- * the snapshot and include nodeRef, shadowDepth, and text.
- */
-function findButtonCounters(
-  counters: readonly { element: number; text?: string; tagName: string; shadowDepth: number; nodeRef?: string }[],
-  texts: readonly string[],
-) {
+function findButtonCounters(counters: SnapshotResult["counters"], texts: readonly string[]) {
   return counters.filter(
     (c) => c.tagName === "BUTTON" && c.shadowDepth > 0 && texts.some((t) => c.text?.includes(t)),
   );
+}
+
+function expectShadowButtons(
+  snapshot: SnapshotResult,
+  options: {
+    readonly requireNodeRef?: boolean;
+    readonly requireShadowDepth?: boolean;
+  } = {},
+): void {
+  for (const text of SHADOW_BUTTON_TEXTS) {
+    expect(snapshot.html).toContain(text);
+  }
+
+  const buttons = findButtonCounters(snapshot.counters, SHADOW_BUTTON_TEXTS);
+  expect(buttons).toHaveLength(2);
+
+  for (const button of buttons) {
+    if (options.requireNodeRef) {
+      expect(button.nodeRef).toBeDefined();
+    }
+    if (options.requireShadowDepth) {
+      expect(button.shadowDepth).toBeGreaterThan(0);
+    }
+  }
+}
+
+async function clickTrigger({ engine, pageRef }: SnapshotSetup): Promise<void> {
+  const frames = await engine.listFrames({ pageRef });
+  const mainFrame = frames.find((frame) => frame.parentFrameRef === undefined);
+  if (mainFrame === undefined) {
+    throw new Error("main frame not found");
+  }
+
+  await engine.evaluateFrame({
+    frameRef: mainFrame.frameRef,
+    script: `(() => { document.getElementById("trigger").click(); })`,
+    args: [],
+  });
+}
+
+async function captureSnapshot(
+  pathname: string,
+  options: {
+    readonly settleMs?: number;
+    readonly prepare?: (setup: SnapshotSetup) => Promise<void>;
+    readonly prepareSettleMs?: number;
+  } = {},
+): Promise<SnapshotResult> {
+  const engine = await createPlaywrightBrowserCoreEngine({
+    launch: { headless: true },
+  });
+
+  try {
+    const sessionRef = await engine.createSession();
+    const created = await engine.createPage({
+      sessionRef,
+      url: `${baseUrl}${pathname}`,
+    });
+    await wait(options.settleMs ?? 300);
+
+    if (options.prepare) {
+      await options.prepare({ engine, pageRef: created.data.pageRef });
+      const prepareSettleMs = options.prepareSettleMs ?? 0;
+      if (prepareSettleMs > 0) {
+        await wait(prepareSettleMs);
+      }
+    }
+
+    return await compileOpensteerSnapshot({
+      engine,
+      pageRef: created.data.pageRef,
+      mode: "action",
+    });
+  } finally {
+    await engine.dispose();
+  }
 }
 
 beforeAll(async () => {
@@ -163,38 +227,13 @@ describe.sequential("Shadow DOM counter sync", () => {
     "assigns counters to static shadow DOM elements in snapshot HTML",
     { timeout: 60_000 },
     async () => {
-      const engine = await createPlaywrightBrowserCoreEngine({
-        launch: { headless: true },
+      const snapshot = await captureSnapshot("/counter-sync/static-shadow", {
+        settleMs: 300,
       });
-
-      try {
-        const sessionRef = await engine.createSession();
-        const created = await engine.createPage({
-          sessionRef,
-          url: `${baseUrl}/counter-sync/static-shadow`,
-        });
-        await wait(300);
-
-        const snapshot = await compileOpensteerSnapshot({
-          engine,
-          pageRef: created.data.pageRef,
-          mode: "action",
-        });
-
-        // Snapshot HTML should contain shadow DOM button text
-        expect(snapshot.html).toContain("Add a note");
-        expect(snapshot.html).toContain("Send without a note");
-
-        // Counter records should include nodeRefs for shadow DOM buttons
-        const dialogButtons = findButtonCounters(snapshot.counters, ["Add a note", "Send without a note"]);
-        expect(dialogButtons.length).toBe(2);
-        for (const record of dialogButtons) {
-          expect(record.nodeRef).toBeDefined();
-          expect(record.shadowDepth).toBeGreaterThan(0);
-        }
-      } finally {
-        await engine.dispose();
-      }
+      expectShadowButtons(snapshot, {
+        requireNodeRef: true,
+        requireShadowDepth: true,
+      });
     },
   );
 
@@ -202,87 +241,21 @@ describe.sequential("Shadow DOM counter sync", () => {
     "assigns counters to dynamically injected shadow DOM elements",
     { timeout: 60_000 },
     async () => {
-      const engine = await createPlaywrightBrowserCoreEngine({
-        launch: { headless: true },
+      const snapshot = await captureSnapshot("/counter-sync/dynamic-shadow-dialog", {
+        settleMs: 300,
+        prepare: clickTrigger,
+        prepareSettleMs: 200,
       });
-
-      try {
-        const sessionRef = await engine.createSession();
-        const created = await engine.createPage({
-          sessionRef,
-          url: `${baseUrl}/counter-sync/dynamic-shadow-dialog`,
-        });
-        await wait(300);
-
-        // Click the trigger to inject dialog into shadow DOM
-        const frames = await engine.listFrames({ pageRef: created.data.pageRef });
-        const mainFrame = (frames as { frameRef: string; parentFrameRef?: string }[]).find(
-          (f) => f.parentFrameRef === undefined,
-        )!;
-        await engine.evaluateFrame({
-          frameRef: mainFrame.frameRef,
-          script: `(() => { document.getElementById("trigger").click(); })`,
-          args: [],
-        });
-        await wait(200);
-
-        // Snapshot should capture the dynamically injected dialog buttons
-        const snapshot = await compileOpensteerSnapshot({
-          engine,
-          pageRef: created.data.pageRef,
-          mode: "action",
-        });
-
-        // Snapshot HTML should contain dynamic dialog button text
-        expect(snapshot.html).toContain("Add a note");
-        expect(snapshot.html).toContain("Send without a note");
-
-        // Counter records should have nodeRefs for dynamically injected buttons
-        const dialogButtons = findButtonCounters(snapshot.counters, ["Add a note", "Send without a note"]);
-        expect(dialogButtons.length).toBe(2);
-        for (const record of dialogButtons) {
-          expect(record.nodeRef).toBeDefined();
-        }
-      } finally {
-        await engine.dispose();
-      }
+      expectShadowButtons(snapshot, {
+        requireNodeRef: true,
+      });
     },
   );
 
-  test(
-    "assigns counters under framework re-rendering",
-    { timeout: 60_000 },
-    async () => {
-      const engine = await createPlaywrightBrowserCoreEngine({
-        launch: { headless: true },
-      });
-
-      try {
-        const sessionRef = await engine.createSession();
-        const created = await engine.createPage({
-          sessionRef,
-          url: `${baseUrl}/counter-sync/framework-rerender`,
-        });
-        await wait(500);
-
-        // Snapshot should capture buttons even under constant re-renders.
-        // Since counter resolution uses the snapshot (not live DOM c= attrs),
-        // re-rendering doesn't affect counter usability.
-        const snapshot = await compileOpensteerSnapshot({
-          engine,
-          pageRef: created.data.pageRef,
-          mode: "action",
-        });
-
-        expect(snapshot.html).toContain("Add a note");
-        expect(snapshot.html).toContain("Send without a note");
-
-        // Counter records should exist for buttons even under re-rendering
-        const dialogButtons = findButtonCounters(snapshot.counters, ["Add a note", "Send without a note"]);
-        expect(dialogButtons.length).toBe(2);
-      } finally {
-        await engine.dispose();
-      }
-    },
-  );
+  test("assigns counters under framework re-rendering", { timeout: 60_000 }, async () => {
+    const snapshot = await captureSnapshot("/counter-sync/framework-rerender", {
+      settleMs: 500,
+    });
+    expectShadowButtons(snapshot);
+  });
 });

--- a/tests/opensteer/shadow-dom-persist.test.ts
+++ b/tests/opensteer/shadow-dom-persist.test.ts
@@ -1,0 +1,384 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { once } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createPlaywrightBrowserCoreEngine } from "../../packages/engine-playwright/src/index.js";
+import {
+  createDomRuntime,
+  createFilesystemOpensteerWorkspace,
+} from "../../packages/opensteer/src/index.js";
+
+let baseUrl = "";
+let closeServer: (() => Promise<void>) | undefined;
+const temporaryRoots: string[] = [];
+
+function html(body: string, title: string): string {
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>${title}</title></head><body>${body}</body></html>`;
+}
+
+/**
+ * Two buttons as direct siblings in a shadow root.
+ * Same class, no aria-label. id is present for selection but deferred
+ * by the replay path builder (won't be used for persist uniqueness).
+ * Position clauses should distinguish them.
+ */
+function genericSiblings(): string {
+  return html(
+    `
+      <div id="host"></div>
+      <script>
+        const host = document.getElementById("host");
+        const shadow = host.attachShadow({ mode: "open" });
+        shadow.innerHTML =
+          '<button id="btn-add" class="action" type="button" style="width:180px;height:42px">Add a note</button>' +
+          '<button id="btn-send" class="action" type="button" style="width:180px;height:42px">Send without a note</button>';
+      </script>
+    `,
+    "shadow-persist: generic siblings",
+  );
+}
+
+/**
+ * Each button is the sole child of an identical wrapper div.
+ * Both buttons are nth-of-type(1) in their own parent. Parent position
+ * must distinguish them.
+ */
+function parallelSubtrees(): string {
+  return html(
+    `
+      <div id="host"></div>
+      <script>
+        const host = document.getElementById("host");
+        const shadow = host.attachShadow({ mode: "open" });
+        shadow.innerHTML =
+          '<div class="option"><button id="btn-add" class="action" type="button" style="width:180px;height:42px">Add a note</button></div>' +
+          '<div class="option"><button id="btn-send" class="action" type="button" style="width:180px;height:42px">Send without a note</button></div>';
+      </script>
+    `,
+    "shadow-persist: parallel subtrees",
+  );
+}
+
+/**
+ * Two bare divs (no class, no id beyond container) each hosting
+ * identical shadow trees. The HOST finalizePath must distinguish the
+ * host divs in the light DOM.
+ */
+function identicalHosts(): string {
+  return html(
+    `
+      <div id="container">
+        <div></div>
+        <div></div>
+      </div>
+      <script>
+        const divs = document.getElementById("container").children;
+        let hostIndex = 0;
+        for (const div of divs) {
+          const shadow = div.attachShadow({ mode: "open" });
+          const suffix = hostIndex++;
+          shadow.innerHTML =
+            '<button id="btn-add-' + suffix + '" class="action" type="button" style="width:180px;height:42px">Add a note</button>' +
+            '<button id="btn-send-' + suffix + '" class="action" type="button" style="width:180px;height:42px">Send without a note</button>';
+        }
+      </script>
+    `,
+    "shadow-persist: identical hosts",
+  );
+}
+
+/**
+ * Deeply nested identical branches where every intermediate element is
+ * a sole child, so all positions are 1. Only the top-level branch
+ * elements are siblings.
+ */
+function deepIdenticalBranches(): string {
+  return html(
+    `
+      <div id="root"></div>
+      <script>
+        const root = document.getElementById("root");
+        for (let i = 0; i < 2; i++) {
+          const branch = document.createElement("div");
+          branch.className = "branch";
+          const inner = document.createElement("div");
+          inner.className = "inner";
+          const host = document.createElement("div");
+          host.className = "host";
+          const shadow = host.attachShadow({ mode: "open" });
+          shadow.innerHTML =
+            '<div class="panel"><button id="btn-add-' + i + '" class="action" type="button" style="width:180px;height:42px">Add a note</button></div>' +
+            '<div class="panel"><button id="btn-send-' + i + '" class="action" type="button" style="width:180px;height:42px">Send without a note</button></div>';
+          inner.appendChild(host);
+          branch.appendChild(inner);
+          root.appendChild(branch);
+        }
+      </script>
+    `,
+    "shadow-persist: deep identical branches",
+  );
+}
+
+/**
+ * Control: same as generic siblings but buttons have aria-label.
+ * Persist should always succeed since aria-label is a stable primary
+ * attribute in the replay path builder.
+ */
+function withAriaLabel(): string {
+  return html(
+    `
+      <div id="host"></div>
+      <script>
+        const host = document.getElementById("host");
+        const shadow = host.attachShadow({ mode: "open" });
+        shadow.innerHTML =
+          '<button id="btn-add" class="action" type="button" aria-label="Add a note" style="width:180px;height:42px">Add a note</button>' +
+          '<button id="btn-send" class="action" type="button" aria-label="Send without a note" style="width:180px;height:42px">Send without a note</button>';
+      </script>
+    `,
+    "shadow-persist: with aria-label",
+  );
+}
+
+async function handleRequest(_request: IncomingMessage, response: ServerResponse): Promise<void> {
+  const url = new URL(_request.url ?? "/", "http://127.0.0.1");
+  const pages: Record<string, () => string> = {
+    "/shadow-persist/generic-siblings": genericSiblings,
+    "/shadow-persist/parallel-subtrees": parallelSubtrees,
+    "/shadow-persist/identical-hosts": identicalHosts,
+    "/shadow-persist/deep-identical-branches": deepIdenticalBranches,
+    "/shadow-persist/with-aria-label": withAriaLabel,
+  };
+
+  const factory = pages[url.pathname];
+  if (factory) {
+    response.setHeader("content-type", "text/html; charset=utf-8");
+    response.end(factory());
+    return;
+  }
+
+  response.statusCode = 404;
+  response.end("not found");
+}
+
+async function startServer(): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = createServer((request, response) => {
+    void handleRequest(request, response);
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("failed to start test server");
+  }
+  return {
+    url: `http://127.0.0.1:${String(address.port)}`,
+    close: async () => {
+      server.close();
+      await once(server, "close");
+    },
+  };
+}
+
+async function createTemporaryRoot(): Promise<string> {
+  const rootPath = await mkdtemp(path.join(tmpdir(), "opensteer-shadow-persist-"));
+  temporaryRoots.push(rootPath);
+  return rootPath;
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+beforeAll(async () => {
+  const started = await startServer();
+  baseUrl = started.url;
+  closeServer = started.close;
+}, 30_000);
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((rootPath) => rm(rootPath, { recursive: true, force: true })),
+  );
+});
+
+afterAll(async () => {
+  if (closeServer) {
+    await closeServer();
+  }
+});
+
+/**
+ * These tests probe the boundary of the replay path builder for shadow DOM
+ * elements. Each fixture targets #btn-send inside a shadow root. The id
+ * attribute is deferred by the builder's shouldDeferMatchAttribute policy,
+ * so the builder must find uniqueness through class + position + ancestors.
+ *
+ * All fixtures are expected to succeed with the current algorithm (position
+ * clauses are robust enough). If a fixture that matches a real-world failure
+ * pattern is identified, it should be added here.
+ */
+describe.sequential("Shadow DOM persist boundary tests", () => {
+  test(
+    "persists click on shadow DOM button with aria-label (control)",
+    { timeout: 60_000 },
+    async () => {
+      const rootPath = await createTemporaryRoot();
+      const root = await createFilesystemOpensteerWorkspace({ rootPath });
+      const engine = await createPlaywrightBrowserCoreEngine({
+        launch: { headless: true },
+      });
+
+      try {
+        const runtime = createDomRuntime({ engine, root, namespace: "shadow-persist" });
+        const sessionRef = await engine.createSession();
+        const created = await engine.createPage({
+          sessionRef,
+          url: `${baseUrl}/shadow-persist/with-aria-label`,
+        });
+        await wait(400);
+
+        await runtime.resolveTarget({
+          pageRef: created.data.pageRef,
+          method: "click",
+          target: { kind: "selector", selector: "#btn-send", persist: "aria-label-button" },
+        });
+        const stored = await runtime.readDescriptor({ method: "click", persist: "aria-label-button" });
+        expect(stored).toBeDefined();
+      } finally {
+        await engine.dispose();
+      }
+    },
+  );
+
+  test(
+    "persists click on generic sibling shadow DOM buttons",
+    { timeout: 60_000 },
+    async () => {
+      const rootPath = await createTemporaryRoot();
+      const root = await createFilesystemOpensteerWorkspace({ rootPath });
+      const engine = await createPlaywrightBrowserCoreEngine({
+        launch: { headless: true },
+      });
+
+      try {
+        const runtime = createDomRuntime({ engine, root, namespace: "shadow-persist" });
+        const sessionRef = await engine.createSession();
+        const created = await engine.createPage({
+          sessionRef,
+          url: `${baseUrl}/shadow-persist/generic-siblings`,
+        });
+        await wait(400);
+
+        await runtime.resolveTarget({
+          pageRef: created.data.pageRef,
+          method: "click",
+          target: { kind: "selector", selector: "#btn-send", persist: "generic-sibling-button" },
+        });
+        const stored = await runtime.readDescriptor({ method: "click", persist: "generic-sibling-button" });
+        expect(stored).toBeDefined();
+      } finally {
+        await engine.dispose();
+      }
+    },
+  );
+
+  test(
+    "persists click on shadow DOM button in parallel subtrees",
+    { timeout: 60_000 },
+    async () => {
+      const rootPath = await createTemporaryRoot();
+      const root = await createFilesystemOpensteerWorkspace({ rootPath });
+      const engine = await createPlaywrightBrowserCoreEngine({
+        launch: { headless: true },
+      });
+
+      try {
+        const runtime = createDomRuntime({ engine, root, namespace: "shadow-persist" });
+        const sessionRef = await engine.createSession();
+        const created = await engine.createPage({
+          sessionRef,
+          url: `${baseUrl}/shadow-persist/parallel-subtrees`,
+        });
+        await wait(400);
+
+        await runtime.resolveTarget({
+          pageRef: created.data.pageRef,
+          method: "click",
+          target: { kind: "selector", selector: "#btn-send", persist: "parallel-subtree-button" },
+        });
+        const stored = await runtime.readDescriptor({ method: "click", persist: "parallel-subtree-button" });
+        expect(stored).toBeDefined();
+      } finally {
+        await engine.dispose();
+      }
+    },
+  );
+
+  test(
+    "persists click on shadow DOM button across identical hosts",
+    { timeout: 60_000 },
+    async () => {
+      const rootPath = await createTemporaryRoot();
+      const root = await createFilesystemOpensteerWorkspace({ rootPath });
+      const engine = await createPlaywrightBrowserCoreEngine({
+        launch: { headless: true },
+      });
+
+      try {
+        const runtime = createDomRuntime({ engine, root, namespace: "shadow-persist" });
+        const sessionRef = await engine.createSession();
+        const created = await engine.createPage({
+          sessionRef,
+          url: `${baseUrl}/shadow-persist/identical-hosts`,
+        });
+        await wait(400);
+
+        await runtime.resolveTarget({
+          pageRef: created.data.pageRef,
+          method: "click",
+          target: { kind: "selector", selector: "#btn-send-1", persist: "identical-host-button" },
+        });
+        const stored = await runtime.readDescriptor({ method: "click", persist: "identical-host-button" });
+        expect(stored).toBeDefined();
+      } finally {
+        await engine.dispose();
+      }
+    },
+  );
+
+  test(
+    "persists click on shadow DOM button in deep identical branches",
+    { timeout: 60_000 },
+    async () => {
+      const rootPath = await createTemporaryRoot();
+      const root = await createFilesystemOpensteerWorkspace({ rootPath });
+      const engine = await createPlaywrightBrowserCoreEngine({
+        launch: { headless: true },
+      });
+
+      try {
+        const runtime = createDomRuntime({ engine, root, namespace: "shadow-persist" });
+        const sessionRef = await engine.createSession();
+        const created = await engine.createPage({
+          sessionRef,
+          url: `${baseUrl}/shadow-persist/deep-identical-branches`,
+        });
+        await wait(400);
+
+        await runtime.resolveTarget({
+          pageRef: created.data.pageRef,
+          method: "click",
+          target: { kind: "selector", selector: "#btn-send-1", persist: "deep-branch-button" },
+        });
+        const stored = await runtime.readDescriptor({ method: "click", persist: "deep-branch-button" });
+        expect(stored).toBeDefined();
+      } finally {
+        await engine.dispose();
+      }
+    },
+  );
+});

--- a/tests/opensteer/shadow-dom-persist.test.ts
+++ b/tests/opensteer/shadow-dom-persist.test.ts
@@ -11,6 +11,13 @@ import {
   createFilesystemOpensteerWorkspace,
 } from "../../packages/opensteer/src/index.js";
 
+type PersistCase = {
+  readonly title: string;
+  readonly pathname: string;
+  readonly selector: string;
+  readonly persist: string;
+};
+
 let baseUrl = "";
 let closeServer: (() => Promise<void>) | undefined;
 const temporaryRoots: string[] = [];
@@ -19,12 +26,6 @@ function html(body: string, title: string): string {
   return `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>${title}</title></head><body>${body}</body></html>`;
 }
 
-/**
- * Two buttons as direct siblings in a shadow root.
- * Same class, no aria-label. id is present for selection but deferred
- * by the replay path builder (won't be used for persist uniqueness).
- * Position clauses should distinguish them.
- */
 function genericSiblings(): string {
   return html(
     `
@@ -41,11 +42,6 @@ function genericSiblings(): string {
   );
 }
 
-/**
- * Each button is the sole child of an identical wrapper div.
- * Both buttons are nth-of-type(1) in their own parent. Parent position
- * must distinguish them.
- */
 function parallelSubtrees(): string {
   return html(
     `
@@ -62,11 +58,6 @@ function parallelSubtrees(): string {
   );
 }
 
-/**
- * Two bare divs (no class, no id beyond container) each hosting
- * identical shadow trees. The HOST finalizePath must distinguish the
- * host divs in the light DOM.
- */
 function identicalHosts(): string {
   return html(
     `
@@ -90,11 +81,6 @@ function identicalHosts(): string {
   );
 }
 
-/**
- * Deeply nested identical branches where every intermediate element is
- * a sole child, so all positions are 1. Only the top-level branch
- * elements are siblings.
- */
 function deepIdenticalBranches(): string {
   return html(
     `
@@ -122,11 +108,6 @@ function deepIdenticalBranches(): string {
   );
 }
 
-/**
- * Control: same as generic siblings but buttons have aria-label.
- * Persist should always succeed since aria-label is a stable primary
- * attribute in the replay path builder.
- */
 function withAriaLabel(): string {
   return html(
     `
@@ -193,6 +174,75 @@ function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+const persistCases = [
+  {
+    title: "persists click on shadow DOM button with aria-label (control)",
+    pathname: "/shadow-persist/with-aria-label",
+    selector: "#btn-send",
+    persist: "aria-label-button",
+  },
+  {
+    title: "persists click on generic sibling shadow DOM buttons",
+    pathname: "/shadow-persist/generic-siblings",
+    selector: "#btn-send",
+    persist: "generic-sibling-button",
+  },
+  {
+    title: "persists click on shadow DOM button in parallel subtrees",
+    pathname: "/shadow-persist/parallel-subtrees",
+    selector: "#btn-send",
+    persist: "parallel-subtree-button",
+  },
+  {
+    title: "persists click on shadow DOM button across identical hosts",
+    pathname: "/shadow-persist/identical-hosts",
+    selector: "#btn-send-1",
+    persist: "identical-host-button",
+  },
+  {
+    title: "persists click on shadow DOM button in deep identical branches",
+    pathname: "/shadow-persist/deep-identical-branches",
+    selector: "#btn-send-1",
+    persist: "deep-branch-button",
+  },
+] satisfies readonly PersistCase[];
+
+async function expectStoredDescriptor(testCase: PersistCase): Promise<void> {
+  const rootPath = await createTemporaryRoot();
+  const root = await createFilesystemOpensteerWorkspace({ rootPath });
+  const engine = await createPlaywrightBrowserCoreEngine({
+    launch: { headless: true },
+  });
+
+  try {
+    const runtime = createDomRuntime({ engine, root, namespace: "shadow-persist" });
+    const sessionRef = await engine.createSession();
+    const created = await engine.createPage({
+      sessionRef,
+      url: `${baseUrl}${testCase.pathname}`,
+    });
+    await wait(400);
+
+    await runtime.resolveTarget({
+      pageRef: created.data.pageRef,
+      method: "click",
+      target: {
+        kind: "selector",
+        selector: testCase.selector,
+        persist: testCase.persist,
+      },
+    });
+
+    const stored = await runtime.readDescriptor({
+      method: "click",
+      persist: testCase.persist,
+    });
+    expect(stored).toBeDefined();
+  } finally {
+    await engine.dispose();
+  }
+}
+
 beforeAll(async () => {
   const started = await startServer();
   baseUrl = started.url;
@@ -211,174 +261,10 @@ afterAll(async () => {
   }
 });
 
-/**
- * These tests probe the boundary of the replay path builder for shadow DOM
- * elements. Each fixture targets #btn-send inside a shadow root. The id
- * attribute is deferred by the builder's shouldDeferMatchAttribute policy,
- * so the builder must find uniqueness through class + position + ancestors.
- *
- * All fixtures are expected to succeed with the current algorithm (position
- * clauses are robust enough). If a fixture that matches a real-world failure
- * pattern is identified, it should be added here.
- */
 describe.sequential("Shadow DOM persist boundary tests", () => {
-  test(
-    "persists click on shadow DOM button with aria-label (control)",
-    { timeout: 60_000 },
-    async () => {
-      const rootPath = await createTemporaryRoot();
-      const root = await createFilesystemOpensteerWorkspace({ rootPath });
-      const engine = await createPlaywrightBrowserCoreEngine({
-        launch: { headless: true },
-      });
-
-      try {
-        const runtime = createDomRuntime({ engine, root, namespace: "shadow-persist" });
-        const sessionRef = await engine.createSession();
-        const created = await engine.createPage({
-          sessionRef,
-          url: `${baseUrl}/shadow-persist/with-aria-label`,
-        });
-        await wait(400);
-
-        await runtime.resolveTarget({
-          pageRef: created.data.pageRef,
-          method: "click",
-          target: { kind: "selector", selector: "#btn-send", persist: "aria-label-button" },
-        });
-        const stored = await runtime.readDescriptor({ method: "click", persist: "aria-label-button" });
-        expect(stored).toBeDefined();
-      } finally {
-        await engine.dispose();
-      }
-    },
-  );
-
-  test(
-    "persists click on generic sibling shadow DOM buttons",
-    { timeout: 60_000 },
-    async () => {
-      const rootPath = await createTemporaryRoot();
-      const root = await createFilesystemOpensteerWorkspace({ rootPath });
-      const engine = await createPlaywrightBrowserCoreEngine({
-        launch: { headless: true },
-      });
-
-      try {
-        const runtime = createDomRuntime({ engine, root, namespace: "shadow-persist" });
-        const sessionRef = await engine.createSession();
-        const created = await engine.createPage({
-          sessionRef,
-          url: `${baseUrl}/shadow-persist/generic-siblings`,
-        });
-        await wait(400);
-
-        await runtime.resolveTarget({
-          pageRef: created.data.pageRef,
-          method: "click",
-          target: { kind: "selector", selector: "#btn-send", persist: "generic-sibling-button" },
-        });
-        const stored = await runtime.readDescriptor({ method: "click", persist: "generic-sibling-button" });
-        expect(stored).toBeDefined();
-      } finally {
-        await engine.dispose();
-      }
-    },
-  );
-
-  test(
-    "persists click on shadow DOM button in parallel subtrees",
-    { timeout: 60_000 },
-    async () => {
-      const rootPath = await createTemporaryRoot();
-      const root = await createFilesystemOpensteerWorkspace({ rootPath });
-      const engine = await createPlaywrightBrowserCoreEngine({
-        launch: { headless: true },
-      });
-
-      try {
-        const runtime = createDomRuntime({ engine, root, namespace: "shadow-persist" });
-        const sessionRef = await engine.createSession();
-        const created = await engine.createPage({
-          sessionRef,
-          url: `${baseUrl}/shadow-persist/parallel-subtrees`,
-        });
-        await wait(400);
-
-        await runtime.resolveTarget({
-          pageRef: created.data.pageRef,
-          method: "click",
-          target: { kind: "selector", selector: "#btn-send", persist: "parallel-subtree-button" },
-        });
-        const stored = await runtime.readDescriptor({ method: "click", persist: "parallel-subtree-button" });
-        expect(stored).toBeDefined();
-      } finally {
-        await engine.dispose();
-      }
-    },
-  );
-
-  test(
-    "persists click on shadow DOM button across identical hosts",
-    { timeout: 60_000 },
-    async () => {
-      const rootPath = await createTemporaryRoot();
-      const root = await createFilesystemOpensteerWorkspace({ rootPath });
-      const engine = await createPlaywrightBrowserCoreEngine({
-        launch: { headless: true },
-      });
-
-      try {
-        const runtime = createDomRuntime({ engine, root, namespace: "shadow-persist" });
-        const sessionRef = await engine.createSession();
-        const created = await engine.createPage({
-          sessionRef,
-          url: `${baseUrl}/shadow-persist/identical-hosts`,
-        });
-        await wait(400);
-
-        await runtime.resolveTarget({
-          pageRef: created.data.pageRef,
-          method: "click",
-          target: { kind: "selector", selector: "#btn-send-1", persist: "identical-host-button" },
-        });
-        const stored = await runtime.readDescriptor({ method: "click", persist: "identical-host-button" });
-        expect(stored).toBeDefined();
-      } finally {
-        await engine.dispose();
-      }
-    },
-  );
-
-  test(
-    "persists click on shadow DOM button in deep identical branches",
-    { timeout: 60_000 },
-    async () => {
-      const rootPath = await createTemporaryRoot();
-      const root = await createFilesystemOpensteerWorkspace({ rootPath });
-      const engine = await createPlaywrightBrowserCoreEngine({
-        launch: { headless: true },
-      });
-
-      try {
-        const runtime = createDomRuntime({ engine, root, namespace: "shadow-persist" });
-        const sessionRef = await engine.createSession();
-        const created = await engine.createPage({
-          sessionRef,
-          url: `${baseUrl}/shadow-persist/deep-identical-branches`,
-        });
-        await wait(400);
-
-        await runtime.resolveTarget({
-          pageRef: created.data.pageRef,
-          method: "click",
-          target: { kind: "selector", selector: "#btn-send-1", persist: "deep-branch-button" },
-        });
-        const stored = await runtime.readDescriptor({ method: "click", persist: "deep-branch-button" });
-        expect(stored).toBeDefined();
-      } finally {
-        await engine.dispose();
-      }
-    },
-  );
+  for (const testCase of persistCases) {
+    test(testCase.title, { timeout: 60_000 }, async () => {
+      await expectStoredDescriptor(testCase);
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- improve hit-test failure descriptions across DOM runtime, protocol, and action bridge layers
- surface clearer CLI and SDK error messages for DOM action and session-related failures
- update selector/path handling and related runtime behavior to better explain target resolution issues
- add and adjust tests covering DOM runtime, policies, cloud browser profiles, and shadow DOM flows

## Testing
- Not run (not requested)