### PR TITLE
Fix cloud base URL defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,9 @@
 # Optional Opensteer Cloud configuration.
 OPENSTEER_API_KEY=osk_your_api_key_here
-# Override only when testing against a non-default control plane.
-OPENSTEER_BASE_URL=https://api.opensteer.dev
+# Optional internal override for non-default control planes. Opensteer Cloud defaults to https://api.opensteer.com.
+# OPENSTEER_BASE_URL=
 # Required for `opensteer record --provider cloud` so the CLI can hand you to the browser session UI.
-OPENSTEER_CLOUD_APP_BASE_URL=https://app.opensteer.dev
+# Set this only if your Opensteer team gives you a cloud app URL.
+# OPENSTEER_CLOUD_APP_BASE_URL=
 # Optional local browser override. Prefer setting this in `.env.local` because it is usually machine-specific.
 # OPENSTEER_EXECUTABLE_PATH=/Applications/Google Chrome.app/Contents/MacOS/Google Chrome

--- a/packages/opensteer/src/cloud/client.ts
+++ b/packages/opensteer/src/cloud/client.ts
@@ -371,12 +371,12 @@ function wrapCloudFetchError(
 ): Error {
   if (!(error instanceof Error)) {
     return new Error(
-      `Failed to reach Opensteer cloud endpoint ${input.method} ${input.url}. Check OPENSTEER_BASE_URL and network reachability from this environment.`,
+      `Failed to reach Opensteer cloud endpoint ${input.method} ${input.url}. Check the configured Opensteer cloud base URL and network reachability from this environment.`,
     );
   }
 
   const wrapped = new Error(
-    `Failed to reach Opensteer cloud endpoint ${input.method} ${input.url}. Check OPENSTEER_BASE_URL and network reachability from this environment.`,
+    `Failed to reach Opensteer cloud endpoint ${input.method} ${input.url}. Check the configured Opensteer cloud base URL and network reachability from this environment.`,
     {
       cause: error,
     },

--- a/packages/opensteer/src/cloud/config.ts
+++ b/packages/opensteer/src/cloud/config.ts
@@ -6,6 +6,8 @@ import {
   type OpensteerProviderOptions,
 } from "../provider/config.js";
 
+export const DEFAULT_OPENSTEER_CLOUD_BASE_URL = "https://api.opensteer.com";
+
 export interface OpensteerCloudConfig {
   readonly apiKey: string;
   readonly baseUrl: string;
@@ -33,22 +35,24 @@ export function resolveCloudConfig(
     input.provider?.mode === "cloud"
       ? (input.provider as OpensteerCloudProviderOptions)
       : undefined;
-  const apiKey = cloudProvider?.apiKey ?? input.environment?.OPENSTEER_API_KEY;
-  if (!apiKey || apiKey.trim().length === 0) {
+  const apiKey =
+    normalizeOptionalCloudConfigValue(cloudProvider?.apiKey) ??
+    normalizeOptionalCloudConfigValue(input.environment?.OPENSTEER_API_KEY);
+  if (apiKey === undefined) {
     throw new Error("provider=cloud requires OPENSTEER_API_KEY or provider.apiKey.");
   }
-  const baseUrl = cloudProvider?.baseUrl ?? input.environment?.OPENSTEER_BASE_URL;
-  if (!baseUrl || baseUrl.trim().length === 0) {
-    throw new Error("provider=cloud requires OPENSTEER_BASE_URL or provider.baseUrl.");
-  }
-  const appBaseUrl = cloudProvider?.appBaseUrl ?? input.environment?.OPENSTEER_CLOUD_APP_BASE_URL;
+  const baseUrl =
+    normalizeOptionalCloudConfigValue(cloudProvider?.baseUrl) ??
+    normalizeOptionalCloudConfigValue(input.environment?.OPENSTEER_BASE_URL) ??
+    DEFAULT_OPENSTEER_CLOUD_BASE_URL;
+  const appBaseUrl =
+    normalizeOptionalCloudConfigValue(cloudProvider?.appBaseUrl) ??
+    normalizeOptionalCloudConfigValue(input.environment?.OPENSTEER_CLOUD_APP_BASE_URL);
 
   return {
-    apiKey: apiKey.trim(),
-    baseUrl: baseUrl.trim().replace(/\/+$/, ""),
-    ...(appBaseUrl === undefined || appBaseUrl.trim().length === 0
-      ? {}
-      : { appBaseUrl: appBaseUrl.trim().replace(/\/+$/, "") }),
+    apiKey,
+    baseUrl,
+    ...(appBaseUrl === undefined ? {} : { appBaseUrl }),
     ...(cloudProvider?.browserProfile === undefined
       ? {}
       : { browserProfile: cloudProvider.browserProfile }),
@@ -58,11 +62,20 @@ export function resolveCloudConfig(
 export function requireCloudAppBaseUrl(
   cloudConfig: Pick<OpensteerCloudConfig, "appBaseUrl">,
 ): string {
-  const appBaseUrl = cloudConfig.appBaseUrl;
-  if (!appBaseUrl || appBaseUrl.trim().length === 0) {
+  const appBaseUrl = normalizeOptionalCloudConfigValue(cloudConfig.appBaseUrl);
+  if (appBaseUrl === undefined) {
     throw new Error(
       'record with provider=cloud requires OPENSTEER_CLOUD_APP_BASE_URL or "--cloud-app-base-url".',
     );
   }
-  return appBaseUrl.trim().replace(/\/+$/, "");
+  return appBaseUrl;
+}
+
+function normalizeOptionalCloudConfigValue(value: string | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalized = value.trim().replace(/\/+$/, "");
+  return normalized.length === 0 ? undefined : normalized;
 }

--- a/packages/opensteer/src/index.ts
+++ b/packages/opensteer/src/index.ts
@@ -227,7 +227,7 @@ export type {
 } from "./browser-manager.js";
 export { OpensteerBrowserManager } from "./browser-manager.js";
 export type { OpensteerCloudConfig } from "./cloud/config.js";
-export { resolveCloudConfig } from "./cloud/config.js";
+export { DEFAULT_OPENSTEER_CLOUD_BASE_URL, resolveCloudConfig } from "./cloud/config.js";
 export type {
   BrowserProfileArchiveFormat,
   BrowserProfileCreateRequest,

--- a/packages/runtime-core/src/recorder/codegen.ts
+++ b/packages/runtime-core/src/recorder/codegen.ts
@@ -302,8 +302,8 @@ function renderOpensteerBootstrap(replayTarget: ReplayTarget): string[] {
     `const opensteer = new Opensteer({`,
     `  provider: {`,
     `    mode: "cloud",`,
-    `    baseUrl: requireEnv(${JSON.stringify(replayTarget.baseUrlEnvVar ?? "OPENSTEER_BASE_URL")}),`,
     `    apiKey: requireEnv(${JSON.stringify(replayTarget.apiKeyEnvVar ?? "OPENSTEER_API_KEY")}),`,
+    ...renderCloudBaseUrl(replayTarget),
     ...renderCloudBrowserProfile(replayTarget),
     `  },`,
     `});`,
@@ -311,17 +311,28 @@ function renderOpensteerBootstrap(replayTarget: ReplayTarget): string[] {
 }
 
 function renderRequireEnvHelper(replayTarget: CloudReplayTarget): string {
-  const baseUrlEnvVar = replayTarget.baseUrlEnvVar ?? "OPENSTEER_BASE_URL";
   const apiKeyEnvVar = replayTarget.apiKeyEnvVar ?? "OPENSTEER_API_KEY";
+  const requiredEnvVars = [
+    ...(replayTarget.baseUrlEnvVar === undefined ? [] : [replayTarget.baseUrlEnvVar]),
+    apiKeyEnvVar,
+  ];
   return [
     `function requireEnv(name: string): string {`,
     `  const value = process.env[name];`,
     `  if (typeof value === "string" && value.trim().length > 0) {`,
     `    return value;`,
     `  }`,
-    `  throw new Error(\`Missing environment variable \${name}. Set ${baseUrlEnvVar} and ${apiKeyEnvVar} before replaying this recording.\`);`,
+    `  throw new Error(\`Missing environment variable \${name}. Set ${requiredEnvVars.join(" and ")} before replaying this recording.\`);`,
     `}`,
   ].join("\n");
+}
+
+function renderCloudBaseUrl(replayTarget: CloudReplayTarget): string[] {
+  if (replayTarget.baseUrlEnvVar === undefined) {
+    return [];
+  }
+
+  return [`    baseUrl: requireEnv(${JSON.stringify(replayTarget.baseUrlEnvVar)}),`];
 }
 
 function renderCloudBrowserProfile(replayTarget: CloudReplayTarget): string[] {

--- a/skills/recorder/SKILL.md
+++ b/skills/recorder/SKILL.md
@@ -15,10 +15,10 @@ Verify the CLI is available:
 command -v opensteer >/dev/null 2>&1 && echo "ok" || echo "opensteer not found"
 ```
 
-For cloud recording, verify environment variables are set:
+For cloud recording, verify the required environment variables are set:
 
 ```bash
-test -n "$OPENSTEER_BASE_URL" && test -n "$OPENSTEER_API_KEY" && test -n "$OPENSTEER_CLOUD_APP_BASE_URL" && echo "ok" || echo "missing cloud env vars"
+test -n "$OPENSTEER_API_KEY" && test -n "$OPENSTEER_CLOUD_APP_BASE_URL" && echo "ok" || echo "missing cloud env vars"
 ```
 
 ## Quick Start

--- a/tests/opensteer/cli-v2.test.ts
+++ b/tests/opensteer/cli-v2.test.ts
@@ -337,7 +337,7 @@ describe("Opensteer v2 CLI", () => {
           "--workspace",
           "exec-cloud-overrides",
           "--cloud-base-url",
-          "https://api.opensteer.dev",
+          "https://api.opensteer.com",
           "1",
         ],
         {

--- a/tests/opensteer/cloud-browser-profile.test.ts
+++ b/tests/opensteer/cloud-browser-profile.test.ts
@@ -24,6 +24,7 @@ import {
   CloudSessionProxy,
   readPersistedCloudSessionRecord,
 } from "../../packages/opensteer/src/cloud/session-proxy.js";
+import { DEFAULT_OPENSTEER_CLOUD_BASE_URL } from "../../packages/opensteer/src/cloud/config.js";
 import { OpensteerCloudAutomationClient } from "../../packages/opensteer/src/cloud/automation-client.js";
 import { resolveOpensteerRuntimeConfig } from "../../packages/opensteer/src/sdk/runtime-resolution.js";
 
@@ -42,7 +43,7 @@ afterEach(() => {
 });
 
 const CLOUD_API_KEY = "osk_test";
-const CLOUD_BASE_URL = "https://api.opensteer.dev";
+const CLOUD_BASE_URL = DEFAULT_OPENSTEER_CLOUD_BASE_URL;
 const CLOUD_WORKSPACE = "cloud-workspace";
 const EXAMPLE_URL = "https://example.com";
 
@@ -143,7 +144,6 @@ describe("cloud browser-profile integration", () => {
   test("resolves cloud runtime config with a default browser profile preference", () => {
     vi.stubEnv("OPENSTEER_PROVIDER", "cloud");
     vi.stubEnv("OPENSTEER_API_KEY", "osk_test");
-    vi.stubEnv("OPENSTEER_BASE_URL", "https://api.opensteer.dev");
 
     expect(
       resolveOpensteerRuntimeConfig({
@@ -162,7 +162,7 @@ describe("cloud browser-profile integration", () => {
       },
       cloud: {
         apiKey: "osk_test",
-        baseUrl: "https://api.opensteer.dev",
+        baseUrl: DEFAULT_OPENSTEER_CLOUD_BASE_URL,
         browserProfile: {
           profileId: "bp_123",
           reuseIfActive: true,
@@ -183,7 +183,7 @@ describe("cloud browser-profile integration", () => {
 
     const client = new OpensteerCloudClient({
       apiKey: "osk_test",
-      baseUrl: "https://api.opensteer.dev",
+      baseUrl: "https://api.opensteer.com",
       browserProfile: {
         profileId: "bp_default",
       },
@@ -198,7 +198,7 @@ describe("cloud browser-profile integration", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.opensteer.dev/v1/sessions",
+      "https://api.opensteer.com/v1/sessions",
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({
@@ -226,7 +226,7 @@ describe("cloud browser-profile integration", () => {
 
     const client = new OpensteerCloudClient({
       apiKey: "osk_test",
-      baseUrl: "https://api.opensteer.dev",
+      baseUrl: "https://api.opensteer.com",
     });
 
     await client.importDescriptors([
@@ -247,7 +247,7 @@ describe("cloud browser-profile integration", () => {
 
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
-      "https://api.opensteer.dev/registry/descriptors/import",
+      "https://api.opensteer.com/registry/descriptors/import",
       expect.objectContaining({
         method: "POST",
       }),
@@ -268,7 +268,7 @@ describe("cloud browser-profile integration", () => {
 
     const client = new OpensteerCloudClient({
       apiKey: "osk_test",
-      baseUrl: "https://api.opensteer.dev",
+      baseUrl: "https://api.opensteer.com",
     });
 
     await client.importRequestPlans({
@@ -297,7 +297,7 @@ describe("cloud browser-profile integration", () => {
 
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
-      "https://api.opensteer.dev/registry/request-plans/import",
+      "https://api.opensteer.com/registry/request-plans/import",
       expect.objectContaining({
         method: "POST",
       }),
@@ -379,7 +379,7 @@ describe("cloud browser-profile integration", () => {
 
     const client = new OpensteerCloudClient({
       apiKey: "osk_test",
-      baseUrl: "https://api.opensteer.dev",
+      baseUrl: "https://api.opensteer.com",
     });
 
     const result = await client.syncBrowserProfileCookies({
@@ -395,7 +395,7 @@ describe("cloud browser-profile integration", () => {
     expect(readBrowserCookiesMock).toHaveBeenCalledWith({});
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
-      "https://api.opensteer.dev/v1/browser-profiles/imports",
+      "https://api.opensteer.com/v1/browser-profiles/imports",
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({
@@ -935,7 +935,7 @@ describe("cloud browser-profile integration", () => {
       });
 
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
-      if (url === "https://api.opensteer.dev/v1/sessions" && init?.method === "POST") {
+      if (url === "https://api.opensteer.com/v1/sessions" && init?.method === "POST") {
         createSessionCalls += 1;
         events.push(`create-session-${createSessionCalls}`);
         return {
@@ -955,7 +955,7 @@ describe("cloud browser-profile integration", () => {
     const proxy = new CloudSessionProxy(
       new OpensteerCloudClient({
         apiKey: "osk_test",
-        baseUrl: "https://api.opensteer.dev",
+        baseUrl: "https://api.opensteer.com",
       }),
     );
 
@@ -999,7 +999,7 @@ describe("cloud browser-profile integration", () => {
       });
 
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
-      if (url === "https://api.opensteer.dev/v1/sessions" && init?.method === "POST") {
+      if (url === "https://api.opensteer.com/v1/sessions" && init?.method === "POST") {
         createSessionCalls += 1;
         events.push(`create-session-${createSessionCalls}`);
         return {
@@ -1019,7 +1019,7 @@ describe("cloud browser-profile integration", () => {
     const proxy = new CloudSessionProxy(
       new OpensteerCloudClient({
         apiKey: "osk_test",
-        baseUrl: "https://api.opensteer.dev",
+        baseUrl: "https://api.opensteer.com",
       }),
     );
 
@@ -1077,7 +1077,7 @@ describe("cloud browser-profile integration", () => {
       });
 
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
-      if (url === "https://api.opensteer.dev/v1/sessions" && init?.method === "POST") {
+      if (url === "https://api.opensteer.com/v1/sessions" && init?.method === "POST") {
         createSessionCalls += 1;
         events.push(`create-session-${createSessionCalls}`);
         if (createSessionCalls === 1) {
@@ -1108,7 +1108,7 @@ describe("cloud browser-profile integration", () => {
       }
 
       if (
-        url === "https://api.opensteer.dev/v1/sessions/session_123/access" &&
+        url === "https://api.opensteer.com/v1/sessions/session_123/access" &&
         init?.method === "POST"
       ) {
         staleAccessCalls += 1;
@@ -1149,7 +1149,7 @@ describe("cloud browser-profile integration", () => {
     const proxy = new CloudSessionProxy(
       new OpensteerCloudClient({
         apiKey: "osk_test",
-        baseUrl: "https://api.opensteer.dev",
+        baseUrl: "https://api.opensteer.com",
       }),
     );
 
@@ -1191,7 +1191,7 @@ describe("cloud browser-profile integration", () => {
     };
 
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
-      if (url === "https://api.opensteer.dev/v1/sessions" && init?.method === "POST") {
+      if (url === "https://api.opensteer.com/v1/sessions" && init?.method === "POST") {
         return {
           ok: true,
           json: async () => ({
@@ -1231,7 +1231,7 @@ describe("cloud browser-profile integration", () => {
       const proxy = new CloudSessionProxy(
         new OpensteerCloudClient({
           apiKey: "osk_test",
-          baseUrl: "https://api.opensteer.dev",
+          baseUrl: "https://api.opensteer.com",
         }),
         {
           rootDir,
@@ -1262,7 +1262,7 @@ describe("cloud browser-profile integration", () => {
     };
 
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
-      if (url === "https://api.opensteer.dev/v1/sessions" && init?.method === "POST") {
+      if (url === "https://api.opensteer.com/v1/sessions" && init?.method === "POST") {
         return {
           ok: true,
           json: async () => ({
@@ -1276,7 +1276,7 @@ describe("cloud browser-profile integration", () => {
         };
       }
 
-      if (url === "https://api.opensteer.dev/v1/sessions/session_123" && init?.method === "GET") {
+      if (url === "https://api.opensteer.com/v1/sessions/session_123" && init?.method === "GET") {
         return {
           ok: true,
           json: async () => ({
@@ -1286,7 +1286,7 @@ describe("cloud browser-profile integration", () => {
       }
 
       if (
-        url === "https://api.opensteer.dev/v1/sessions/session_123/access" &&
+        url === "https://api.opensteer.com/v1/sessions/session_123/access" &&
         init?.method === "POST"
       ) {
         return {
@@ -1326,7 +1326,7 @@ describe("cloud browser-profile integration", () => {
     try {
       const client = new OpensteerCloudClient({
         apiKey: "osk_test",
-        baseUrl: "https://api.opensteer.dev",
+        baseUrl: "https://api.opensteer.com",
       });
 
       syncLocalWorkspaceToCloudMock.mockResolvedValueOnce(undefined);
@@ -1366,7 +1366,7 @@ describe("cloud browser-profile integration", () => {
     let accessCalls = 0;
 
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
-      if (url === "https://api.opensteer.dev/v1/sessions" && init?.method === "POST") {
+      if (url === "https://api.opensteer.com/v1/sessions" && init?.method === "POST") {
         return {
           ok: true,
           json: async () => ({
@@ -1381,7 +1381,7 @@ describe("cloud browser-profile integration", () => {
       }
 
       if (
-        url === "https://api.opensteer.dev/v1/sessions/session_123/access" &&
+        url === "https://api.opensteer.com/v1/sessions/session_123/access" &&
         init?.method === "POST"
       ) {
         accessCalls += 1;
@@ -1421,7 +1421,7 @@ describe("cloud browser-profile integration", () => {
     const proxy = new CloudSessionProxy(
       new OpensteerCloudClient({
         apiKey: "osk_test",
-        baseUrl: "https://api.opensteer.dev",
+        baseUrl: "https://api.opensteer.com",
       }),
     );
 
@@ -1451,7 +1451,7 @@ describe("cloud browser-profile integration", () => {
     const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
 
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
-      if (url === "https://api.opensteer.dev/v1/sessions" && init?.method === "POST") {
+      if (url === "https://api.opensteer.com/v1/sessions" && init?.method === "POST") {
         return {
           ok: true,
           json: async () => ({
@@ -1495,7 +1495,7 @@ describe("cloud browser-profile integration", () => {
     const proxy = new CloudSessionProxy(
       new OpensteerCloudClient({
         apiKey: "osk_test",
-        baseUrl: "https://api.opensteer.dev",
+        baseUrl: "https://api.opensteer.com",
       }),
       {
         policy: {
@@ -1542,7 +1542,7 @@ describe("cloud browser-profile integration", () => {
     const proxy = new CloudSessionProxy(
       new OpensteerCloudClient({
         apiKey: "osk_test",
-        baseUrl: "https://api.opensteer.dev",
+        baseUrl: "https://api.opensteer.com",
       }),
     );
 

--- a/tests/opensteer/provider-selection.test.ts
+++ b/tests/opensteer/provider-selection.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import { afterEach, describe, expect, test, vi } from "vitest";
 
+import { DEFAULT_OPENSTEER_CLOUD_BASE_URL } from "../../packages/opensteer/src/cloud/config.js";
 import { CloudSessionProxy } from "../../packages/opensteer/src/cloud/session-proxy.js";
 import { resolveFilesystemWorkspacePath } from "../../packages/opensteer/src/root.js";
 import {
@@ -38,7 +39,7 @@ describe("provider selection", () => {
     });
   });
 
-  test("cloud provider requires both api key and base url", () => {
+  test("cloud provider requires an api key and falls back to the default base URL", () => {
     expect(() =>
       resolveOpensteerRuntimeConfig({
         provider: {
@@ -48,14 +49,24 @@ describe("provider selection", () => {
     ).toThrow("provider=cloud requires OPENSTEER_API_KEY or provider.apiKey.");
 
     vi.stubEnv("OPENSTEER_API_KEY", "osk_test");
+    vi.stubEnv("OPENSTEER_BASE_URL", "   ");
 
-    expect(() =>
+    expect(
       resolveOpensteerRuntimeConfig({
         provider: {
           mode: "cloud",
         },
       }),
-    ).toThrow("provider=cloud requires OPENSTEER_BASE_URL or provider.baseUrl.");
+    ).toEqual({
+      provider: {
+        mode: "cloud",
+        source: "explicit",
+      },
+      cloud: {
+        apiKey: "osk_test",
+        baseUrl: DEFAULT_OPENSTEER_CLOUD_BASE_URL,
+      },
+    });
   });
 
   test("existing local lane does not force local execution when provider resolves to cloud", async () => {

--- a/tests/opensteer/recorder-cli.test.ts
+++ b/tests/opensteer/recorder-cli.test.ts
@@ -73,7 +73,7 @@ describe("recorder CLI", () => {
 
     await expect(execution).rejects.toMatchObject({
       stderr: expect.stringContaining(
-        "provider=cloud requires OPENSTEER_BASE_URL or provider.baseUrl.",
+        "record with provider=cloud requires OPENSTEER_CLOUD_APP_BASE_URL",
       ),
     });
   }, 60_000);
@@ -112,7 +112,7 @@ describe("recorder CLI", () => {
 
     await expect(execution).rejects.toMatchObject({
       stderr: expect.stringContaining(
-        "provider=cloud requires OPENSTEER_BASE_URL or provider.baseUrl.",
+        "record with provider=cloud requires OPENSTEER_CLOUD_APP_BASE_URL",
       ),
     });
   }, 60_000);
@@ -133,8 +133,6 @@ describe("recorder CLI", () => {
         "https://example.com",
         "--cloud-api-key",
         "test-api-key",
-        "--cloud-base-url",
-        "https://api.opensteer.dev",
       ],
       {
         cwd: process.cwd(),

--- a/tests/opensteer/recorder-codegen.test.ts
+++ b/tests/opensteer/recorder-codegen.test.ts
@@ -177,7 +177,7 @@ describe("recorder codegen", () => {
     expect(script).toContain(`await opensteer.close();`);
   });
 
-  test("generates cloud replay bootstrap with env-backed provider config", () => {
+  test("generates cloud replay bootstrap with the default cloud base URL", () => {
     const script = generateReplayScript({
       actions: [],
       initialPages: [
@@ -194,10 +194,28 @@ describe("recorder codegen", () => {
     });
 
     expect(script).toContain(`mode: "cloud"`);
-    expect(script).toContain(`baseUrl: requireEnv("OPENSTEER_BASE_URL")`);
     expect(script).toContain(`apiKey: requireEnv("OPENSTEER_API_KEY")`);
+    expect(script).not.toContain(`baseUrl: requireEnv("OPENSTEER_BASE_URL")`);
     expect(script).toContain(`profileId: "bp_123"`);
     expect(script).toContain(`reuseIfActive: true`);
+  });
+
+  test("supports env-backed cloud base URL overrides for replay bootstrap", () => {
+    const script = generateReplayScript({
+      actions: [],
+      startUrl: "https://example.com",
+      replayTarget: {
+        kind: "cloud",
+        baseUrlEnvVar: "OPENSTEER_BASE_URL",
+        apiKeyEnvVar: "OPENSTEER_API_KEY",
+      },
+    });
+
+    expect(script).toContain(`baseUrl: requireEnv("OPENSTEER_BASE_URL")`);
+    expect(script).toContain(`apiKey: requireEnv("OPENSTEER_API_KEY")`);
+    expect(script).toContain(
+      `Missing environment variable \${name}. Set OPENSTEER_BASE_URL and OPENSTEER_API_KEY before replaying this recording.`,
+    );
   });
 
   test("bootstraps pre-existing cloud tabs before replaying actions", () => {

--- a/tests/opensteer/status.test.ts
+++ b/tests/opensteer/status.test.ts
@@ -9,6 +9,7 @@ import {
   collectOpensteerStatus,
   renderOpensteerStatus,
 } from "../../packages/opensteer/src/cli/status.js";
+import { DEFAULT_OPENSTEER_CLOUD_BASE_URL } from "../../packages/opensteer/src/cloud/config.js";
 import { OpensteerCloudClient } from "../../packages/opensteer/src/cloud/client.js";
 import { resolveFilesystemWorkspacePath } from "../../packages/opensteer/src/root.js";
 import { writePersistedSessionRecord } from "../../packages/opensteer/src/live-session.js";
@@ -62,7 +63,7 @@ describe("opensteer status", () => {
         },
         cloudConfig: {
           apiKey: "osk_test",
-          baseUrl: "https://api.opensteer.dev",
+          baseUrl: DEFAULT_OPENSTEER_CLOUD_BASE_URL,
         },
       });
 
@@ -87,7 +88,7 @@ describe("opensteer status", () => {
             status: "connected",
             current: true,
             sessionId: "session_123",
-            baseUrl: "https://api.opensteer.dev",
+            baseUrl: DEFAULT_OPENSTEER_CLOUD_BASE_URL,
           },
         },
       });
@@ -95,7 +96,7 @@ describe("opensteer status", () => {
       const rendered = renderOpensteerStatus(status);
       expect(rendered).toContain("Provider resolution");
       expect(rendered).toContain("current: cloud");
-      expect(rendered).toMatch(/session_123\s+https:\/\/api\.opensteer\.dev/u);
+      expect(rendered).toMatch(/session_123\s+https:\/\/api\.opensteer\.com/u);
       expect(rendered).toMatch(/\* cloud\s+connected/u);
       expect(rendered).toMatch(/\s local\s+active/u);
     } finally {


### PR DESCRIPTION
## Summary
- Add a root default cloud control-plane URL of `https://api.opensteer.com`
- Keep `OPENSTEER_BASE_URL` and `provider.baseUrl` as overrides, with blank values falling back to the default
- Remove stale `api.opensteer.dev` examples and align recorder codegen and docs with the new default

## Testing
- `pnpm vitest --run tests/opensteer/provider-selection.test.ts tests/opensteer/cloud-browser-profile.test.ts tests/opensteer/recorder-codegen.test.ts tests/opensteer/recorder-cli.test.ts tests/opensteer/status.test.ts tests/opensteer/cli-v2.test.ts`
- `pnpm vitest run --config vitest.unit.config.ts tests/engine-playwright/playwright-engine.test.ts`
- `pnpm vitest run --config vitest.unit.config.ts tests/opensteer/sdk-surface.test.ts tests/opensteer/env-loader.test.ts tests/opensteer/runtime-resolution.test.ts tests/opensteer/record-command.test.ts tests/opensteer/cli-surface.test.ts`
- `pnpm build`
- `pnpm package:check`
- `pnpm skills:check`