### PR TITLE
Fix local view tab ordering and active tab restore

### DIFF
--- a/packages/opensteer/src/live-session.ts
+++ b/packages/opensteer/src/live-session.ts
@@ -18,6 +18,8 @@ interface PersistedSessionRecordBase {
   readonly workspace?: string;
   readonly updatedAt: number;
   readonly activePageRef?: string;
+  readonly activePageUrl?: string;
+  readonly activePageTitle?: string;
   readonly reconnectable?: boolean;
   readonly capabilities?: OpensteerSessionCapabilities;
 }
@@ -143,6 +145,8 @@ function isPersistedCloudSessionRecord(
     value.provider === "cloud" &&
     typeof value.sessionId === "string" &&
     value.sessionId.length > 0 &&
+    (value.activePageUrl === undefined || typeof value.activePageUrl === "string") &&
+    (value.activePageTitle === undefined || typeof value.activePageTitle === "string") &&
     typeof value.startedAt === "number" &&
     Number.isFinite(value.startedAt) &&
     typeof value.updatedAt === "number" &&
@@ -161,6 +165,8 @@ function isPersistedLocalBrowserSessionRecord(
     (value.ownership === undefined ||
       value.ownership === "owned" ||
       value.ownership === "attached") &&
+    (value.activePageUrl === undefined || typeof value.activePageUrl === "string") &&
+    (value.activePageTitle === undefined || typeof value.activePageTitle === "string") &&
     typeof value.pid === "number" &&
     Number.isFinite(value.pid) &&
     typeof value.startedAt === "number" &&

--- a/packages/opensteer/src/local-view/browser-target-order.ts
+++ b/packages/opensteer/src/local-view/browser-target-order.ts
@@ -157,7 +157,7 @@ function normalizeBrowserPageTargetOrder(
     const insertionIndex =
       openerIndex === -1
         ? orderedTargetIds.length
-        : findPopupInsertionIndex(orderedTargetIds, openerIndex, targetInfoById);
+        : findPopupInsertionIndex(orderedTargetIds, openerIndex, openerId, targetInfoById);
     orderedTargetIds.splice(insertionIndex, 0, targetId);
     placed.add(targetId);
   };
@@ -172,6 +172,7 @@ function normalizeBrowserPageTargetOrder(
 function findPopupInsertionIndex(
   orderedTargetIds: readonly string[],
   openerIndex: number,
+  openerTargetId: string,
   targetInfoById: ReadonlyMap<string, NormalizedPageTargetInfo>,
 ): number {
   let index = openerIndex + 1;
@@ -179,7 +180,7 @@ function findPopupInsertionIndex(
     const candidateTargetId = orderedTargetIds[index];
     if (
       !candidateTargetId ||
-      !isDescendantTarget(candidateTargetId, orderedTargetIds[openerIndex]!, targetInfoById)
+      !isDescendantTarget(candidateTargetId, openerTargetId, targetInfoById)
     ) {
       break;
     }

--- a/packages/opensteer/src/local-view/browser-target-order.ts
+++ b/packages/opensteer/src/local-view/browser-target-order.ts
@@ -1,0 +1,209 @@
+import type { Browser, BrowserContext, Page } from "playwright";
+
+interface BrowserTargetInfo {
+  readonly targetId?: unknown;
+  readonly type?: unknown;
+  readonly openerId?: unknown;
+}
+
+interface NormalizedPageTargetInfo {
+  readonly targetId: string;
+  readonly openerId: string | undefined;
+}
+
+export async function readPageTargetId(page: Page): Promise<string | null> {
+  const cdp = await page.context().newCDPSession(page);
+  try {
+    const result = (await cdp.send("Target.getTargetInfo")) as {
+      readonly targetInfo?: {
+        readonly targetId?: unknown;
+      };
+    } | null;
+    const targetId = result?.targetInfo?.targetId;
+    return typeof targetId === "string" && targetId.length > 0 ? targetId : null;
+  } finally {
+    await cdp.detach().catch(() => undefined);
+  }
+}
+
+export async function readBrowserPageTargetOrder(
+  browserContext: BrowserContext,
+): Promise<readonly string[]> {
+  const browser = browserContext.browser();
+  if (!browser || !hasBrowserCdpSession(browser)) {
+    return [];
+  }
+
+  const cdp = await browser.newBrowserCDPSession();
+  try {
+    const result = (await cdp.send("Target.getTargets")) as {
+      readonly targetInfos?: readonly BrowserTargetInfo[];
+    } | null;
+    return normalizeBrowserPageTargetOrder(result?.targetInfos ?? []);
+  } catch {
+    return [];
+  } finally {
+    await cdp.detach().catch(() => undefined);
+  }
+}
+
+export async function orderPagesByBrowserTargetOrder(
+  browserContext: BrowserContext,
+  pages: readonly Page[],
+): Promise<readonly Page[]> {
+  if (pages.length < 2) {
+    return pages;
+  }
+
+  const orderedTargetIds = await readBrowserPageTargetOrder(browserContext);
+  if (orderedTargetIds.length === 0) {
+    return pages;
+  }
+
+  const rankByTargetId = new Map(orderedTargetIds.map((targetId, index) => [targetId, index]));
+  const targetIds = await Promise.all(
+    pages.map((page) => readPageTargetId(page).catch(() => null)),
+  );
+
+  return pages
+    .map((page, index) => {
+      const targetId = targetIds[index] ?? undefined;
+      return {
+        page,
+        index,
+        rank: targetId === undefined ? undefined : rankByTargetId.get(targetId),
+      };
+    })
+    .sort((left, right) => {
+      if (left.rank !== undefined && right.rank !== undefined) {
+        return left.rank - right.rank;
+      }
+      if (left.rank !== undefined) {
+        return -1;
+      }
+      if (right.rank !== undefined) {
+        return 1;
+      }
+      return left.index - right.index;
+    })
+    .map((entry) => entry.page);
+}
+
+function hasBrowserCdpSession(browser: Browser): browser is Browser & {
+  newBrowserCDPSession(): Promise<{
+    send(method: string, params?: object): Promise<unknown>;
+    detach(): Promise<void>;
+  }>;
+} {
+  return (
+    typeof (browser as Browser & { newBrowserCDPSession?: unknown }).newBrowserCDPSession ===
+    "function"
+  );
+}
+
+function normalizeBrowserPageTargetOrder(
+  targetInfos: readonly BrowserTargetInfo[],
+): readonly string[] {
+  const reversedPageInfos: NormalizedPageTargetInfo[] = [];
+  for (const targetInfo of targetInfos) {
+    if (targetInfo.type !== "page") {
+      continue;
+    }
+    const targetId =
+      typeof targetInfo.targetId === "string" && targetInfo.targetId.length > 0
+        ? targetInfo.targetId
+        : undefined;
+    if (targetId === undefined) {
+      continue;
+    }
+    reversedPageInfos.push({
+      targetId,
+      openerId:
+        typeof targetInfo.openerId === "string" && targetInfo.openerId.length > 0
+          ? targetInfo.openerId
+          : undefined,
+    });
+  }
+  reversedPageInfos.reverse();
+
+  const targetInfoById = new Map(
+    reversedPageInfos.map((targetInfo) => [targetInfo.targetId, targetInfo] as const),
+  );
+  const orderedTargetIds: string[] = [];
+  const placed = new Set<string>();
+
+  const placeTarget = (targetId: string): void => {
+    if (placed.has(targetId)) {
+      return;
+    }
+
+    const targetInfo = targetInfoById.get(targetId);
+    if (!targetInfo) {
+      return;
+    }
+
+    const openerId =
+      targetInfo.openerId !== undefined && targetInfoById.has(targetInfo.openerId)
+        ? targetInfo.openerId
+        : undefined;
+    if (openerId === undefined) {
+      orderedTargetIds.push(targetId);
+      placed.add(targetId);
+      return;
+    }
+
+    placeTarget(openerId);
+    const openerIndex = orderedTargetIds.indexOf(openerId);
+    const insertionIndex =
+      openerIndex === -1
+        ? orderedTargetIds.length
+        : findPopupInsertionIndex(orderedTargetIds, openerIndex, targetInfoById);
+    orderedTargetIds.splice(insertionIndex, 0, targetId);
+    placed.add(targetId);
+  };
+
+  for (const targetInfo of reversedPageInfos) {
+    placeTarget(targetInfo.targetId);
+  }
+
+  return orderedTargetIds;
+}
+
+function findPopupInsertionIndex(
+  orderedTargetIds: readonly string[],
+  openerIndex: number,
+  targetInfoById: ReadonlyMap<string, NormalizedPageTargetInfo>,
+): number {
+  let index = openerIndex + 1;
+  while (index < orderedTargetIds.length) {
+    const candidateTargetId = orderedTargetIds[index];
+    if (
+      !candidateTargetId ||
+      !isDescendantTarget(candidateTargetId, orderedTargetIds[openerIndex]!, targetInfoById)
+    ) {
+      break;
+    }
+    index += 1;
+  }
+  return index;
+}
+
+function isDescendantTarget(
+  targetId: string,
+  ancestorTargetId: string,
+  targetInfoById: ReadonlyMap<string, NormalizedPageTargetInfo>,
+): boolean {
+  let currentTargetId: string | undefined = targetId;
+  while (currentTargetId !== undefined) {
+    const currentTargetInfo = targetInfoById.get(currentTargetId);
+    const openerId = currentTargetInfo?.openerId;
+    if (openerId === undefined) {
+      return false;
+    }
+    if (openerId === ancestorTargetId) {
+      return true;
+    }
+    currentTargetId = openerId;
+  }
+  return false;
+}

--- a/packages/opensteer/src/local-view/browser-target-order.ts
+++ b/packages/opensteer/src/local-view/browser-target-order.ts
@@ -126,8 +126,20 @@ function normalizeBrowserPageTargetOrder(
   }
   reversedPageInfos.reverse();
 
-  const targetInfoById = new Map(
+  const rawTargetInfoById = new Map(
     reversedPageInfos.map((targetInfo) => [targetInfo.targetId, targetInfo] as const),
+  );
+  const targetInfoById = new Map(
+    reversedPageInfos.map(
+      (targetInfo) =>
+        [
+          targetInfo.targetId,
+          {
+            ...targetInfo,
+            openerId: resolveAcyclicOpenerId(targetInfo.targetId, rawTargetInfoById),
+          } satisfies NormalizedPageTargetInfo,
+        ] as const,
+    ),
   );
   const orderedTargetIds: string[] = [];
   const placed = new Set<string>();
@@ -142,10 +154,7 @@ function normalizeBrowserPageTargetOrder(
       return;
     }
 
-    const openerId =
-      targetInfo.openerId !== undefined && targetInfoById.has(targetInfo.openerId)
-        ? targetInfo.openerId
-        : undefined;
+    const openerId = targetInfo.openerId;
     if (openerId === undefined) {
       orderedTargetIds.push(targetId);
       placed.add(targetId);
@@ -167,6 +176,28 @@ function normalizeBrowserPageTargetOrder(
   }
 
   return orderedTargetIds;
+}
+
+function resolveAcyclicOpenerId(
+  targetId: string,
+  targetInfoById: ReadonlyMap<string, NormalizedPageTargetInfo>,
+): string | undefined {
+  const openerId = targetInfoById.get(targetId)?.openerId;
+  if (openerId === undefined || !targetInfoById.has(openerId)) {
+    return undefined;
+  }
+
+  const visitedTargetIds = new Set<string>([targetId]);
+  let currentTargetId: string | undefined = openerId;
+  while (currentTargetId !== undefined) {
+    if (visitedTargetIds.has(currentTargetId)) {
+      return undefined;
+    }
+    visitedTargetIds.add(currentTargetId);
+    currentTargetId = targetInfoById.get(currentTargetId)?.openerId;
+  }
+
+  return openerId;
 }
 
 function findPopupInsertionIndex(
@@ -194,8 +225,13 @@ function isDescendantTarget(
   ancestorTargetId: string,
   targetInfoById: ReadonlyMap<string, NormalizedPageTargetInfo>,
 ): boolean {
+  const visitedTargetIds = new Set<string>();
   let currentTargetId: string | undefined = targetId;
   while (currentTargetId !== undefined) {
+    if (visitedTargetIds.has(currentTargetId)) {
+      return false;
+    }
+    visitedTargetIds.add(currentTargetId);
     const currentTargetInfo = targetInfoById.get(currentTargetId);
     const openerId = currentTargetInfo?.openerId;
     if (openerId === undefined) {

--- a/packages/opensteer/src/local-view/tab-state-tracker.ts
+++ b/packages/opensteer/src/local-view/tab-state-tracker.ts
@@ -428,6 +428,13 @@ export class TabStateTracker {
   >(
     pageStates: readonly T[],
   ): Promise<Array<Omit<T, "originalIndex"> & { readonly index: number }>> {
+    if (pageStates.length < 2) {
+      return pageStates.map(({ originalIndex: _originalIndex, ...state }, index) => ({
+        ...state,
+        index,
+      }));
+    }
+
     const orderedTargetIds = await readBrowserPageTargetOrder(this.deps.browserContext);
     const rankByTargetId = new Map(orderedTargetIds.map((targetId, index) => [targetId, index]));
 

--- a/packages/opensteer/src/local-view/tab-state-tracker.ts
+++ b/packages/opensteer/src/local-view/tab-state-tracker.ts
@@ -2,6 +2,7 @@ import type { BrowserContext, Page } from "playwright";
 
 import type { OpensteerViewStreamTab } from "@opensteer/protocol";
 
+import { readBrowserPageTargetOrder, readPageTargetId } from "./browser-target-order.js";
 import { LocalViewRuntimeState } from "./runtime-state.js";
 
 interface CachedPageMetadata {
@@ -16,6 +17,7 @@ export interface TabStateTrackerDeps {
   readonly sessionId: string;
   readonly pollMs: number;
   readonly runtimeState: LocalViewRuntimeState;
+  readonly initialActivePage?: Page;
   readonly onTabsChanged: (payload: {
     readonly tabs: readonly OpensteerViewStreamTab[];
     readonly activeTabIndex: number;
@@ -37,6 +39,7 @@ export class TabStateTracker {
 
   constructor(deps: TabStateTrackerDeps) {
     this.deps = deps;
+    this.lastActivePage = deps.initialActivePage ?? null;
   }
 
   start(): void {
@@ -183,7 +186,7 @@ export class TabStateTracker {
       const preferredActivePage = this.lastActivePage ?? pages[0] ?? null;
 
       const pageStates = await Promise.all(
-        pages.map(async (page, index) => {
+        pages.map(async (page, originalIndex) => {
           const metadata = await this.readPageMetadata(page, {
             refresh: args.refreshMetadata,
           });
@@ -196,7 +199,7 @@ export class TabStateTracker {
 
           return {
             page,
-            index,
+            originalIndex,
             targetId: metadata.targetId,
             url: page.url(),
             title: metadata.title,
@@ -205,19 +208,20 @@ export class TabStateTracker {
           };
         }),
       );
+      const orderedPageStates = await this.orderPageStates(pageStates);
 
       const activePage = this.pickActivePage(
-        pageStates,
+        orderedPageStates,
         this.lastActivePage,
         preferredActivePage,
-        this.resolveIntentPage(pageStates),
+        this.resolveIntentPage(orderedPageStates),
       );
       if (activePage && activePage !== this.lastActivePage) {
         this.lastActivePage = activePage;
         this.deps.onActivePageChanged(activePage);
       }
 
-      const tabs = pageStates.map((state) => ({
+      const tabs = orderedPageStates.map((state) => ({
         index: state.index,
         ...(state.targetId === undefined ? {} : { targetId: state.targetId }),
         url: state.url,
@@ -277,22 +281,11 @@ export class TabStateTracker {
       return cached;
     }
 
-    const cdp = await page.context().newCDPSession(page);
-    try {
-      const result = (await cdp.send("Target.getTargetInfo")) as {
-        readonly targetInfo?: {
-          readonly targetId?: unknown;
-        };
-      } | null;
-      const targetId = result?.targetInfo?.targetId;
-      if (typeof targetId === "string" && targetId.length > 0) {
-        this.targetIdByPage.set(page, targetId);
-        return targetId;
-      }
-      return null;
-    } finally {
-      await cdp.detach().catch(() => undefined);
+    const targetId = await readPageTargetId(page);
+    if (targetId) {
+      this.targetIdByPage.set(page, targetId);
     }
+    return targetId;
   }
 
   private async readFocusState(page: Page): Promise<{
@@ -424,5 +417,40 @@ export class TabStateTracker {
 
     this.deps.runtimeState.clearPageActivationIntent(this.deps.sessionId, intent.targetId);
     return { page: matched.page };
+  }
+
+  private async orderPageStates<
+    T extends {
+      readonly page: Page;
+      readonly originalIndex: number;
+      readonly targetId: string | undefined;
+    },
+  >(
+    pageStates: readonly T[],
+  ): Promise<Array<Omit<T, "originalIndex"> & { readonly index: number }>> {
+    const orderedTargetIds = await readBrowserPageTargetOrder(this.deps.browserContext);
+    const rankByTargetId = new Map(orderedTargetIds.map((targetId, index) => [targetId, index]));
+
+    return [...pageStates]
+      .sort((left, right) => {
+        const leftRank =
+          left.targetId === undefined ? undefined : rankByTargetId.get(left.targetId);
+        const rightRank =
+          right.targetId === undefined ? undefined : rankByTargetId.get(right.targetId);
+        if (leftRank !== undefined && rightRank !== undefined) {
+          return leftRank - rightRank;
+        }
+        if (leftRank !== undefined) {
+          return -1;
+        }
+        if (rightRank !== undefined) {
+          return 1;
+        }
+        return left.originalIndex - right.originalIndex;
+      })
+      .map(({ originalIndex: _originalIndex, ...state }, index) => ({
+        ...state,
+        index,
+      }));
   }
 }

--- a/packages/opensteer/src/local-view/view-stream.ts
+++ b/packages/opensteer/src/local-view/view-stream.ts
@@ -3,6 +3,7 @@ import WebSocket, { type RawData } from "ws";
 
 import type { OpensteerViewport, OpensteerViewStreamTab } from "@opensteer/protocol";
 
+import { orderPagesByBrowserTargetOrder } from "./browser-target-order.js";
 import { resolveLocalViewSession } from "./discovery.js";
 import { LocalViewRuntimeState } from "./runtime-state.js";
 import { TabStateTracker } from "./tab-state-tracker.js";
@@ -291,6 +292,7 @@ class SessionViewStreamProducer {
       sessionId: this.deps.sessionId,
       pollMs: TAB_STATE_POLL_MS,
       runtimeState: this.deps.runtimeState,
+      initialActivePage: session.page,
       onActivePageChanged: (page) => {
         this.activePage = page;
         void this.queueBindToPage(page).catch(() => undefined);
@@ -423,7 +425,26 @@ class SessionViewStreamProducer {
         throw new Error("Connected browser did not expose a Chromium browser context.");
       }
 
-      const page = context.pages()[0] ?? (await context.newPage());
+      const existingPages = context.pages();
+      if (existingPages.length === 0) {
+        const page = await context.newPage();
+        return {
+          browser,
+          context,
+          page,
+        };
+      }
+
+      const orderedPages = await orderPagesByBrowserTargetOrder(context, existingPages);
+      const page =
+        (await resolvePersistedActivePage(orderedPages, {
+          ...(resolved.record.activePageUrl === undefined
+            ? {}
+            : { activePageUrl: resolved.record.activePageUrl }),
+          ...(resolved.record.activePageTitle === undefined
+            ? {}
+            : { activePageTitle: resolved.record.activePageTitle }),
+        })) ?? orderedPages[0]!;
       return {
         browser,
         context,
@@ -855,4 +876,36 @@ async function disconnectPlaywrightChromiumBrowser(browser: Browser): Promise<vo
   const { disconnectPlaywrightChromiumBrowser: disconnect } =
     await import("@opensteer/engine-playwright");
   await disconnect(browser);
+}
+
+async function resolvePersistedActivePage(
+  pages: readonly Page[],
+  input: {
+    readonly activePageUrl?: string;
+    readonly activePageTitle?: string;
+  },
+): Promise<Page | null> {
+  if (pages.length === 0) {
+    return null;
+  }
+
+  const matchesByUrl =
+    input.activePageUrl === undefined
+      ? pages
+      : pages.filter((page) => page.url() === input.activePageUrl);
+  if (matchesByUrl.length === 0) {
+    return null;
+  }
+  if (input.activePageTitle === undefined) {
+    return matchesByUrl[0] ?? null;
+  }
+
+  for (const page of matchesByUrl) {
+    const title = await page.title().catch(() => "");
+    if (title === input.activePageTitle) {
+      return page;
+    }
+  }
+
+  return matchesByUrl[0] ?? null;
 }

--- a/packages/opensteer/src/local-view/view-stream.ts
+++ b/packages/opensteer/src/local-view/view-stream.ts
@@ -888,6 +888,9 @@ async function resolvePersistedActivePage(
   if (pages.length === 0) {
     return null;
   }
+  if (input.activePageUrl === undefined && input.activePageTitle === undefined) {
+    return null;
+  }
 
   const matchesByUrl =
     input.activePageUrl === undefined

--- a/packages/opensteer/src/sdk/runtime.ts
+++ b/packages/opensteer/src/sdk/runtime.ts
@@ -85,7 +85,50 @@ export interface OpensteerSessionRuntimeOptions {
   readonly observationSink?: ObservationSink;
 }
 
-export class OpensteerRuntime extends SharedOpensteerSessionRuntime {
+abstract class LocalActivePageHintRuntime extends SharedOpensteerSessionRuntime {
+  protected async completeWithLocalActivePageHint<T>(operation: () => Promise<T>): Promise<T> {
+    const output = await operation();
+    await persistLocalActivePageHint(this, this.rootPath);
+    return output;
+  }
+
+  override async open(
+    input: OpensteerOpenInput = {},
+    options: Parameters<SharedOpensteerSessionRuntime["open"]>[1] = {},
+  ): Promise<OpensteerOpenOutput> {
+    return this.completeWithLocalActivePageHint(() => super.open(input, options));
+  }
+
+  override async newPage(
+    input: OpensteerPageNewInput = {},
+    options: Parameters<SharedOpensteerSessionRuntime["newPage"]>[1] = {},
+  ): Promise<OpensteerPageNewOutput> {
+    return this.completeWithLocalActivePageHint(() => super.newPage(input, options));
+  }
+
+  override async activatePage(
+    input: OpensteerPageActivateInput,
+    options: Parameters<SharedOpensteerSessionRuntime["activatePage"]>[1] = {},
+  ): Promise<OpensteerPageActivateOutput> {
+    return this.completeWithLocalActivePageHint(() => super.activatePage(input, options));
+  }
+
+  override async closePage(
+    input: OpensteerPageCloseInput = {},
+    options: Parameters<SharedOpensteerSessionRuntime["closePage"]>[1] = {},
+  ): Promise<OpensteerPageCloseOutput> {
+    return this.completeWithLocalActivePageHint(() => super.closePage(input, options));
+  }
+
+  override async goto(
+    input: OpensteerPageGotoInput,
+    options: Parameters<SharedOpensteerSessionRuntime["goto"]>[1] = {},
+  ): Promise<OpensteerPageGotoOutput> {
+    return this.completeWithLocalActivePageHint(() => super.goto(input, options));
+  }
+}
+
+export class OpensteerRuntime extends LocalActivePageHintRuntime {
   constructor(options: OpensteerRuntimeOptions = {}) {
     const publicWorkspace = normalizeWorkspace(options.workspace);
     const rootPath =
@@ -136,54 +179,9 @@ export class OpensteerRuntime extends SharedOpensteerSessionRuntime {
       }),
     );
   }
-
-  override async open(
-    input: OpensteerOpenInput = {},
-    options: Parameters<SharedOpensteerSessionRuntime["open"]>[1] = {},
-  ): Promise<OpensteerOpenOutput> {
-    const output = await super.open(input, options);
-    await persistLocalActivePageHint(this, this.rootPath);
-    return output;
-  }
-
-  override async newPage(
-    input: OpensteerPageNewInput = {},
-    options: Parameters<SharedOpensteerSessionRuntime["newPage"]>[1] = {},
-  ): Promise<OpensteerPageNewOutput> {
-    const output = await super.newPage(input, options);
-    await persistLocalActivePageHint(this, this.rootPath);
-    return output;
-  }
-
-  override async activatePage(
-    input: OpensteerPageActivateInput,
-    options: Parameters<SharedOpensteerSessionRuntime["activatePage"]>[1] = {},
-  ): Promise<OpensteerPageActivateOutput> {
-    const output = await super.activatePage(input, options);
-    await persistLocalActivePageHint(this, this.rootPath);
-    return output;
-  }
-
-  override async closePage(
-    input: OpensteerPageCloseInput = {},
-    options: Parameters<SharedOpensteerSessionRuntime["closePage"]>[1] = {},
-  ): Promise<OpensteerPageCloseOutput> {
-    const output = await super.closePage(input, options);
-    await persistLocalActivePageHint(this, this.rootPath);
-    return output;
-  }
-
-  override async goto(
-    input: OpensteerPageGotoInput,
-    options: Parameters<SharedOpensteerSessionRuntime["goto"]>[1] = {},
-  ): Promise<OpensteerPageGotoOutput> {
-    const output = await super.goto(input, options);
-    await persistLocalActivePageHint(this, this.rootPath);
-    return output;
-  }
 }
 
-export class OpensteerSessionRuntime extends SharedOpensteerSessionRuntime {
+export class OpensteerSessionRuntime extends LocalActivePageHintRuntime {
   constructor(options: OpensteerSessionRuntimeOptions) {
     const rootPath = options.rootPath ?? path.resolve(options.rootDir ?? process.cwd());
     const cleanupRootOnClose = options.cleanupRootOnClose ?? false;
@@ -225,54 +223,18 @@ export class OpensteerSessionRuntime extends SharedOpensteerSessionRuntime {
       }),
     );
   }
-
-  override async open(
-    input: OpensteerOpenInput = {},
-    options: Parameters<SharedOpensteerSessionRuntime["open"]>[1] = {},
-  ): Promise<OpensteerOpenOutput> {
-    const output = await super.open(input, options);
-    await persistLocalActivePageHint(this, this.rootPath);
-    return output;
-  }
-
-  override async newPage(
-    input: OpensteerPageNewInput = {},
-    options: Parameters<SharedOpensteerSessionRuntime["newPage"]>[1] = {},
-  ): Promise<OpensteerPageNewOutput> {
-    const output = await super.newPage(input, options);
-    await persistLocalActivePageHint(this, this.rootPath);
-    return output;
-  }
-
-  override async activatePage(
-    input: OpensteerPageActivateInput,
-    options: Parameters<SharedOpensteerSessionRuntime["activatePage"]>[1] = {},
-  ): Promise<OpensteerPageActivateOutput> {
-    const output = await super.activatePage(input, options);
-    await persistLocalActivePageHint(this, this.rootPath);
-    return output;
-  }
-
-  override async closePage(
-    input: OpensteerPageCloseInput = {},
-    options: Parameters<SharedOpensteerSessionRuntime["closePage"]>[1] = {},
-  ): Promise<OpensteerPageCloseOutput> {
-    const output = await super.closePage(input, options);
-    await persistLocalActivePageHint(this, this.rootPath);
-    return output;
-  }
-
-  override async goto(
-    input: OpensteerPageGotoInput,
-    options: Parameters<SharedOpensteerSessionRuntime["goto"]>[1] = {},
-  ): Promise<OpensteerPageGotoOutput> {
-    const output = await super.goto(input, options);
-    await persistLocalActivePageHint(this, this.rootPath);
-    return output;
-  }
 }
 
 async function persistLocalActivePageHint(
+  runtime: SharedOpensteerSessionRuntime,
+  rootPath: string,
+): Promise<void> {
+  try {
+    await syncPersistedLocalActivePageHint(runtime, rootPath);
+  } catch {}
+}
+
+async function syncPersistedLocalActivePageHint(
   runtime: SharedOpensteerSessionRuntime,
   rootPath: string,
 ): Promise<void> {

--- a/packages/opensteer/src/sdk/runtime.ts
+++ b/packages/opensteer/src/sdk/runtime.ts
@@ -15,6 +15,16 @@ import type {
   OpensteerBrowserOptions,
   OpensteerBrowserContextOptions,
   OpensteerBrowserLaunchOptions,
+  OpensteerOpenInput,
+  OpensteerOpenOutput,
+  OpensteerPageActivateInput,
+  OpensteerPageActivateOutput,
+  OpensteerPageCloseInput,
+  OpensteerPageCloseOutput,
+  OpensteerPageGotoInput,
+  OpensteerPageGotoOutput,
+  OpensteerPageNewInput,
+  OpensteerPageNewOutput,
   ObservabilityConfig,
   ObservationSink,
 } from "@opensteer/protocol";
@@ -26,6 +36,10 @@ import {
   type OpensteerEngineName,
 } from "../internal/engine-selection.js";
 import type { OpensteerEnvironment } from "../env.js";
+import {
+  readPersistedLocalBrowserSessionRecord,
+  writePersistedSessionRecord,
+} from "../live-session.js";
 import type { OpensteerPolicy } from "../policy/index.js";
 import { resolveFilesystemWorkspacePath } from "../root.js";
 
@@ -122,6 +136,51 @@ export class OpensteerRuntime extends SharedOpensteerSessionRuntime {
       }),
     );
   }
+
+  override async open(
+    input: OpensteerOpenInput = {},
+    options: Parameters<SharedOpensteerSessionRuntime["open"]>[1] = {},
+  ): Promise<OpensteerOpenOutput> {
+    const output = await super.open(input, options);
+    await persistLocalActivePageHint(this, this.rootPath);
+    return output;
+  }
+
+  override async newPage(
+    input: OpensteerPageNewInput = {},
+    options: Parameters<SharedOpensteerSessionRuntime["newPage"]>[1] = {},
+  ): Promise<OpensteerPageNewOutput> {
+    const output = await super.newPage(input, options);
+    await persistLocalActivePageHint(this, this.rootPath);
+    return output;
+  }
+
+  override async activatePage(
+    input: OpensteerPageActivateInput,
+    options: Parameters<SharedOpensteerSessionRuntime["activatePage"]>[1] = {},
+  ): Promise<OpensteerPageActivateOutput> {
+    const output = await super.activatePage(input, options);
+    await persistLocalActivePageHint(this, this.rootPath);
+    return output;
+  }
+
+  override async closePage(
+    input: OpensteerPageCloseInput = {},
+    options: Parameters<SharedOpensteerSessionRuntime["closePage"]>[1] = {},
+  ): Promise<OpensteerPageCloseOutput> {
+    const output = await super.closePage(input, options);
+    await persistLocalActivePageHint(this, this.rootPath);
+    return output;
+  }
+
+  override async goto(
+    input: OpensteerPageGotoInput,
+    options: Parameters<SharedOpensteerSessionRuntime["goto"]>[1] = {},
+  ): Promise<OpensteerPageGotoOutput> {
+    const output = await super.goto(input, options);
+    await persistLocalActivePageHint(this, this.rootPath);
+    return output;
+  }
 }
 
 export class OpensteerSessionRuntime extends SharedOpensteerSessionRuntime {
@@ -166,6 +225,88 @@ export class OpensteerSessionRuntime extends SharedOpensteerSessionRuntime {
       }),
     );
   }
+
+  override async open(
+    input: OpensteerOpenInput = {},
+    options: Parameters<SharedOpensteerSessionRuntime["open"]>[1] = {},
+  ): Promise<OpensteerOpenOutput> {
+    const output = await super.open(input, options);
+    await persistLocalActivePageHint(this, this.rootPath);
+    return output;
+  }
+
+  override async newPage(
+    input: OpensteerPageNewInput = {},
+    options: Parameters<SharedOpensteerSessionRuntime["newPage"]>[1] = {},
+  ): Promise<OpensteerPageNewOutput> {
+    const output = await super.newPage(input, options);
+    await persistLocalActivePageHint(this, this.rootPath);
+    return output;
+  }
+
+  override async activatePage(
+    input: OpensteerPageActivateInput,
+    options: Parameters<SharedOpensteerSessionRuntime["activatePage"]>[1] = {},
+  ): Promise<OpensteerPageActivateOutput> {
+    const output = await super.activatePage(input, options);
+    await persistLocalActivePageHint(this, this.rootPath);
+    return output;
+  }
+
+  override async closePage(
+    input: OpensteerPageCloseInput = {},
+    options: Parameters<SharedOpensteerSessionRuntime["closePage"]>[1] = {},
+  ): Promise<OpensteerPageCloseOutput> {
+    const output = await super.closePage(input, options);
+    await persistLocalActivePageHint(this, this.rootPath);
+    return output;
+  }
+
+  override async goto(
+    input: OpensteerPageGotoInput,
+    options: Parameters<SharedOpensteerSessionRuntime["goto"]>[1] = {},
+  ): Promise<OpensteerPageGotoOutput> {
+    const output = await super.goto(input, options);
+    await persistLocalActivePageHint(this, this.rootPath);
+    return output;
+  }
+}
+
+async function persistLocalActivePageHint(
+  runtime: SharedOpensteerSessionRuntime,
+  rootPath: string,
+): Promise<void> {
+  const record = await readPersistedLocalBrowserSessionRecord(rootPath);
+  if (!record) {
+    return;
+  }
+
+  const sessionInfo = await runtime.info();
+  const activePageRef = sessionInfo.activePageRef;
+  let activePageUrl: string | undefined;
+  let activePageTitle: string | undefined;
+
+  if (activePageRef !== undefined) {
+    const pages = await runtime.listPages();
+    const activePage = pages.pages.find((page) => page.pageRef === activePageRef);
+    activePageUrl = activePage?.url;
+    activePageTitle = activePage?.title;
+  }
+
+  const {
+    activePageRef: _previousActivePageRef,
+    activePageUrl: _previousActivePageUrl,
+    activePageTitle: _previousActivePageTitle,
+    ...restRecord
+  } = record;
+
+  await writePersistedSessionRecord(rootPath, {
+    ...restRecord,
+    updatedAt: Date.now(),
+    ...(activePageRef === undefined ? {} : { activePageRef }),
+    ...(activePageUrl === undefined ? {} : { activePageUrl }),
+    ...(activePageTitle === undefined ? {} : { activePageTitle }),
+  });
 }
 
 function buildSharedRuntimeOptions(input: {

--- a/tests/opensteer/browser-target-order.test.ts
+++ b/tests/opensteer/browser-target-order.test.ts
@@ -1,0 +1,42 @@
+import type { BrowserContext } from "playwright";
+
+import { describe, expect, test, vi } from "vitest";
+
+import { readBrowserPageTargetOrder } from "../../packages/opensteer/src/local-view/browser-target-order.js";
+
+describe("browser target order", () => {
+  test("drops cyclic opener chains instead of recursing forever", async () => {
+    const detach = vi.fn(async () => undefined);
+    const send = vi.fn(async () => ({
+      targetInfos: [
+        {
+          targetId: "tab-a",
+          type: "page",
+          openerId: "tab-b",
+        },
+        {
+          targetId: "tab-b",
+          type: "page",
+          openerId: "tab-a",
+        },
+        {
+          targetId: "worker-1",
+          type: "worker",
+        },
+      ],
+    }));
+
+    const browserContext = {
+      browser: () => ({
+        newBrowserCDPSession: async () => ({
+          send,
+          detach,
+        }),
+      }),
+    } as unknown as BrowserContext;
+
+    await expect(readBrowserPageTargetOrder(browserContext)).resolves.toEqual(["tab-b", "tab-a"]);
+    expect(send).toHaveBeenCalledWith("Target.getTargets");
+    expect(detach).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/opensteer/local-view.test.ts
+++ b/tests/opensteer/local-view.test.ts
@@ -7,7 +7,14 @@ import path from "node:path";
 import { chromium, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 
-import { OpensteerSessionRuntime } from "../../packages/opensteer/src/sdk/runtime.js";
+import {
+  OpensteerRuntime,
+  OpensteerSessionRuntime,
+} from "../../packages/opensteer/src/sdk/runtime.js";
+import {
+  readPersistedLocalBrowserSessionRecord,
+  writePersistedSessionRecord,
+} from "../../packages/opensteer/src/live-session.js";
 import { bestEffortRegisterLocalViewSession } from "../../packages/opensteer/src/local-view/registration.js";
 import {
   resolveLocalViewMode,
@@ -17,6 +24,7 @@ import { stopLocalViewService } from "../../packages/opensteer/src/local-view/se
 import { readLocalViewServiceState } from "../../packages/opensteer/src/local-view/service-state.js";
 import { startLocalViewServer } from "../../packages/opensteer/src/local-view/server.js";
 import { isProcessRunning } from "../../packages/opensteer/src/local-browser/process-owner.js";
+import { resolveFilesystemWorkspacePath } from "../../packages/opensteer/src/root.js";
 
 let fixtureUrl = "";
 let closeFixtureServer: (() => Promise<void>) | undefined;
@@ -493,6 +501,411 @@ describe("local browser view", () => {
       }
     },
   );
+
+  test(
+    "restores browser-order tabs and the persisted active tab when attaching to an existing headless session",
+    { timeout: 90_000 },
+    async () => {
+      const priorOpensteerHome = process.env.OPENSTEER_HOME;
+      const stateHome = await mkdtemp(path.join(tmpdir(), "opensteer-local-view-tab-attach-"));
+      process.env.OPENSTEER_HOME = stateHome;
+      await setLocalViewMode("manual");
+      const rootPath = await mkdtemp(path.join(tmpdir(), "opensteer-local-view-tab-root-"));
+
+      const runtime = new OpensteerSessionRuntime({
+        name: "local-view-tab-attach-runtime",
+        rootPath,
+        browser: "temporary",
+        launch: {
+          headless: true,
+        },
+        context: {
+          viewport: {
+            width: 800,
+            height: 600,
+          },
+        },
+      });
+
+      const viewerBrowser = await chromium.launch({ headless: true });
+      let localViewServer: Awaited<ReturnType<typeof startLocalViewServer>> | undefined;
+
+      try {
+        await runtime.open({ url: `${fixtureUrl}/viewer` });
+        const firstPageRef = (await runtime.listPages()).pages[0]?.pageRef;
+        expect(firstPageRef).toBeDefined();
+        await runtime.newPage({ url: `${fixtureUrl}/destination` });
+        await runtime.activatePage({ pageRef: firstPageRef! });
+
+        localViewServer = await startLocalViewServer({
+          token: "local-view-tab-attach-token",
+        });
+
+        const session = await waitFor(async () => {
+          const response = await fetch(new URL("/api/sessions", localViewServer.url), {
+            headers: {
+              "x-opensteer-local-token": localViewServer.token,
+            },
+          });
+          if (!response.ok) {
+            return null;
+          }
+          const payload = await response.json();
+          const sessions = Array.isArray(payload?.sessions) ? payload.sessions : [];
+          return sessions.find((candidate) => candidate.rootPath === rootPath) ?? null;
+        });
+
+        const page = await viewerBrowser.newPage({
+          viewport: {
+            width: 1800,
+            height: 900,
+          },
+        });
+        await page.goto(`${localViewServer.url}#session=${encodeURIComponent(session.sessionId)}`, {
+          waitUntil: "networkidle",
+        });
+
+        const tabStates = await waitFor(async () => {
+          const current = await readTabStates(page);
+          return current.length === 2 ? current : null;
+        });
+        expect(tabStates.map((tab) => tab.text)).toEqual([
+          "OpenSteer Local Fixture",
+          "Destination",
+        ]);
+        expect(tabStates.map((tab) => tab.active)).toEqual([true, false]);
+        expect(await page.locator("[data-testid='address-input']").inputValue()).toBe(
+          `${fixtureUrl}/viewer`,
+        );
+      } finally {
+        await viewerBrowser.close().catch(() => undefined);
+        await localViewServer?.close().catch(() => undefined);
+        await runtime.close().catch(() => undefined);
+        await rm(rootPath, { recursive: true, force: true }).catch(() => undefined);
+        await rm(stateHome, { recursive: true, force: true }).catch(() => undefined);
+        if (priorOpensteerHome === undefined) {
+          delete process.env.OPENSTEER_HOME;
+        } else {
+          process.env.OPENSTEER_HOME = priorOpensteerHome;
+        }
+      }
+    },
+  );
+
+  test(
+    "persists the active tab hint for workspace runtimes before the local view attaches",
+    { timeout: 90_000 },
+    async () => {
+      const priorOpensteerHome = process.env.OPENSTEER_HOME;
+      const stateHome = await mkdtemp(path.join(tmpdir(), "opensteer-local-view-workspace-state-"));
+      process.env.OPENSTEER_HOME = stateHome;
+      await setLocalViewMode("manual");
+      const rootDir = await mkdtemp(path.join(tmpdir(), "opensteer-local-view-workspace-root-"));
+      const workspace = "local-view-workspace-attach";
+      const rootPath = resolveFilesystemWorkspacePath({
+        rootDir,
+        workspace,
+      });
+
+      const runtime = new OpensteerRuntime({
+        rootDir,
+        workspace,
+        browser: "temporary",
+        launch: {
+          headless: true,
+        },
+        context: {
+          viewport: {
+            width: 800,
+            height: 600,
+          },
+        },
+      });
+
+      const viewerBrowser = await chromium.launch({ headless: true });
+      let localViewServer: Awaited<ReturnType<typeof startLocalViewServer>> | undefined;
+
+      try {
+        await runtime.open({ url: `${fixtureUrl}/viewer` });
+        const firstPageRef = (await runtime.listPages()).pages[0]?.pageRef;
+        expect(firstPageRef).toBeDefined();
+        await runtime.newPage({ url: `${fixtureUrl}/destination` });
+        await runtime.activatePage({ pageRef: firstPageRef! });
+
+        const record = await readPersistedLocalBrowserSessionRecord(rootPath);
+        expect(record?.activePageUrl).toBe(`${fixtureUrl}/viewer`);
+        expect(record?.activePageTitle).toBe("OpenSteer Local Fixture");
+
+        localViewServer = await startLocalViewServer({
+          token: "local-view-workspace-attach-token",
+        });
+
+        const session = await waitFor(async () => {
+          const response = await fetch(new URL("/api/sessions", localViewServer.url), {
+            headers: {
+              "x-opensteer-local-token": localViewServer.token,
+            },
+          });
+          if (!response.ok) {
+            return null;
+          }
+          const payload = await response.json();
+          const sessions = Array.isArray(payload?.sessions) ? payload.sessions : [];
+          return sessions.find((candidate) => candidate.rootPath === rootPath) ?? null;
+        });
+
+        const page = await viewerBrowser.newPage({
+          viewport: {
+            width: 1800,
+            height: 900,
+          },
+        });
+        await page.goto(`${localViewServer.url}#session=${encodeURIComponent(session.sessionId)}`, {
+          waitUntil: "networkidle",
+        });
+
+        const tabStates = await waitFor(async () => {
+          const current = await readTabStates(page);
+          return current.length === 2 ? current : null;
+        });
+        expect(tabStates.map((tab) => tab.text)).toEqual([
+          "OpenSteer Local Fixture",
+          "Destination",
+        ]);
+        expect(tabStates.map((tab) => tab.active)).toEqual([true, false]);
+        expect(await page.locator("[data-testid='address-input']").inputValue()).toBe(
+          `${fixtureUrl}/viewer`,
+        );
+      } finally {
+        await viewerBrowser.close().catch(() => undefined);
+        await localViewServer?.close().catch(() => undefined);
+        await runtime.close().catch(() => undefined);
+        await rm(rootDir, { recursive: true, force: true }).catch(() => undefined);
+        await rm(stateHome, { recursive: true, force: true }).catch(() => undefined);
+        if (priorOpensteerHome === undefined) {
+          delete process.env.OPENSTEER_HOME;
+        } else {
+          process.env.OPENSTEER_HOME = priorOpensteerHome;
+        }
+      }
+    },
+  );
+
+  test(
+    "falls back to the browser-order first tab when persisted active page hints are unavailable",
+    { timeout: 90_000 },
+    async () => {
+      const priorOpensteerHome = process.env.OPENSTEER_HOME;
+      const stateHome = await mkdtemp(path.join(tmpdir(), "opensteer-local-view-tab-fallback-"));
+      process.env.OPENSTEER_HOME = stateHome;
+      await setLocalViewMode("manual");
+      const rootPath = await mkdtemp(
+        path.join(tmpdir(), "opensteer-local-view-tab-fallback-root-"),
+      );
+
+      const runtime = new OpensteerSessionRuntime({
+        name: "local-view-tab-fallback-runtime",
+        rootPath,
+        browser: "temporary",
+        launch: {
+          headless: true,
+        },
+        context: {
+          viewport: {
+            width: 800,
+            height: 600,
+          },
+        },
+      });
+
+      const viewerBrowser = await chromium.launch({ headless: true });
+      let localViewServer: Awaited<ReturnType<typeof startLocalViewServer>> | undefined;
+
+      try {
+        await runtime.open({ url: `${fixtureUrl}/viewer` });
+        const firstPageRef = (await runtime.listPages()).pages[0]?.pageRef;
+        expect(firstPageRef).toBeDefined();
+        await runtime.newPage({ url: `${fixtureUrl}/destination` });
+        await runtime.activatePage({ pageRef: firstPageRef! });
+
+        const record = await readPersistedLocalBrowserSessionRecord(rootPath);
+        expect(record).toBeDefined();
+        const {
+          activePageUrl: _activePageUrl,
+          activePageTitle: _activePageTitle,
+          ...recordWithoutPageHints
+        } = record!;
+        await writePersistedSessionRecord(rootPath, {
+          ...recordWithoutPageHints,
+          updatedAt: Date.now(),
+        });
+
+        localViewServer = await startLocalViewServer({
+          token: "local-view-tab-fallback-token",
+        });
+
+        const session = await waitFor(async () => {
+          const response = await fetch(new URL("/api/sessions", localViewServer.url), {
+            headers: {
+              "x-opensteer-local-token": localViewServer.token,
+            },
+          });
+          if (!response.ok) {
+            return null;
+          }
+          const payload = await response.json();
+          const sessions = Array.isArray(payload?.sessions) ? payload.sessions : [];
+          return sessions.find((candidate) => candidate.rootPath === rootPath) ?? null;
+        });
+
+        const page = await viewerBrowser.newPage({
+          viewport: {
+            width: 1800,
+            height: 900,
+          },
+        });
+        await page.goto(`${localViewServer.url}#session=${encodeURIComponent(session.sessionId)}`, {
+          waitUntil: "networkidle",
+        });
+
+        const tabStates = await waitFor(async () => {
+          const current = await readTabStates(page);
+          return current.length === 2 ? current : null;
+        });
+        expect(tabStates.map((tab) => tab.text)).toEqual([
+          "OpenSteer Local Fixture",
+          "Destination",
+        ]);
+        expect(tabStates.map((tab) => tab.active)).toEqual([true, false]);
+        expect(await page.locator("[data-testid='address-input']").inputValue()).toBe(
+          `${fixtureUrl}/viewer`,
+        );
+      } finally {
+        await viewerBrowser.close().catch(() => undefined);
+        await localViewServer?.close().catch(() => undefined);
+        await runtime.close().catch(() => undefined);
+        await rm(rootPath, { recursive: true, force: true }).catch(() => undefined);
+        await rm(stateHome, { recursive: true, force: true }).catch(() => undefined);
+        if (priorOpensteerHome === undefined) {
+          delete process.env.OPENSTEER_HOME;
+        } else {
+          process.env.OPENSTEER_HOME = priorOpensteerHome;
+        }
+      }
+    },
+  );
+
+  test(
+    "places popup tabs next to their opener in the local view",
+    { timeout: 90_000 },
+    async () => {
+      const priorOpensteerHome = process.env.OPENSTEER_HOME;
+      const stateHome = await mkdtemp(path.join(tmpdir(), "opensteer-local-view-popup-order-"));
+      process.env.OPENSTEER_HOME = stateHome;
+      await setLocalViewMode("manual");
+      const rootPath = await mkdtemp(path.join(tmpdir(), "opensteer-local-view-popup-root-"));
+
+      const runtime = new OpensteerSessionRuntime({
+        name: "local-view-popup-order-runtime",
+        rootPath,
+        browser: "temporary",
+        launch: {
+          headless: true,
+        },
+        context: {
+          viewport: {
+            width: 800,
+            height: 600,
+          },
+        },
+      });
+
+      const viewerBrowser = await chromium.launch({ headless: true });
+      let localViewServer: Awaited<ReturnType<typeof startLocalViewServer>> | undefined;
+
+      try {
+        await runtime.open({ url: `${fixtureUrl}/popup-opener` });
+        localViewServer = await startLocalViewServer({
+          token: "local-view-popup-order-token",
+        });
+
+        const session = await waitFor(async () => {
+          const response = await fetch(new URL("/api/sessions", localViewServer.url), {
+            headers: {
+              "x-opensteer-local-token": localViewServer.token,
+            },
+          });
+          if (!response.ok) {
+            return null;
+          }
+          const payload = await response.json();
+          const sessions = Array.isArray(payload?.sessions) ? payload.sessions : [];
+          return sessions.find((candidate) => candidate.rootPath === rootPath) ?? null;
+        });
+
+        const page = await viewerBrowser.newPage({
+          viewport: {
+            width: 1800,
+            height: 900,
+          },
+        });
+        await page.goto(`${localViewServer.url}#session=${encodeURIComponent(session.sessionId)}`, {
+          waitUntil: "networkidle",
+        });
+
+        await page.waitForFunction(() => {
+          const image = document.querySelector("[data-testid='viewer-image']");
+          return image instanceof HTMLImageElement && image.complete && image.naturalWidth > 0;
+        });
+
+        await page.getByTestId("new-tab-button").click();
+        await page.waitForFunction(
+          () => document.querySelectorAll("#tab-strip .tab-button").length === 2,
+        );
+        await page.getByTestId("address-input").fill(`${fixtureUrl}/tab-secondary`);
+        await page.getByTestId("address-input").press("Enter");
+        await waitFor(async () => {
+          const current = await readTabStates(page);
+          return current.at(-1)?.text === "Secondary Tab" ? current : null;
+        });
+
+        await page.locator("#tab-strip .tab-button").first().click();
+        await waitFor(async () => {
+          const current = await readTabStates(page);
+          return current[0]?.active === true ? current : null;
+        });
+
+        await runtime.evaluate({
+          script: `() => {
+            window.open(${JSON.stringify(`${fixtureUrl}/popup-child`)}, "_blank");
+            return true;
+          }`,
+        });
+
+        const popupTabs = await waitFor(async () => {
+          const current = await readTabStates(page);
+          return current.length === 3 ? current : null;
+        });
+        expect(popupTabs.map((tab) => tab.text)).toEqual([
+          "Popup Opener",
+          "Popup Child",
+          "Secondary Tab",
+        ]);
+        expect(popupTabs.map((tab) => tab.active)).toEqual([true, false, false]);
+      } finally {
+        await viewerBrowser.close().catch(() => undefined);
+        await localViewServer?.close().catch(() => undefined);
+        await runtime.close().catch(() => undefined);
+        await rm(rootPath, { recursive: true, force: true }).catch(() => undefined);
+        await rm(stateHome, { recursive: true, force: true }).catch(() => undefined);
+        if (priorOpensteerHome === undefined) {
+          delete process.env.OPENSTEER_HOME;
+        } else {
+          process.env.OPENSTEER_HOME = priorOpensteerHome;
+        }
+      }
+    },
+  );
 });
 
 async function startFixtureServer(): Promise<{
@@ -557,6 +970,79 @@ async function startFixtureServer(): Promise<{
   </head>
   <body>
     <main>Clicked</main>
+  </body>
+</html>`);
+      return;
+    }
+
+    if (url.pathname === "/popup-child") {
+      response.setHeader("content-type", "text/html; charset=utf-8");
+      response.end(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Popup Child</title>
+  </head>
+  <body>
+    <main>Popup Child</main>
+  </body>
+</html>`);
+      return;
+    }
+
+    if (url.pathname === "/tab-secondary") {
+      response.setHeader("content-type", "text/html; charset=utf-8");
+      response.end(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Secondary Tab</title>
+  </head>
+  <body>
+    <main>Secondary Tab</main>
+  </body>
+</html>`);
+      return;
+    }
+
+    if (url.pathname === "/popup-opener") {
+      response.setHeader("content-type", "text/html; charset=utf-8");
+      response.end(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Popup Opener</title>
+    <style>
+      body {
+        margin: 0;
+      }
+      main {
+        width: 800px;
+        min-height: 600px;
+        padding: 48px;
+        box-sizing: border-box;
+      }
+      #open-popup {
+        width: 220px;
+        height: 120px;
+        border: 0;
+        border-radius: 10px;
+        background: #0f766e;
+        color: #ffffff;
+        font-size: 26px;
+        font-weight: 600;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <button id="open-popup" type="button">Open Popup</button>
+    </main>
+    <script>
+      document.getElementById("open-popup").addEventListener("click", () => {
+        window.open("/popup-child", "_blank");
+      });
+    </script>
   </body>
 </html>`);
       return;
@@ -661,6 +1147,23 @@ async function readActiveTabText(page: Page): Promise<string> {
     const activeTab = document.querySelector('#tab-strip .tab-button[data-active="true"]');
     return activeTab?.textContent ?? "";
   });
+}
+
+async function readTabStates(page: Page): Promise<
+  ReadonlyArray<{
+    readonly text: string;
+    readonly active: boolean;
+  }>
+> {
+  return page.evaluate(() =>
+    Array.from(document.querySelectorAll(".chrome-tab-chip")).map((chip) => {
+      const button = chip.querySelector(".tab-button");
+      return {
+        text: button?.textContent ?? "",
+        active: chip instanceof HTMLElement ? chip.dataset.active === "true" : false,
+      };
+    }),
+  );
 }
 
 async function readViewerImageSrc(page: Page): Promise<string> {

--- a/tests/opensteer/runtime-active-page-hint.test.ts
+++ b/tests/opensteer/runtime-active-page-hint.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  open: vi.fn(),
+  newPage: vi.fn(),
+  activatePage: vi.fn(),
+  closePage: vi.fn(),
+  goto: vi.fn(),
+  info: vi.fn(),
+  listPages: vi.fn(),
+  readPersistedLocalBrowserSessionRecord: vi.fn(),
+  writePersistedSessionRecord: vi.fn(),
+  assertSupportedEngineOptions: vi.fn(),
+}));
+
+vi.mock("@opensteer/runtime-core", () => {
+  class MockSharedOpensteerSessionRuntime {
+    readonly rootPath: string;
+
+    constructor(options: { readonly rootPath: string }) {
+      this.rootPath = options.rootPath;
+    }
+
+    async open(input: unknown, options: unknown): Promise<unknown> {
+      return state.open(input, options);
+    }
+
+    async newPage(input: unknown, options: unknown): Promise<unknown> {
+      return state.newPage(input, options);
+    }
+
+    async activatePage(input: unknown, options: unknown): Promise<unknown> {
+      return state.activatePage(input, options);
+    }
+
+    async closePage(input: unknown, options: unknown): Promise<unknown> {
+      return state.closePage(input, options);
+    }
+
+    async goto(input: unknown, options: unknown): Promise<unknown> {
+      return state.goto(input, options);
+    }
+
+    async info(): Promise<unknown> {
+      return state.info();
+    }
+
+    async listPages(): Promise<unknown> {
+      return state.listPages();
+    }
+  }
+
+  return {
+    OpensteerSessionRuntime: MockSharedOpensteerSessionRuntime,
+  };
+});
+
+vi.mock("../../packages/opensteer/src/browser-manager.js", () => ({
+  OpensteerBrowserManager: class MockOpensteerBrowserManager {
+    async createEngine(): Promise<never> {
+      throw new Error("OpensteerBrowserManager.createEngine should not be called in this test.");
+    }
+  },
+}));
+
+vi.mock("../../packages/opensteer/src/internal/engine-selection.js", () => ({
+  DEFAULT_OPENSTEER_ENGINE: "playwright",
+  assertSupportedEngineOptions: state.assertSupportedEngineOptions,
+}));
+
+vi.mock("../../packages/opensteer/src/live-session.js", () => ({
+  readPersistedLocalBrowserSessionRecord: state.readPersistedLocalBrowserSessionRecord,
+  writePersistedSessionRecord: state.writePersistedSessionRecord,
+}));
+
+import {
+  OpensteerRuntime,
+  OpensteerSessionRuntime,
+} from "../../packages/opensteer/src/sdk/runtime.js";
+
+describe("local active page hint persistence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    state.open.mockImplementation(async (input: unknown) => ({
+      kind: "open",
+      input,
+    }));
+    state.newPage.mockImplementation(async (input: unknown) => ({
+      kind: "new-page",
+      input,
+    }));
+    state.activatePage.mockImplementation(async (input: unknown) => ({
+      kind: "activate-page",
+      input,
+    }));
+    state.closePage.mockImplementation(async (input: unknown) => ({
+      kind: "close-page",
+      input,
+    }));
+    state.goto.mockImplementation(async (input: unknown) => ({
+      kind: "goto",
+      input,
+    }));
+    state.info.mockImplementation(async () => ({
+      activePageRef: "page-active",
+    }));
+    state.listPages.mockImplementation(async () => ({
+      pages: [
+        {
+          pageRef: "page-active",
+          url: "https://example.com/active",
+          title: "Active Page",
+        },
+      ],
+    }));
+    state.readPersistedLocalBrowserSessionRecord.mockImplementation(async () => ({
+      layout: "opensteer-session",
+      version: 1,
+      provider: "local",
+      engine: "playwright",
+      pid: 1,
+      startedAt: 10,
+      updatedAt: 20,
+      userDataDir: "/tmp/opensteer-profile",
+    }));
+    state.writePersistedSessionRecord.mockImplementation(async () => undefined);
+  });
+
+  test("OpensteerRuntime keeps successful open results when hint record lookup fails", async () => {
+    state.readPersistedLocalBrowserSessionRecord.mockRejectedValueOnce(
+      new Error("permissions changed"),
+    );
+
+    const runtime = new OpensteerRuntime({
+      rootPath: "/tmp/opensteer-runtime-root",
+    });
+
+    await expect(runtime.open({ url: "https://example.com" })).resolves.toEqual({
+      kind: "open",
+      input: { url: "https://example.com" },
+    });
+    expect(state.writePersistedSessionRecord).not.toHaveBeenCalled();
+    expect(state.info).not.toHaveBeenCalled();
+    expect(state.listPages).not.toHaveBeenCalled();
+  });
+
+  test("OpensteerSessionRuntime keeps successful goto results when hint persistence writes fail", async () => {
+    state.writePersistedSessionRecord.mockRejectedValueOnce(new Error("disk full"));
+
+    const runtime = new OpensteerSessionRuntime({
+      name: "session-runtime",
+      rootPath: "/tmp/opensteer-session-root",
+    });
+
+    await expect(runtime.goto({ url: "https://example.com/next" })).resolves.toEqual({
+      kind: "goto",
+      input: { url: "https://example.com/next" },
+    });
+    expect(state.info).toHaveBeenCalledTimes(1);
+    expect(state.listPages).toHaveBeenCalledTimes(1);
+    expect(state.writePersistedSessionRecord).toHaveBeenCalledWith(
+      "/tmp/opensteer-session-root",
+      expect.objectContaining({
+        provider: "local",
+        activePageRef: "page-active",
+        activePageUrl: "https://example.com/active",
+        activePageTitle: "Active Page",
+      }),
+    );
+  });
+
+  test("still propagates the primary browser operation error", async () => {
+    state.open.mockRejectedValueOnce(new Error("open failed"));
+
+    const runtime = new OpensteerRuntime({
+      rootPath: "/tmp/opensteer-runtime-root",
+    });
+
+    await expect(runtime.open()).rejects.toThrow("open failed");
+    expect(state.readPersistedLocalBrowserSessionRecord).not.toHaveBeenCalled();
+    expect(state.writePersistedSessionRecord).not.toHaveBeenCalled();
+  });
+});

--- a/tests/opensteer/tab-state-tracker.test.ts
+++ b/tests/opensteer/tab-state-tracker.test.ts
@@ -1,0 +1,72 @@
+import type { BrowserContext, Page } from "playwright";
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  readBrowserPageTargetOrder: vi.fn(),
+  readPageTargetId: vi.fn(),
+}));
+
+vi.mock("../../packages/opensteer/src/local-view/browser-target-order.js", () => ({
+  readBrowserPageTargetOrder: state.readBrowserPageTargetOrder,
+  readPageTargetId: state.readPageTargetId,
+}));
+
+import { LocalViewRuntimeState } from "../../packages/opensteer/src/local-view/runtime-state.js";
+import { TabStateTracker } from "../../packages/opensteer/src/local-view/tab-state-tracker.js";
+
+describe("TabStateTracker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.readBrowserPageTargetOrder.mockImplementation(async () => ["page-1"]);
+    state.readPageTargetId.mockImplementation(async () => "page-1");
+  });
+
+  test("does not query browser target order when tracking a single page", async () => {
+    const page = {
+      title: vi.fn(async () => "Single Tab"),
+      url: vi.fn(() => "https://example.com/"),
+      evaluate: vi.fn(async () => ({
+        visibilityState: "visible",
+        hasFocus: true,
+      })),
+      on: vi.fn(),
+      off: vi.fn(),
+    } as unknown as Page;
+
+    const browserContext = {
+      pages: vi.fn(() => [page]),
+      on: vi.fn(),
+      off: vi.fn(),
+    } as unknown as BrowserContext;
+    const onTabsChanged = vi.fn();
+
+    const tracker = new TabStateTracker({
+      browserContext,
+      sessionId: "session-1",
+      pollMs: 10_000,
+      runtimeState: new LocalViewRuntimeState(),
+      initialActivePage: page,
+      onTabsChanged,
+      onActivePageChanged: vi.fn(),
+    });
+
+    tracker.start();
+    await vi.waitFor(() => expect(onTabsChanged).toHaveBeenCalledTimes(1));
+    tracker.stop();
+
+    expect(state.readBrowserPageTargetOrder).not.toHaveBeenCalled();
+    expect(onTabsChanged).toHaveBeenCalledWith({
+      activeTabIndex: 0,
+      tabs: [
+        {
+          index: 0,
+          targetId: "page-1",
+          url: "https://example.com/",
+          title: "Single Tab",
+          active: true,
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Normalize local-view tab ordering from browser target order so attached headless sessions match real browser behavior.
- Persist and restore the active tab hint across open, new-tab, activate, close, and navigation flows.
- Add regressions for attach-order restoration, popup placement, and workspace-runtime persistence.

## Testing
- `pnpm test tests/opensteer/local-view.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm package:check`
- `pnpm skills:check`