### PR TITLE
[codex] Stage remote browser uploads

### DIFF
--- a/opensteer/daemon.py
+++ b/opensteer/daemon.py
@@ -15,7 +15,7 @@ from cdp_use.client import CDPClient
 
 from .env import load_env
 from .errors import OpenSteerError, error_log_line, error_to_wire, normalize_exception
-from .http_client import request_json
+from .http_client import request_file_upload, request_json
 from .paths import broker_paths, get_name, session_paths, session_state_path
 
 
@@ -149,6 +149,34 @@ def stop_remote():
         log(f"stopped remote browser {REMOTE_ID}")
     except Exception as e:
         log(f"stop_remote failed ({REMOTE_ID}): {e}")
+
+
+def stage_remote_upload(file_path):
+    if not REMOTE_ID or not API_KEY:
+        return {"path": file_path, "staged": False}
+    if not isinstance(file_path, str) or not file_path:
+        raise OpenSteerError(
+            "Upload path is required.",
+            code="OPENSTEER_INVALID_ARGUMENT",
+            source="daemon",
+        )
+    session = urllib.parse.quote(REMOTE_ID, safe="")
+    staged = request_file_upload(
+        OPENSTEER_API,
+        API_KEY,
+        f"/v2/opensteer/sessions/{session}/uploads",
+        file_path,
+        filename=os.path.basename(file_path),
+        timeout=120,
+    )
+    remote_path = staged.get("remotePath") if isinstance(staged, dict) else None
+    if not remote_path:
+        raise OpenSteerError(
+            "OpenSteer upload staging did not return a remote path.",
+            code="OPENSTEER_API_BAD_RESPONSE",
+            source="opensteer-api",
+        )
+    return {"path": remote_path, "staged": True, "upload": staged}
 
 
 def parse_surface_target_id(value):
@@ -496,6 +524,8 @@ class BrowserSession:
             return {"surface": active}
         if meta == "switch_surface":
             return await self.switch_surface(req.get("surface_id") or req.get("target_id"))
+        if meta == "stage_upload":
+            return await asyncio.to_thread(stage_remote_upload, req.get("path"))
 
         async with self._lock:
             method = req["method"]

--- a/opensteer/helpers.py
+++ b/opensteer/helpers.py
@@ -382,7 +382,22 @@ def upload_file(selector, path):
             source="cdp",
             details={"selector": selector},
         )
-    cdp("DOM.setFileInputFiles", files=[path] if isinstance(path, str) else list(path), nodeId=nid)
+    files = [path] if isinstance(path, str) else list(path)
+    staged_files = [_stage_upload_path(file_path) for file_path in files]
+    cdp("DOM.setFileInputFiles", files=staged_files, nodeId=nid)
+
+
+def _stage_upload_path(path):
+    try:
+        response = _send({"meta": "stage_upload", "path": path})
+    except OpenSteerError as error:
+        if error.code == "OPENSTEER_DAEMON_BAD_RESPONSE" or (
+            error.code == "OPENSTEER_ERROR" and error.message in {"'method'", "method"}
+        ):
+            return path
+        raise
+    staged_path = response.get("path")
+    return staged_path if isinstance(staged_path, str) and staged_path else path
 
 
 def http_get(url, headers=None, timeout=20.0):

--- a/opensteer/http_client.py
+++ b/opensteer/http_client.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import json
+import mimetypes
+import os
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Any
 
@@ -48,6 +51,57 @@ def request_json(
             details={"method": method, "path": path, "reason": reason},
             cause=exc,
         ) from exc
+
+
+def request_file_upload(
+    api_base: str,
+    api_key: str,
+    path: str,
+    file_path: str,
+    *,
+    filename: str | None = None,
+    timeout: float = 60,
+    source: str = "opensteer-api",
+) -> Any:
+    if not api_key:
+        raise OpenSteerError("OPENSTEER_API_KEY missing", code="OPENSTEER_API_KEY_MISSING", source=source)
+
+    display_name = filename or os.path.basename(file_path) or "upload.bin"
+    media_type = mimetypes.guess_type(display_name)[0] or "application/octet-stream"
+    size = os.path.getsize(file_path)
+
+    with open(file_path, "rb") as fh:
+        req = urllib.request.Request(
+            f"{api_base.rstrip('/')}{path}",
+            method="POST",
+            data=fh,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/octet-stream",
+                "Content-Length": str(size),
+                "X-OpenSteer-Filename": urllib.parse.quote(display_name, safe=""),
+                "X-OpenSteer-Media-Type": media_type,
+            },
+        )
+        try:
+            response = urllib.request.urlopen(req, timeout=timeout)
+            try:
+                return _decode_json(response.read(), source=source, method="POST", path=path)
+            finally:
+                close = getattr(response, "close", None)
+                if close:
+                    close()
+        except urllib.error.HTTPError as exc:
+            raise _http_error(exc, method="POST", path=path, source=source) from exc
+        except urllib.error.URLError as exc:
+            reason = str(getattr(exc, "reason", None) or exc)
+            raise OpenSteerError(
+                "OpenSteer API is unreachable.",
+                code="OPENSTEER_API_UNREACHABLE",
+                source=source,
+                details={"method": "POST", "path": path, "reason": reason},
+                cause=exc,
+            ) from exc
 
 
 def _decode_json(raw: bytes, *, source: str, method: str, path: str) -> Any:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opensteer"
-version = "0.10.0"
+version = "0.10.1"
 description = "Global browser-control runtime and agent skills for Opensteer."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/test_helpers.py
+++ b/test_helpers.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from PIL import Image
 
 from opensteer import helpers
+from opensteer.errors import OpenSteerError
 
 
 def _png(width, height):
@@ -34,3 +35,82 @@ def test_capture_screenshot_max_dim_skips_small_image():
 
 def test_capture_screenshot_default_does_not_resize():
     assert _screenshot_size(4592, 2286) == (4592, 2286)
+
+
+def test_upload_file_stages_paths_before_setting_input_files():
+    cdp_calls = []
+
+    def fake_cdp(method, **params):
+        cdp_calls.append((method, params))
+        if method == "DOM.getDocument":
+            return {"root": {"nodeId": 1}}
+        if method == "DOM.querySelector":
+            return {"nodeId": 2}
+        return {}
+
+    def fake_send(req):
+        assert req == {"meta": "stage_upload", "path": "/workspace/report.csv"}
+        return {"path": "/tmp/opensteer-browser-uploads/session/upl/report.csv"}
+
+    with patch("opensteer.helpers.cdp", side_effect=fake_cdp), patch(
+        "opensteer.helpers._send", side_effect=fake_send
+    ):
+        helpers.upload_file("input[type=file]", "/workspace/report.csv")
+
+    assert cdp_calls[-1] == (
+        "DOM.setFileInputFiles",
+        {
+            "files": ["/tmp/opensteer-browser-uploads/session/upl/report.csv"],
+            "nodeId": 2,
+        },
+    )
+
+
+def test_upload_file_falls_back_to_original_path_for_old_local_daemons():
+    cdp_calls = []
+
+    def fake_cdp(method, **params):
+        cdp_calls.append((method, params))
+        if method == "DOM.getDocument":
+            return {"root": {"nodeId": 1}}
+        if method == "DOM.querySelector":
+            return {"nodeId": 2}
+        return {}
+
+    def fake_send(_req):
+        raise OpenSteerError("'method'", code="OPENSTEER_ERROR", source="daemon")
+
+    with patch("opensteer.helpers.cdp", side_effect=fake_cdp), patch(
+        "opensteer.helpers._send", side_effect=fake_send
+    ):
+        helpers.upload_file("input[type=file]", "/workspace/report.csv")
+
+    assert cdp_calls[-1] == (
+        "DOM.setFileInputFiles",
+        {
+            "files": ["/workspace/report.csv"],
+            "nodeId": 2,
+        },
+    )
+
+
+def test_upload_file_propagates_staging_failures():
+    def fake_cdp(method, **_params):
+        if method == "DOM.getDocument":
+            return {"root": {"nodeId": 1}}
+        if method == "DOM.querySelector":
+            return {"nodeId": 2}
+        return {}
+
+    def fake_send(_req):
+        raise OpenSteerError("No such file", code="OPENSTEER_ERROR", source="daemon")
+
+    with patch("opensteer.helpers.cdp", side_effect=fake_cdp), patch(
+        "opensteer.helpers._send", side_effect=fake_send
+    ):
+        try:
+            helpers.upload_file("input[type=file]", "/workspace/missing.csv")
+        except OpenSteerError as error:
+            assert error.message == "No such file"
+        else:
+            raise AssertionError("expected staging failure")

--- a/test_remote.py
+++ b/test_remote.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import opensteer.runtime as runtime
 import opensteer.daemon as daemon
+import opensteer.http_client as http_client
 import opensteer.paths as paths
 from opensteer.errors import OpenSteerError
 
@@ -319,6 +320,118 @@ def test_daemon_stop_remote_deletes_opensteer_session():
     assert calls == [
         ("/v2/opensteer/sessions/session%2Fwith%20spaces", "DELETE", None, 15),
     ]
+
+
+def test_daemon_stage_remote_upload_returns_browser_remote_path():
+    calls = []
+
+    def fake_upload(api_base, api_key, path, file_path, **kwargs):
+        calls.append((api_base, api_key, path, file_path, kwargs))
+        return {
+            "remotePath": "/tmp/opensteer-browser-uploads/session/upl/report.csv",
+        }
+
+    with (
+        patch.object(daemon, "REMOTE_ID", "session/with spaces"),
+        patch.object(daemon, "API_KEY", "osk_test"),
+        patch.object(daemon, "OPENSTEER_API", "https://api.test"),
+        patch.object(daemon, "request_file_upload", side_effect=fake_upload),
+    ):
+        assert daemon.stage_remote_upload("/workspace/report.csv") == {
+            "path": "/tmp/opensteer-browser-uploads/session/upl/report.csv",
+            "staged": True,
+            "upload": {
+                "remotePath": "/tmp/opensteer-browser-uploads/session/upl/report.csv",
+            },
+        }
+
+    assert calls == [
+        (
+            "https://api.test",
+            "osk_test",
+            "/v2/opensteer/sessions/session%2Fwith%20spaces/uploads",
+            "/workspace/report.csv",
+            {
+                "filename": "report.csv",
+                "timeout": 120,
+            },
+        ),
+    ]
+
+
+def test_request_file_upload_uses_binary_transport_with_media_type_metadata(tmp_path):
+    uploaded = tmp_path / "data.json"
+    uploaded.write_text('{"ok":true}')
+    captured = {}
+
+    class Response:
+        def read(self):
+            return b'{"remotePath":"/tmp/opensteer-browser-uploads/session/upl/data.json"}'
+
+        def close(self):
+            captured["closed"] = True
+
+    def fake_urlopen(req, timeout=60):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["timeout"] = timeout
+        captured["headers"] = {
+            name.lower(): value for name, value in req.header_items()
+        }
+        captured["body"] = req.data.read()
+        return Response()
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        assert http_client.request_file_upload(
+            "https://api.test/",
+            "osk_test",
+            "/v2/opensteer/sessions/session-1/uploads",
+            str(uploaded),
+            timeout=12,
+        ) == {
+            "remotePath": "/tmp/opensteer-browser-uploads/session/upl/data.json",
+        }
+
+    assert captured == {
+        "url": "https://api.test/v2/opensteer/sessions/session-1/uploads",
+        "method": "POST",
+        "timeout": 12,
+        "headers": {
+            "authorization": "Bearer osk_test",
+            "content-type": "application/octet-stream",
+            "content-length": "11",
+            "x-opensteer-filename": "data.json",
+            "x-opensteer-media-type": "application/json",
+        },
+        "body": b'{"ok":true}',
+        "closed": True,
+    }
+
+
+def test_daemon_stage_remote_upload_returns_original_path_for_local_browser():
+    with (
+        patch.object(daemon, "REMOTE_ID", None),
+        patch.object(daemon, "API_KEY", ""),
+    ):
+        assert daemon.stage_remote_upload("/workspace/report.csv") == {
+            "path": "/workspace/report.csv",
+            "staged": False,
+        }
+
+
+def test_daemon_stage_remote_upload_skips_network_with_api_key_without_remote_browser():
+    def fail_upload(*_args, **_kwargs):
+        raise AssertionError("local browser uploads must not call the remote upload API")
+
+    with (
+        patch.object(daemon, "REMOTE_ID", None),
+        patch.object(daemon, "API_KEY", "osk_test"),
+        patch.object(daemon, "request_file_upload", side_effect=fail_upload),
+    ):
+        assert daemon.stage_remote_upload("/workspace/report.csv") == {
+            "path": "/workspace/report.csv",
+            "staged": False,
+        }
 
 
 def test_stop_remote_daemon_stops_shared_broker():

--- a/uv.lock
+++ b/uv.lock
@@ -113,7 +113,7 @@ wheels = [
 
 [[package]]
 name = "opensteer"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "cdp-use" },


### PR DESCRIPTION
## Summary
- stage local upload paths through the OpenSteer daemon before DOM.setFileInputFiles
- upload raw file bytes to the remote browser session only when the daemon has both OPENSTEER_BROWSER_ID and OPENSTEER_API_KEY
- preserve local-browser behavior by returning the original path for local/API-key-only/old-daemon cases
- bump the Python package version to 0.10.1 for a distinct release

## Validation
- uv run pytest -q
- uv run --with build python -m build

## Notes
- The unrelated switch_tab behavior change is intentionally excluded from this PR and isolated on codex/switch-tab-unmark-before-switch.
