### PR TITLE
bumped & published v0.9.6

### DIFF
--- a/packages/engine-abp/package.json
+++ b/packages/engine-abp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensteer/engine-abp",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Agent Browser Protocol engine for Opensteer.",
   "license": "MIT",
   "type": "module",

--- a/packages/engine-playwright/package.json
+++ b/packages/engine-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensteer/engine-playwright",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Playwright-backed browser engine for Opensteer.",
   "license": "MIT",
   "type": "module",

--- a/packages/opensteer/package.json
+++ b/packages/opensteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensteer",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Opensteer browser automation, replay, and reverse-engineering toolkit.",
   "license": "MIT",
   "type": "module",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opensteer/protocol",
   "private": false,
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Public wire schemas and versioned envelopes for Opensteer APIs.",
   "license": "MIT",
   "type": "module",

--- a/packages/runtime-core/package.json
+++ b/packages/runtime-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensteer/runtime-core",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Shared semantic runtime for Opensteer local and cloud execution.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump `opensteer` to 0.9.6, `@opensteer/protocol` to 0.8.5, `@opensteer/runtime-core` to 0.2.5, `@opensteer/engine-playwright` to 0.8.10, `@opensteer/engine-abp` to 0.8.10
- All packages published to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)