### PR TITLE
Add scoped observation session IDs

### DIFF
--- a/packages/browser-core/src/metadata.ts
+++ b/packages/browser-core/src/metadata.ts
@@ -5,6 +5,7 @@ export type PageLifecycleState = "opening" | "open" | "closing" | "closed" | "cr
 export interface PageInfo {
   readonly pageRef: PageRef;
   readonly sessionRef: SessionRef;
+  readonly targetId?: string;
   readonly openerPageRef?: PageRef;
   readonly url: string;
   readonly title: string;

--- a/packages/engine-playwright/src/browser-fetch.ts
+++ b/packages/engine-playwright/src/browser-fetch.ts
@@ -99,13 +99,17 @@ export async function executeBrowserFetch(
       }
 
       try {
+        const requestBody =
+          inp.bodyBase64 === undefined
+            ? undefined
+            : new Uint8Array(decodeBase64(inp.bodyBase64));
         const response = await fetch(inp.url, {
           method: inp.method,
           headers,
           credentials: "include",
           redirect: inp.followRedirects ? "follow" : "manual",
           signal: controller.signal,
-          ...(inp.bodyBase64 === undefined ? {} : { body: decodeBase64(inp.bodyBase64) }),
+          ...(requestBody === undefined ? {} : { body: requestBody }),
         });
 
         const body = new Uint8Array(await response.arrayBuffer());

--- a/packages/engine-playwright/src/browser-fetch.ts
+++ b/packages/engine-playwright/src/browser-fetch.ts
@@ -99,10 +99,7 @@ export async function executeBrowserFetch(
       }
 
       try {
-        const requestBody =
-          inp.bodyBase64 === undefined
-            ? undefined
-            : new Uint8Array(decodeBase64(inp.bodyBase64));
+        const requestBody = inp.bodyBase64 === undefined ? undefined : decodeBase64(inp.bodyBase64);
         const response = await fetch(inp.url, {
           method: inp.method,
           headers,

--- a/packages/engine-playwright/src/engine.ts
+++ b/packages/engine-playwright/src/engine.ts
@@ -1982,6 +1982,7 @@ export class PlaywrightBrowserCoreEngine implements BrowserCoreEngine {
     const controller: PageController = {
       pageRef,
       sessionRef: session.sessionRef,
+      targetId: undefined,
       page,
       cdp,
       externallyOwned,
@@ -2016,6 +2017,7 @@ export class PlaywrightBrowserCoreEngine implements BrowserCoreEngine {
     await cdp.send("DOM.enable", { includeWhitespace: "none" });
     await cdp.send("DOMStorage.enable");
     await cdp.send("DOM.getDocument", { depth: 0 });
+    controller.targetId = await this.readTargetId(cdp);
     await this.installRuntimeEventRecorder(page);
     await this.actionSettler.installTracker(controller);
 
@@ -2950,6 +2952,7 @@ export class PlaywrightBrowserCoreEngine implements BrowserCoreEngine {
     return {
       pageRef: controller.pageRef,
       sessionRef: controller.sessionRef,
+      ...(controller.targetId === undefined ? {} : { targetId: controller.targetId }),
       ...(controller.openerPageRef === undefined
         ? {}
         : { openerPageRef: controller.openerPageRef }),
@@ -2957,6 +2960,22 @@ export class PlaywrightBrowserCoreEngine implements BrowserCoreEngine {
       title: controller.lastKnownTitle,
       lifecycleState: controller.lifecycleState,
     };
+  }
+
+  private async readTargetId(cdp: CDPSession): Promise<string | undefined> {
+    try {
+      const result = (await cdp.send("Target.getTargetInfo")) as
+        | {
+            targetInfo?: {
+              targetId?: unknown;
+            };
+          }
+        | undefined;
+      const targetId = result?.targetInfo?.targetId;
+      return typeof targetId === "string" && targetId.length > 0 ? targetId : undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   private buildFrameInfo(frame: FrameState): FrameInfo {

--- a/packages/engine-playwright/src/types.ts
+++ b/packages/engine-playwright/src/types.ts
@@ -40,6 +40,7 @@ export interface PendingPageRegistration {
 export interface PageController {
   readonly pageRef: PageRef;
   readonly sessionRef: SessionRef;
+  targetId: string | undefined;
   readonly page: Page;
   readonly cdp: CDPSession;
   readonly externallyOwned: boolean;

--- a/packages/protocol/src/metadata.ts
+++ b/packages/protocol/src/metadata.ts
@@ -20,6 +20,9 @@ export const pageInfoSchema: JsonSchema = objectSchema(
   {
     pageRef: pageRefSchema,
     sessionRef: sessionRefSchema,
+    targetId: stringSchema({
+      description: "Underlying browser target identifier when available.",
+    }),
     openerPageRef: pageRefSchema,
     url: stringSchema({
       description: "Current main-frame URL.",

--- a/packages/protocol/src/observability.ts
+++ b/packages/protocol/src/observability.ts
@@ -137,6 +137,11 @@ export interface OpenObservationSessionInput {
   readonly config?: Partial<ObservabilityConfig>;
 }
 
+export interface ConfigureObservationSessionInput {
+  readonly updatedAt?: number;
+  readonly config?: Partial<ObservabilityConfig>;
+}
+
 export interface AppendObservationEventInput {
   readonly eventId?: string;
   readonly kind: ObservationEventKind;
@@ -167,6 +172,7 @@ export interface WriteObservationArtifactInput {
 export interface SessionObservationSink {
   readonly sessionId: string;
 
+  configure?(input: ConfigureObservationSessionInput): Promise<void>;
   append(input: AppendObservationEventInput): Promise<ObservationEvent>;
   appendBatch(input: readonly AppendObservationEventInput[]): Promise<readonly ObservationEvent[]>;
   writeArtifact(input: WriteObservationArtifactInput): Promise<ObservationArtifact>;

--- a/packages/runtime-core/src/observations.ts
+++ b/packages/runtime-core/src/observations.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 
 import type {
   AppendObservationEventInput,
+  ConfigureObservationSessionInput,
   ObservationArtifact,
   ObservationEvent,
   ObservationSession,
@@ -141,6 +142,10 @@ class FilesystemSessionSink implements SessionObservationSink {
     readonly sessionId: string,
   ) {}
 
+  configure(input: ConfigureObservationSessionInput): Promise<void> {
+    return this.store.configureSession(this.sessionId, input);
+  }
+
   append(input: AppendObservationEventInput): Promise<ObservationEvent> {
     return this.store.appendEvent(this.sessionId, input);
   }
@@ -179,42 +184,18 @@ class FilesystemObservationStoreImpl implements FilesystemObservationStore {
     const sessionId = normalizeNonEmptyString("sessionId", input.sessionId);
     const openedAt = normalizeTimestamp("openedAt", input.openedAt ?? Date.now());
     const config = normalizeObservabilityConfig(input.config);
-    const redactor = createObservationRedactor(config);
-    this.redactors.set(sessionId, redactor);
-    const redactedLabels = redactor.redactLabels(config.labels);
-    const redactedTraceContext = redactor.redactTraceContext(config.traceContext);
-
-    await withFilesystemLock(this.sessionLockPath(sessionId), async () => {
-      const existing = await this.reconcileSessionManifest(sessionId);
-      if (existing === undefined) {
-        await ensureDirectory(this.sessionEventsDirectory(sessionId));
-        await ensureDirectory(this.sessionArtifactsDirectory(sessionId));
-        const session: ObservationSession = {
-          sessionId,
-          profile: config.profile,
-          ...(redactedLabels === undefined ? {} : { labels: redactedLabels }),
-          ...(redactedTraceContext === undefined ? {} : { traceContext: redactedTraceContext }),
-          openedAt,
-          updatedAt: openedAt,
-          currentSequence: 0,
-          eventCount: 0,
-          artifactCount: 0,
-        };
-        await writeJsonFileExclusive(this.sessionManifestPath(sessionId), session);
-        return;
-      }
-
-      const patched: ObservationSession = {
-        ...existing,
-        profile: config.profile,
-        ...(redactedLabels === undefined ? {} : { labels: redactedLabels }),
-        ...(redactedTraceContext === undefined ? {} : { traceContext: redactedTraceContext }),
-        updatedAt: Math.max(existing.updatedAt, openedAt),
-      };
-      await writeJsonFileAtomic(this.sessionManifestPath(sessionId), patched);
-    });
+    await this.applySessionConfiguration(sessionId, config, openedAt);
 
     return new FilesystemSessionSink(this, sessionId);
+  }
+
+  async configureSession(
+    sessionId: string,
+    input: ConfigureObservationSessionInput,
+  ): Promise<void> {
+    const updatedAt = normalizeTimestamp("updatedAt", input.updatedAt ?? Date.now());
+    const config = normalizeObservabilityConfig(input.config);
+    await this.applySessionConfiguration(sessionId, config, updatedAt);
   }
 
   async getSession(sessionId: string): Promise<ObservationSession | undefined> {
@@ -510,6 +491,47 @@ class FilesystemObservationStoreImpl implements FilesystemObservationStore {
 
   private sessionLockPath(sessionId: string): string {
     return path.join(this.sessionDirectory(sessionId), ".lock");
+  }
+
+  private async applySessionConfiguration(
+    sessionId: string,
+    config: NormalizedObservabilityConfig,
+    timestamp: number,
+  ): Promise<void> {
+    const redactor = createObservationRedactor(config);
+    this.redactors.set(sessionId, redactor);
+    const redactedLabels = redactor.redactLabels(config.labels);
+    const redactedTraceContext = redactor.redactTraceContext(config.traceContext);
+
+    await withFilesystemLock(this.sessionLockPath(sessionId), async () => {
+      const existing = await this.reconcileSessionManifest(sessionId);
+      if (existing === undefined) {
+        await ensureDirectory(this.sessionEventsDirectory(sessionId));
+        await ensureDirectory(this.sessionArtifactsDirectory(sessionId));
+        const session: ObservationSession = {
+          sessionId,
+          profile: config.profile,
+          ...(redactedLabels === undefined ? {} : { labels: redactedLabels }),
+          ...(redactedTraceContext === undefined ? {} : { traceContext: redactedTraceContext }),
+          openedAt: timestamp,
+          updatedAt: timestamp,
+          currentSequence: 0,
+          eventCount: 0,
+          artifactCount: 0,
+        };
+        await writeJsonFileExclusive(this.sessionManifestPath(sessionId), session);
+        return;
+      }
+
+      const patched: ObservationSession = {
+        ...existing,
+        profile: config.profile,
+        ...(redactedLabels === undefined ? {} : { labels: redactedLabels }),
+        ...(redactedTraceContext === undefined ? {} : { traceContext: redactedTraceContext }),
+        updatedAt: Math.max(existing.updatedAt, timestamp),
+      };
+      await writeJsonFileAtomic(this.sessionManifestPath(sessionId), patched);
+    });
   }
 
   private async reconcileSessionManifest(

--- a/packages/runtime-core/src/sdk/runtime.observation.test.ts
+++ b/packages/runtime-core/src/sdk/runtime.observation.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { OpensteerSessionRuntime } from "./runtime.js";
+
+test("OpensteerSessionRuntime uses the scoped observation session id when provided", async () => {
+    const openedSessionIds: string[] = [];
+    const runtime = new OpensteerSessionRuntime({
+      name: "observation-test",
+      engine: {} as never,
+      observationSessionId: "root-session",
+      observability: {
+        profile: "baseline",
+      },
+      observationSink: {
+        async openSession(input: { sessionId: string }) {
+          openedSessionIds.push(input.sessionId);
+          return {
+            async appendEvents() {
+              return [];
+            },
+            async appendArtifacts() {
+              return [];
+            },
+            async close() {},
+          } as never;
+        },
+      } as never,
+    });
+
+    await runtime.withObservationSessionId("controller-session", async () => {
+      await runtime.setObservabilityConfig({
+        profile: "diagnostic",
+      });
+    });
+
+    assert.deepEqual(openedSessionIds, ["controller-session"]);
+});
+
+test("OpensteerSessionRuntime falls back to the fixed observation session id when no override is active", async () => {
+    const openedSessionIds: string[] = [];
+    const runtime = new OpensteerSessionRuntime({
+      name: "observation-test",
+      engine: {} as never,
+      observationSessionId: "root-session",
+      observability: {
+        profile: "baseline",
+      },
+      observationSink: {
+        async openSession(input: { sessionId: string }) {
+          openedSessionIds.push(input.sessionId);
+          return {
+            async appendEvents() {
+              return [];
+            },
+            async appendArtifacts() {
+              return [];
+            },
+            async close() {},
+          } as never;
+        },
+      } as never,
+    });
+
+    await runtime.setObservabilityConfig({
+      profile: "diagnostic",
+    });
+
+    assert.deepEqual(openedSessionIds, ["root-session"]);
+});

--- a/packages/runtime-core/src/sdk/runtime.observation.test.ts
+++ b/packages/runtime-core/src/sdk/runtime.observation.test.ts
@@ -1,16 +1,41 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { ObservationSink, SessionObservationSink } from "@opensteer/protocol";
+import type {
+  ConfigureObservationSessionInput,
+  ObservationSink,
+  SessionObservationSink,
+} from "@opensteer/protocol";
 import { OpensteerSessionRuntime } from "./runtime.js";
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return {
+    promise,
+    resolve,
+    reject,
+  };
+}
 
 function createObservationRuntime() {
   const openedSessionIds: string[] = [];
   const closedSessionIds: string[] = [];
+  const configuredSessions: Array<{ sessionId: string; profile: string | undefined }> = [];
   const observationSink = {
     async openSession(input: { sessionId: string }) {
       openedSessionIds.push(input.sessionId);
       return {
         sessionId: input.sessionId,
+        async configure(nextInput: ConfigureObservationSessionInput) {
+          configuredSessions.push({
+            sessionId: input.sessionId,
+            profile: nextInput.config?.profile,
+          });
+        },
         async append(): Promise<never> {
           throw new Error("append should not be called in observation session tests");
         },
@@ -41,6 +66,7 @@ function createObservationRuntime() {
     runtime,
     openedSessionIds,
     closedSessionIds,
+    configuredSessions,
   };
 }
 
@@ -71,6 +97,38 @@ test("OpensteerSessionRuntime falls back to the fixed observation session id whe
   });
 
   assert.deepEqual(openedSessionIds, ["root-session"]);
+});
+
+test("OpensteerSessionRuntime reconfigures an open observation session without reopening it", async () => {
+  const { runtime, openedSessionIds, configuredSessions, closedSessionIds } =
+    createObservationRuntime();
+
+  await runtime.setObservabilityConfig({
+    profile: "baseline",
+  });
+  await runtime.setObservabilityConfig({
+    profile: "diagnostic",
+  });
+  await runtime.close();
+
+  assert.deepEqual(openedSessionIds, ["root-session"]);
+  assert.deepEqual(configuredSessions, [
+    {
+      sessionId: "root-session",
+      profile: "diagnostic",
+    },
+  ]);
+  assert.deepEqual(closedSessionIds, ["root-session"]);
+});
+
+test("OpensteerSessionRuntime does not open an observation session when observability is off", async () => {
+  const { runtime, openedSessionIds } = createObservationRuntime();
+
+  await runtime.setObservabilityConfig({
+    profile: "off",
+  });
+
+  assert.deepEqual(openedSessionIds, []);
 });
 
 test("OpensteerSessionRuntime resolves scoped observation sessions even after the root session was opened", async () => {
@@ -140,4 +198,51 @@ test("OpensteerSessionRuntime closes every observation session opened during its
   await runtime.close();
 
   assert.deepEqual(closedSessionIds.sort(), ["controller-session", "root-session"]);
+});
+
+test("OpensteerSessionRuntime deduplicates concurrent observation session opens", async () => {
+  const openStarted = createDeferred<void>();
+  const releaseOpen = createDeferred<void>();
+  const openedSessionIds: string[] = [];
+  const observationSink = {
+    async openSession(input: { sessionId: string }) {
+      openedSessionIds.push(input.sessionId);
+      openStarted.resolve();
+      await releaseOpen.promise;
+      return {
+        sessionId: input.sessionId,
+        async append(): Promise<never> {
+          throw new Error("append should not be called in observation session tests");
+        },
+        async appendBatch() {
+          return [];
+        },
+        async writeArtifact(): Promise<never> {
+          throw new Error("writeArtifact should not be called in observation session tests");
+        },
+        async flush() {},
+        async close() {},
+      } satisfies SessionObservationSink;
+    },
+  } satisfies ObservationSink;
+  const runtime = new OpensteerSessionRuntime({
+    name: "observation-test",
+    engine: {} as never,
+    observationSessionId: "root-session",
+    observability: {
+      profile: "baseline",
+    },
+    observationSink,
+  });
+
+  const firstObservationSession = ensureObservationSession(runtime);
+  await openStarted.promise;
+  const secondObservationSession = ensureObservationSession(runtime);
+  releaseOpen.resolve();
+
+  const [first, second] = await Promise.all([firstObservationSession, secondObservationSession]);
+
+  assert.equal(first?.sessionId, "root-session");
+  assert.equal(second?.sessionId, "root-session");
+  assert.deepEqual(openedSessionIds, ["root-session"]);
 });

--- a/packages/runtime-core/src/sdk/runtime.observation.test.ts
+++ b/packages/runtime-core/src/sdk/runtime.observation.test.ts
@@ -1,69 +1,143 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { ObservationSink, SessionObservationSink } from "@opensteer/protocol";
 import { OpensteerSessionRuntime } from "./runtime.js";
 
+function createObservationRuntime() {
+  const openedSessionIds: string[] = [];
+  const closedSessionIds: string[] = [];
+  const observationSink = {
+    async openSession(input: { sessionId: string }) {
+      openedSessionIds.push(input.sessionId);
+      return {
+        sessionId: input.sessionId,
+        async append(): Promise<never> {
+          throw new Error("append should not be called in observation session tests");
+        },
+        async appendBatch() {
+          return [];
+        },
+        async writeArtifact(): Promise<never> {
+          throw new Error("writeArtifact should not be called in observation session tests");
+        },
+        async flush() {},
+        async close() {
+          closedSessionIds.push(input.sessionId);
+        },
+      } satisfies SessionObservationSink;
+    },
+  } satisfies ObservationSink;
+  const runtime = new OpensteerSessionRuntime({
+    name: "observation-test",
+    engine: {} as never,
+    observationSessionId: "root-session",
+    observability: {
+      profile: "baseline",
+    },
+    observationSink,
+  });
+
+  return {
+    runtime,
+    openedSessionIds,
+    closedSessionIds,
+  };
+}
+
+async function ensureObservationSession(
+  runtime: OpensteerSessionRuntime,
+): Promise<{ readonly sessionId: string } | undefined> {
+  // @ts-expect-error exercising a private helper for regression coverage
+  return await runtime.ensureObservationSession();
+}
+
 test("OpensteerSessionRuntime uses the scoped observation session id when provided", async () => {
-    const openedSessionIds: string[] = [];
-    const runtime = new OpensteerSessionRuntime({
-      name: "observation-test",
-      engine: {} as never,
-      observationSessionId: "root-session",
-      observability: {
-        profile: "baseline",
-      },
-      observationSink: {
-        async openSession(input: { sessionId: string }) {
-          openedSessionIds.push(input.sessionId);
-          return {
-            async appendEvents() {
-              return [];
-            },
-            async appendArtifacts() {
-              return [];
-            },
-            async close() {},
-          } as never;
-        },
-      } as never,
-    });
+  const { runtime, openedSessionIds } = createObservationRuntime();
 
-    await runtime.withObservationSessionId("controller-session", async () => {
-      await runtime.setObservabilityConfig({
-        profile: "diagnostic",
-      });
-    });
-
-    assert.deepEqual(openedSessionIds, ["controller-session"]);
-});
-
-test("OpensteerSessionRuntime falls back to the fixed observation session id when no override is active", async () => {
-    const openedSessionIds: string[] = [];
-    const runtime = new OpensteerSessionRuntime({
-      name: "observation-test",
-      engine: {} as never,
-      observationSessionId: "root-session",
-      observability: {
-        profile: "baseline",
-      },
-      observationSink: {
-        async openSession(input: { sessionId: string }) {
-          openedSessionIds.push(input.sessionId);
-          return {
-            async appendEvents() {
-              return [];
-            },
-            async appendArtifacts() {
-              return [];
-            },
-            async close() {},
-          } as never;
-        },
-      } as never,
-    });
-
+  await runtime.withObservationSessionId("controller-session", async () => {
     await runtime.setObservabilityConfig({
       profile: "diagnostic",
     });
+  });
 
-    assert.deepEqual(openedSessionIds, ["root-session"]);
+  assert.deepEqual(openedSessionIds, ["controller-session"]);
+});
+
+test("OpensteerSessionRuntime falls back to the fixed observation session id when no override is active", async () => {
+  const { runtime, openedSessionIds } = createObservationRuntime();
+
+  await runtime.setObservabilityConfig({
+    profile: "diagnostic",
+  });
+
+  assert.deepEqual(openedSessionIds, ["root-session"]);
+});
+
+test("OpensteerSessionRuntime resolves scoped observation sessions even after the root session was opened", async () => {
+  const { runtime, openedSessionIds } = createObservationRuntime();
+
+  await runtime.setObservabilityConfig({
+    profile: "diagnostic",
+  });
+
+  const scopedObservationSession = await runtime.withObservationSessionId(
+    "controller-session",
+    () => ensureObservationSession(runtime),
+  );
+
+  assert.equal(scopedObservationSession?.sessionId, "controller-session");
+  assert.deepEqual(openedSessionIds, ["root-session", "controller-session"]);
+});
+
+test("OpensteerSessionRuntime restores the root observation session after a scoped override ends", async () => {
+  const { runtime, openedSessionIds } = createObservationRuntime();
+
+  const scopedObservationSession = await runtime.withObservationSessionId(
+    "controller-session",
+    () => ensureObservationSession(runtime),
+  );
+  const rootObservationSession = await ensureObservationSession(runtime);
+
+  assert.equal(scopedObservationSession?.sessionId, "controller-session");
+  assert.equal(rootObservationSession?.sessionId, "root-session");
+  assert.deepEqual(openedSessionIds, ["controller-session", "root-session"]);
+});
+
+test("OpensteerSessionRuntime can explicitly suppress observation inside a scoped block", async () => {
+  const { runtime, openedSessionIds } = createObservationRuntime();
+
+  await runtime.setObservabilityConfig({
+    profile: "diagnostic",
+  });
+
+  const scopedObservationSession = await runtime.withoutObservationSession(() =>
+    ensureObservationSession(runtime),
+  );
+
+  assert.equal(scopedObservationSession, undefined);
+  assert.deepEqual(openedSessionIds, ["root-session"]);
+});
+
+test("OpensteerSessionRuntime rejects undefined observation session ids from untyped callers", async () => {
+  const { runtime, openedSessionIds } = createObservationRuntime();
+
+  await assert.rejects(() => {
+    // @ts-expect-error exercising an untyped caller passing undefined
+    return runtime.withObservationSessionId(undefined, async () => {});
+  }, TypeError);
+
+  assert.deepEqual(openedSessionIds, []);
+});
+
+test("OpensteerSessionRuntime closes every observation session opened during its lifetime", async () => {
+  const { runtime, closedSessionIds } = createObservationRuntime();
+
+  await ensureObservationSession(runtime);
+  await runtime.withObservationSessionId("controller-session", async () => {
+    await ensureObservationSession(runtime);
+  });
+
+  await runtime.close();
+
+  assert.deepEqual(closedSessionIds.sort(), ["controller-session", "root-session"]);
 });

--- a/packages/runtime-core/src/sdk/runtime.ts
+++ b/packages/runtime-core/src/sdk/runtime.ts
@@ -327,6 +327,7 @@ export class OpensteerSessionRuntime {
   private pageRef: PageRef | undefined;
   private runId: string | undefined;
   private observations: SessionObservationSink | undefined;
+  private readonly observationSessionStorage = new AsyncLocalStorage<string | undefined>();
   private readonly operationEventStorage = new AsyncLocalStorage<OpensteerEvent[]>();
   private readonly pendingOperationEventCaptures: PendingOperationEventCapture[] = [];
   private ownsEngine = false;
@@ -402,6 +403,13 @@ export class OpensteerSessionRuntime {
       config: this.observationConfig,
     });
     return this.observationConfig;
+  }
+
+  async withObservationSessionId<T>(
+    sessionId: string | undefined,
+    task: () => Promise<T>,
+  ): Promise<T> {
+    return await this.observationSessionStorage.run(sessionId, task);
   }
 
   async open(
@@ -4776,6 +4784,10 @@ export class OpensteerSessionRuntime {
   }
 
   private resolveObservationSessionId(): string | undefined {
+    const scopedSessionId = this.observationSessionStorage.getStore();
+    if (scopedSessionId !== undefined) {
+      return scopedSessionId;
+    }
     return this.observationSessionId ?? this.sessionRef;
   }
 

--- a/packages/runtime-core/src/sdk/runtime.ts
+++ b/packages/runtime-core/src/sdk/runtime.ts
@@ -336,6 +336,7 @@ export class OpensteerSessionRuntime {
   private pageRef: PageRef | undefined;
   private runId: string | undefined;
   private readonly observationSessions = new Map<string, SessionObservationSink>();
+  private readonly openingObservationSessions = new Map<string, Promise<SessionObservationSink>>();
   private readonly openedObservationSessions = new Set<SessionObservationSink>();
   private readonly observationSessionStorage = new AsyncLocalStorage<ObservationSessionScope>();
   private readonly operationEventStorage = new AsyncLocalStorage<OpensteerEvent[]>();
@@ -401,12 +402,7 @@ export class OpensteerSessionRuntime {
     input: Partial<ObservabilityConfig> | undefined,
   ): Promise<ObservabilityConfig> {
     this.observationConfig = normalizeObservabilityConfig(input);
-    const observationSessionId = this.resolveObservationSessionId();
-    if (observationSessionId === undefined) {
-      return this.observationConfig;
-    }
-
-    await this.openObservationSession(observationSessionId);
+    await this.ensureConfiguredObservationSession();
     return this.observationConfig;
   }
 
@@ -4770,6 +4766,7 @@ export class OpensteerSessionRuntime {
     this.extractionDescriptors = undefined;
     this.engine = undefined;
     this.observationSessions.clear();
+    this.openingObservationSessions.clear();
     this.openedObservationSessions.clear();
     this.pendingOperationEventCaptures.length = 0;
 
@@ -4798,7 +4795,41 @@ export class OpensteerSessionRuntime {
       return existingObservationSession;
     }
 
-    return await this.openObservationSession(observationSessionId);
+    const openingObservationSession = this.openingObservationSessions.get(observationSessionId);
+    if (openingObservationSession !== undefined) {
+      return await openingObservationSession;
+    }
+
+    const openObservationSessionTask = this.openObservationSession(observationSessionId).finally(
+      () => {
+        this.openingObservationSessions.delete(observationSessionId);
+      },
+    );
+    this.openingObservationSessions.set(observationSessionId, openObservationSessionTask);
+    return await openObservationSessionTask;
+  }
+
+  private async ensureConfiguredObservationSession(): Promise<SessionObservationSink | undefined> {
+    if (this.observationConfig.profile === "off") {
+      return undefined;
+    }
+    const observationSessionId = this.resolveObservationSessionId();
+    if (observationSessionId === undefined) {
+      return undefined;
+    }
+
+    const hadObservationSession =
+      this.observationSessions.has(observationSessionId) ||
+      this.openingObservationSessions.has(observationSessionId);
+    const observationSession = await this.ensureObservationSession();
+    if (observationSession !== undefined && hadObservationSession) {
+      await observationSession.configure?.({
+        config: this.observationConfig,
+        updatedAt: Date.now(),
+      });
+    }
+
+    return observationSession;
   }
 
   private resolveObservationSessionId(): string | undefined {

--- a/packages/runtime-core/src/sdk/runtime.ts
+++ b/packages/runtime-core/src/sdk/runtime.ts
@@ -134,7 +134,7 @@ import {
   type ActionBoundaryDiagnostics,
 } from "../action-boundary.js";
 import { normalizeThrownOpensteerError } from "../internal/errors.js";
-import { sha256Hex } from "../internal/filesystem.js";
+import { normalizeNonEmptyString, sha256Hex } from "../internal/filesystem.js";
 import { canonicalJsonString, toCanonicalJsonValue } from "../json.js";
 import { normalizeObservationContext } from "../observation-utils.js";
 import { normalizeObservabilityConfig } from "../observations.js";
@@ -262,6 +262,15 @@ interface PendingOperationEventCapture {
   readonly events: readonly OpensteerEvent[];
 }
 
+type ObservationSessionScope =
+  | {
+      readonly mode: "session";
+      readonly sessionId: string;
+    }
+  | {
+      readonly mode: "disabled";
+    };
+
 interface RuntimeOperationOptions {
   readonly signal?: AbortSignal;
   readonly timeoutMs?: number;
@@ -326,8 +335,9 @@ export class OpensteerSessionRuntime {
   private sessionRef: SessionRef | undefined;
   private pageRef: PageRef | undefined;
   private runId: string | undefined;
-  private observations: SessionObservationSink | undefined;
-  private readonly observationSessionStorage = new AsyncLocalStorage<string | undefined>();
+  private readonly observationSessions = new Map<string, SessionObservationSink>();
+  private readonly openedObservationSessions = new Set<SessionObservationSink>();
+  private readonly observationSessionStorage = new AsyncLocalStorage<ObservationSessionScope>();
   private readonly operationEventStorage = new AsyncLocalStorage<OpensteerEvent[]>();
   private readonly pendingOperationEventCaptures: PendingOperationEventCapture[] = [];
   private ownsEngine = false;
@@ -396,20 +406,27 @@ export class OpensteerSessionRuntime {
       return this.observationConfig;
     }
 
-    const sink = this.injectedObservationSink ?? (await this.ensureRoot()).observations;
-    this.observations = await sink.openSession({
-      sessionId: observationSessionId,
-      openedAt: Date.now(),
-      config: this.observationConfig,
-    });
+    await this.openObservationSession(observationSessionId);
     return this.observationConfig;
   }
 
-  async withObservationSessionId<T>(
-    sessionId: string | undefined,
-    task: () => Promise<T>,
-  ): Promise<T> {
-    return await this.observationSessionStorage.run(sessionId, task);
+  async withObservationSessionId<T>(sessionId: string, task: () => Promise<T>): Promise<T> {
+    return await this.observationSessionStorage.run(
+      {
+        mode: "session",
+        sessionId: normalizeNonEmptyString("sessionId", sessionId),
+      },
+      task,
+    );
+  }
+
+  async withoutObservationSession<T>(task: () => Promise<T>): Promise<T> {
+    return await this.observationSessionStorage.run(
+      {
+        mode: "disabled",
+      },
+      task,
+    );
   }
 
   async open(
@@ -4742,7 +4759,7 @@ export class OpensteerSessionRuntime {
 
   private async resetRuntimeState(options: { readonly disposeEngine: boolean }): Promise<void> {
     const engine = this.engine;
-    const observations = this.observations;
+    const observationSessions = [...this.openedObservationSessions];
 
     this.networkHistory.clear();
     this.sessionRef = undefined;
@@ -4752,10 +4769,15 @@ export class OpensteerSessionRuntime {
     this.computer = undefined;
     this.extractionDescriptors = undefined;
     this.engine = undefined;
-    this.observations = undefined;
+    this.observationSessions.clear();
+    this.openedObservationSessions.clear();
     this.pendingOperationEventCaptures.length = 0;
 
-    await observations?.close("runtime_reset").catch(() => undefined);
+    await Promise.allSettled(
+      observationSessions.map((observationSession) =>
+        observationSession.close("runtime_reset").catch(() => undefined),
+      ),
+    );
     if (options.disposeEngine && this.ownsEngine && engine?.dispose) {
       await engine.dispose();
     }
@@ -4766,29 +4788,40 @@ export class OpensteerSessionRuntime {
     if (this.observationConfig.profile === "off") {
       return undefined;
     }
-    if (this.observations !== undefined) {
-      return this.observations;
-    }
     const observationSessionId = this.resolveObservationSessionId();
     if (observationSessionId === undefined) {
       return undefined;
     }
 
-    const sink = this.injectedObservationSink ?? (await this.ensureRoot()).observations;
-    this.observations = await sink.openSession({
-      sessionId: observationSessionId,
-      openedAt: Date.now(),
-      config: this.observationConfig,
-    });
-    return this.observations;
+    const existingObservationSession = this.observationSessions.get(observationSessionId);
+    if (existingObservationSession !== undefined) {
+      return existingObservationSession;
+    }
+
+    return await this.openObservationSession(observationSessionId);
   }
 
   private resolveObservationSessionId(): string | undefined {
-    const scopedSessionId = this.observationSessionStorage.getStore();
-    if (scopedSessionId !== undefined) {
-      return scopedSessionId;
+    const scopedSession = this.observationSessionStorage.getStore();
+    if (scopedSession?.mode === "session") {
+      return scopedSession.sessionId;
+    }
+    if (scopedSession?.mode === "disabled") {
+      return undefined;
     }
     return this.observationSessionId ?? this.sessionRef;
+  }
+
+  private async openObservationSession(sessionId: string): Promise<SessionObservationSink> {
+    const sink = this.injectedObservationSink ?? (await this.ensureRoot()).observations;
+    const observationSession = await sink.openSession({
+      sessionId,
+      openedAt: Date.now(),
+      config: this.observationConfig,
+    });
+    this.observationSessions.set(sessionId, observationSession);
+    this.openedObservationSessions.add(observationSession);
+    return observationSession;
   }
 
   private runWithOperationTimeout<T>(


### PR DESCRIPTION
## Summary
- propagate Playwright target IDs through page metadata when available
- decode browser fetch bodies as `Uint8Array` for `fetch`
- scope observation session IDs with async-local storage and add runtime tests

## Testing
- Not run (not requested)