### PR TITLE
Prepare Python package publishing

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,0 +1,46 @@
+name: Publish Python
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate release tag
+        if: github.event_name == 'release'
+        shell: bash
+        run: |
+          version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          tag="${GITHUB_REF_NAME#v}"
+          if [ "$tag" != "$version" ]; then
+            echo "Release tag v$tag does not match pyproject.toml version $version" >&2
+            exit 1
+          fi
+
+      - name: Build distributions
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Publish distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opensteer"
-version = "0.1.0"
+version = "0.10.0"
 description = "Global browser-control runtime and agent skills for Opensteer."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -113,7 +113,7 @@ wheels = [
 
 [[package]]
 name = "opensteer"
-version = "0.1.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "cdp-use" },


### PR DESCRIPTION
## Summary\n- bump the Python package version to 0.10.0\n- add a PyPI Trusted Publishing workflow for GitHub releases\n- keep uv.lock in sync with the package version\n\n## Verification\n- uv run ruff check .\n- uv run pytest -q\n- rm -rf dist build opensteer.egg-info && uv run --with build python -m build && uv run --with twine twine check dist/*\n- git diff --check